### PR TITLE
Disable database features for mirror service

### DIFF
--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -15,6 +15,12 @@
         <dependency>
             <groupId>org.hyades</groupId>
             <artifactId>commons</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-postgresql</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/mirror-service/src/main/resources/application.properties
+++ b/mirror-service/src/main/resources/application.properties
@@ -1,6 +1,12 @@
 ## Quarkus
 #
 quarkus.http.port=8093
+# Hibernate is inherited from the commons module,
+# but the mirror service does not need database access.
+quarkus.hibernate-orm.enabled=false
+# Repository classes try to inject EntityManager which
+# is not available when Hibernate is disabled.
+quarkus.arc.exclude-types=org.hyades.persistence.*
 
 ## Native Image
 #
@@ -34,33 +40,3 @@ mirror.osv.base.url=https://osv-vulnerabilities.storage.googleapis.com
 
 ## NVD mirroring
 mirror.nvd.api.api-key=
-
-quarkus.datasource.db-kind=postgresql
-
-# Always use quotes for keywords, column- and table names.
-# e.g. SELECT "FOO"."BAR" FROM "BAZ". This matches what the API server does,
-# and is required for compatibility with its schema.
-quarkus.hibernate-orm.database.globally-quoted-identifiers=true
-
-# Hibernate should only validate that the existing schema matches our entity classes,
-# but it should never generate a schema by itself.
-quarkus.hibernate-orm.database.generation=validate
-
-# Use external Postgres DB for dev mode (./mvnw quarkus:dev), but let Quarkus
-# take care of test container creation in the test profile.
-# See https://quarkus.io/guides/databases-dev-services
-%dev.quarkus.datasource.username=dtrack
-%dev.quarkus.datasource.password=dtrack
-%dev.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/dtrack
-%prod.quarkus.datasource.username=dtrack
-%prod.quarkus.datasource.password=dtrack
-%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/dtrack
-
-# Use Flyway only in test mode to populate the DB with the schema generated
-# by the API server. In production or dev mode, this will be handled by the
-# API server itself. See https://quarkus.io/guides/flyway
-%test.quarkus.flyway.migrate-at-start=true
-%test.quarkus.flyway.locations=migrations/postgres
-
-%dev.quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.active=true


### PR DESCRIPTION
The service does not need nor use database access, yet it still tries to connect to one and creates a connection pool. This is happening because Quarkus auto-detects entity and repository classes from the `commons` module, making the assumption that we want to use Hibernate.