### PR TITLE
Avoid repartition caused by tombstone emitters

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
@@ -1,16 +1,6 @@
 package org.hyades;
 
 import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
-import org.hyades.common.KafkaTopic;
-import org.hyades.config.InternalScannerConfig;
-import org.hyades.config.OssIndexConfig;
-import org.hyades.config.SnykConfig;
-import org.hyades.model.*;
-import org.hyades.processor.internal.InternalScannerProcessorSupplier;
-import org.hyades.processor.misc.TombstoneEmittingProcessorSupplier;
-import org.hyades.processor.ossindex.OssIndexProcessorSupplier;
-import org.hyades.processor.snyk.SnykProcessorSupplier;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
@@ -27,6 +17,22 @@ import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Repartitioned;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.hyades.common.KafkaTopic;
+import org.hyades.config.InternalScannerConfig;
+import org.hyades.config.OssIndexConfig;
+import org.hyades.config.SnykConfig;
+import org.hyades.model.AnalyzerIdentity;
+import org.hyades.model.CompletedScans;
+import org.hyades.model.Component;
+import org.hyades.model.ExpectedScanResults;
+import org.hyades.model.ScanKey;
+import org.hyades.model.ScanResult;
+import org.hyades.model.ScanStatus;
+import org.hyades.model.ScanTask;
+import org.hyades.processor.internal.InternalScannerProcessorSupplier;
+import org.hyades.processor.misc.TombstoneEmittingProcessorSupplier;
+import org.hyades.processor.ossindex.OssIndexProcessorSupplier;
+import org.hyades.processor.snyk.SnykProcessorSupplier;
 import org.hyades.serializers.ScanKeySerde;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -35,7 +41,6 @@ import javax.inject.Inject;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -172,7 +177,7 @@ public class VulnerabilityAnalyzerTopology {
                 // Emit tombstone events for scan keys for which no events have been received
                 // for >= 1h (stream time). Check every 5min (also stream time) for eligible keys.
                 // This keeps the KTable from growing indefinitely.
-                .process(new TombstoneEmittingProcessorSupplier<>(
+                .processValues(new TombstoneEmittingProcessorSupplier<>(
                         "expected-scan-results-last-update-store",
                         scanKeySerde, Duration.ofMinutes(5), Duration.ofHours(1),
                         ScanTask::asTombstone
@@ -212,7 +217,7 @@ public class VulnerabilityAnalyzerTopology {
                 // Emit tombstone events for ScanKeys for which no events have been received
                 // for >= 1h (stream time). Check every 5min (also stream time) for eligible keys.
                 // This keeps the KTable from growing indefinitely.
-                .process(new TombstoneEmittingProcessorSupplier<>(
+                .processValues(new TombstoneEmittingProcessorSupplier<>(
                         "completed-scans-table-last-update-store",
                         scanKeySerde, Duration.ofMinutes(5), Duration.ofHours(1),
                         CompletedScans::asTombstone

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/TombstoneEmittingProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/TombstoneEmittingProcessor.java
@@ -4,11 +4,13 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.ContextualFixedKeyProcessor;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
-import org.apache.kafka.streams.processor.api.ProcessorContext;
-import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.hyades.util.FixedKeyRecordFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +30,7 @@ import java.util.function.Supplier;
  * @param <V> Value type of incoming and outgoing records
  * @see <a href="https://developer.confluent.io/tutorials/schedule-ktable-ttl/kstreams.html">Related Confluent Tutorial</a>
  */
-public class TombstoneEmittingProcessor<K, V> extends ContextualProcessor<K, V, K, V> {
+public class TombstoneEmittingProcessor<K, V> extends ContextualFixedKeyProcessor<K, V, V> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TombstoneEmittingProcessor.class);
 
@@ -48,7 +50,7 @@ public class TombstoneEmittingProcessor<K, V> extends ContextualProcessor<K, V, 
     }
 
     @Override
-    public void init(final ProcessorContext<K, V> context) {
+    public void init(final FixedKeyProcessorContext<K, V> context) {
         super.init(context);
 
         store = context().getStateStore(storeName);
@@ -56,7 +58,7 @@ public class TombstoneEmittingProcessor<K, V> extends ContextualProcessor<K, V, 
     }
 
     @Override
-    public void process(final Record<K, V> record) {
+    public void process(final FixedKeyRecord<K, V> record) {
         if (record.value() == null) {
             store.delete(record.key());
         } else {
@@ -79,7 +81,8 @@ public class TombstoneEmittingProcessor<K, V> extends ContextualProcessor<K, V, 
                 final KeyValue<K, Long> record = all.next();
                 if (record.value != null && Instant.ofEpochMilli(record.value).isBefore(cutoffTimestamp)) {
                     LOGGER.debug("Sending tombstone for key {}", record.key);
-                    context().forward(new Record<>(record.key, tombstoneSupplier.get(), context().currentStreamTimeMs()));
+                    context().forward(FixedKeyRecordFactory.create(
+                            record.key, tombstoneSupplier.get(), context().currentStreamTimeMs(), null));
                     store.delete(record.key);
                 }
             }

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/TombstoneEmittingProcessorSupplier.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/TombstoneEmittingProcessorSupplier.java
@@ -2,8 +2,8 @@ package org.hyades.processor.misc;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.processor.api.Processor;
-import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 
@@ -14,7 +14,7 @@ import java.util.function.Supplier;
 import static org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore;
 import static org.apache.kafka.streams.state.Stores.keyValueStoreBuilder;
 
-public class TombstoneEmittingProcessorSupplier<K, V> implements ProcessorSupplier<K, V, K, V> {
+public class TombstoneEmittingProcessorSupplier<K, V> implements FixedKeyProcessorSupplier<K, V, V> {
 
     private final StoreBuilder<KeyValueStore<K, Long>> storeBuilder;
     private final Duration checkInterval;
@@ -31,7 +31,7 @@ public class TombstoneEmittingProcessorSupplier<K, V> implements ProcessorSuppli
     }
 
     @Override
-    public Processor<K, V, K, V> get() {
+    public FixedKeyProcessor<K, V, V> get() {
         return new TombstoneEmittingProcessor<>(storeBuilder.name(), checkInterval, maxLifetime, tombstoneSupplier);
     }
 

--- a/vulnerability-analyzer/src/main/java/org/hyades/util/FixedKeyRecordFactory.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/util/FixedKeyRecordFactory.java
@@ -1,0 +1,52 @@
+package org.hyades.util;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.processor.api.Processor;
+
+import java.lang.reflect.Constructor;
+
+@RegisterForReflection(targets = FixedKeyRecord.class)
+public class FixedKeyRecordFactory {
+
+    private FixedKeyRecordFactory() {
+    }
+
+    /**
+     * Create a {@link FixedKeyRecord} by making its package-private constructor accessible via reflection.
+     * <p>
+     * {@link FixedKeyRecord}s are not intended to be created by users of the Kafka Streams API.
+     * However, using {@link FixedKeyProcessor} instead of {@link Processor} allows for avoiding
+     * unnecessary repartition operations, as Kafka Streams can assume that the record key has not changed.
+     * <p>
+     * <strong>Only use this when you know for sure that the record key doesn't change!</strong>
+     *
+     * @param key   Key of the record to create
+     * @param value Value of the record to create
+     * @return A {@link FixedKeyRecord} instance
+     */
+    @SuppressWarnings("unchecked")
+    public static <K, V> FixedKeyRecord<K, V> create(final K key, final V value, final long timestamp, final Headers headers) {
+        // We can't get a specific constructor, because the arguments of the constructor
+        // we want are generic, so they are subject to type erasure at runtime.
+        // Instead, we assume that there is only one constructor. If there are less
+        // or more than 1, we throw. This can happen when we upgrade Kafka Streams,
+        // but it will be caught by our tests.
+        final Constructor<?>[] constructors = FixedKeyRecord.class.getDeclaredConstructors();
+        if (constructors.length != 1) {
+            throw new IllegalStateException("Unexpected number of constructors (expected 1, got %d)".formatted(constructors.length));
+        }
+
+        constructors[0].setAccessible(true);
+
+        try {
+            return (FixedKeyRecord<K, V>) constructors[0].newInstance(key, value, timestamp, headers);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create instance of %s".formatted(FixedKeyRecord.class.getName()), e);
+        }
+
+    }
+
+}

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/misc/TombstoneEmittingProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/misc/TombstoneEmittingProcessorTest.java
@@ -3,10 +3,12 @@ package org.hyades.processor.misc;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
-import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.test.TestRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,14 +30,13 @@ class TombstoneEmittingProcessorTest {
         final var processorSupplier = new TombstoneEmittingProcessorSupplier<String, String>(
                 "emitter-processor-store", Serdes.String(), Duration.ofSeconds(5), Duration.ofSeconds(30), () -> null);
 
-        final var topology = new Topology();
-        topology.addSource("sourceProcessor", new StringDeserializer(),
-                new StringDeserializer(), "input-topic");
-        topology.addProcessor("emitterProcessor", processorSupplier, "sourceProcessor");
-        topology.addSink("sinkProcessor", "output-topic",
-                new StringSerializer(), new StringSerializer(), "emitterProcessor");
+        final var streamsBuilder = new StreamsBuilder();
+        streamsBuilder
+                .stream("input-topic", Consumed.with(Serdes.String(), Serdes.String()))
+                .processValues(processorSupplier)
+                .to("output-topic", Produced.with(Serdes.String(), Serdes.String()));
 
-        testDriver = new TopologyTestDriver(topology);
+        testDriver = new TopologyTestDriver(streamsBuilder.build());
         inputTopic = testDriver.createInputTopic("input-topic", new StringSerializer(), new StringSerializer());
         outputTopic = testDriver.createOutputTopic("output-topic", new StringDeserializer(), new StringDeserializer());
     }

--- a/vulnerability-analyzer/src/test/java/org/hyades/util/FixedKeyRecordFactoryTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/util/FixedKeyRecordFactoryTest.java
@@ -1,0 +1,26 @@
+package org.hyades.util;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FixedKeyRecordFactoryTest {
+
+    @Test
+    void testCreate() {
+        final Headers headers = new RecordHeaders().add("foo", "bar".getBytes(StandardCharsets.UTF_8));
+        final FixedKeyRecord<String, String> record = FixedKeyRecordFactory.create("foo", "bar", 123, headers);
+
+        assertThat(record).isNotNull();
+        assertThat(record.key()).isEqualTo("foo");
+        assertThat(record.value()).isEqualTo("bar");
+        assertThat(record.timestamp()).isEqualTo(123);
+        assertThat(record.headers()).isEqualTo(headers);
+    }
+
+}


### PR DESCRIPTION
By using `FixedKeyProcessor`, we can hint to Kafka Streams that the record key does not change while `TombstoneEmittingProcessor` is processing it.

In the current topology, this avoids **2** repartition operations, and reduces the number of sub-topologies from 6 to 4.

Before:

![before](https://user-images.githubusercontent.com/5693141/216702187-a7b09cf9-134d-4c00-99e3-9b08d2739c0b.png)

After:

![after](https://user-images.githubusercontent.com/5693141/216702203-6f6f19dc-6e4b-4706-833e-49d2d5b7f4dd.png)