### PR TITLE
Fix `NugetMetaAnalyzer` reporting `MetaModel.component` as `null`

### DIFF
--- a/repository-meta-analyzer/src/main/java/org/hyades/repositories/NugetMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/hyades/repositories/NugetMetaAnalyzer.java
@@ -51,7 +51,7 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
     };
-    MetaModel meta = new MetaModel();
+
     private static final Logger LOGGER = LoggerFactory.getLogger(NugetMetaAnalyzer.class);
     private static final String DEFAULT_BASE_URL = "https://api.nuget.org";
 
@@ -98,6 +98,7 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
      * {@inheritDoc}
      */
     public MetaModel analyze(final Component component) {
+        final var meta = new MetaModel(component);
         if (component.getPurl() != null && performVersionCheck(meta, component)) {
                 performLastPublishedCheck(meta, component);
         }

--- a/repository-meta-analyzer/src/test/java/org/hyades/repositories/NugetMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/hyades/repositories/NugetMetaAnalyzerTest.java
@@ -92,7 +92,7 @@ class NugetMetaAnalyzerTest {
         analyzer.setRepositoryUsernameAndPassword(null, "password");
         analyzer.setRepositoryBaseUrl("http://localhost:1080");
         MetaModel metaModel = analyzer.analyze(component);
-        Assertions.assertNull(metaModel.getComponent());
+        Assertions.assertNotNull(metaModel.getComponent());
     }
 
 
@@ -106,6 +106,7 @@ class NugetMetaAnalyzerTest {
 
         Assertions.assertTrue(analyzer.isApplicable(component));
         Assertions.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
+        Assertions.assertNotNull(metaModel.getComponent());
         Assertions.assertNotNull(metaModel.getLatestVersion());
         Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
@@ -163,6 +164,7 @@ class NugetMetaAnalyzerTest {
         analyzer.setRepositoryUsernameAndPassword(null, "password");
         analyzer.setRepositoryBaseUrl("http://localhost:1080");
         MetaModel metaModel = analyzer.analyze(component);
+        Assertions.assertNotNull(metaModel.getComponent());
         Assertions.assertEquals("5.0.2", metaModel.getLatestVersion());
         Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }


### PR DESCRIPTION
MetaModel was instantiated on class-level (deviating from how it was originally done in the API server). The `component` field of that `MetaModel` instance was never populated, causing problems on the API server side when consuming result events.