### PR TITLE
Compose: Add frontend container; Increase default stream threads to 3

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -25,12 +25,13 @@ docker compose --profile demo up -d --pull always
 
 Once completed, the following services will be available:
 
-| Service                                | URL                    |
-|:---------------------------------------|:-----------------------|
-| Dependency-Track API Server + Frontend | http://localhost:8080  |
-| Redpanda Console                       | http://localhost:28080 |
-| PostgreSQL                             | `localhost:5432`       |
-| Redpanda Kafka API                     | `localhost:9092`       |
+| Service            | URL                    |
+|:-------------------|:-----------------------|
+| API Server         | http://localhost:8080  |
+| Frontend           | http://localhost:8081  |
+| Redpanda Console   | http://localhost:28080 |
+| PostgreSQL         | `localhost:5432`       |
+| Redpanda Kafka API | `localhost:9092`       |
 
 > **Note**  
 > You'll not need to interact with PostgreSQL or the Kafka API directly to try out the project,
@@ -62,8 +63,8 @@ docker restart dt-postgres
 
 ## Testing 🤞
 
-1. In a web browser, navigate to http://localhost:8080 and login (username: `admin`, password: `admin`)
-2. Navigate to the *Notifications* section in the [administration panel](http://localhost:8080/admin)
+1. In a web browser, navigate to http://localhost:8081 and login (username: `admin`, password: `admin`)
+2. Navigate to the *Notifications* section in the [administration panel](http://localhost:8081/admin)
 3. Create a new alert with publisher *Outbound Webhook*
    ![Create Alert](.github/images/demo_dtrack_create-alert.png)
 4. Select a few notification groups and enter a destination URL ([Pipedream](https://pipedream.com/) is convenient for testing Webhooks)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - redpanda
     environment:
       QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
-      KAFKA_STREAMS_NUM_STREAM_THREADS: "1"
+      KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
       QUARKUS_DATASOURCE_USERNAME: "dtrack"
       QUARKUS_DATASOURCE_PASSWORD: "dtrack"
@@ -27,7 +27,7 @@ services:
       - redpanda
     environment:
       QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
-      KAFKA_STREAMS_NUM_STREAM_THREADS: "1"
+      KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
       QUARKUS_DATASOURCE_USERNAME: "dtrack"
       QUARKUS_DATASOURCE_PASSWORD: "dtrack"
@@ -49,7 +49,7 @@ services:
       - redpanda
     environment:
       QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
-      KAFKA_STREAMS_NUM_STREAM_THREADS: "1"
+      KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
       QUARKUS_DATASOURCE_USERNAME: "dtrack"
       QUARKUS_DATASOURCE_PASSWORD: "dtrack"
@@ -60,7 +60,7 @@ services:
       # SCANNER_OSSINDEX_API_USERNAME: "email@example.com"
       # SCANNER_OSSINDEX_API_TOKEN: "your-token"
       # SCANNER_SNYK_ENABLED: "true"
-      # SCANNER_SNYK_TOPIC_PARTITIONS: "3
+      # SCANNER_SNYK_TOPIC_PARTITIONS: "3"
       # SCANNER_SNYK_API_ORG_ID: "your-org-id"
       # SCANNER_SNYK_API_TOKENS: "your-token-1,your-token-2"
     ports:
@@ -79,7 +79,7 @@ services:
       - redpanda
     environment:
       QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
-      KAFKA_STREAMS_NUM_STREAM_THREADS: "1"
+      KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
     ports:
       # Dynamic host port binding to allow for scaling of the service.
       # Scaling with Compose doesn't work when assigning static host ports.
@@ -116,6 +116,17 @@ services:
     profiles:
       - demo
       - load-test
+    restart: unless-stopped
+
+  frontend:
+    image: dependencytrack/frontend:4.7.0
+    container_name: dt-frontend
+    environment:
+      API_BASE_URL: "http://localhost:8080"
+    ports:
+    - "127.0.0.1:8081:8080"
+    profiles:
+    - demo
     restart: unless-stopped
 
   postgres:


### PR DESCRIPTION
hyades-apiserver does not publish `bundled` container images anymore. As such, the frontend container needs to be deployed separately for the `demo` compose profile.

I also increased the default number of Kafka Streams stream threads for the hyades services to `3`. As they're running as native executables now, it's fine to have more threads, even for cases where users have a less powerful workstation.

Signed-off-by: nscuro <nscuro@protonmail.com>