### PR TITLE
Update _build-native-meta.yml

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -58,7 +58,7 @@ jobs:
           -Dquarkus.native.resources.includes="$RESOURCES_INCLUDES" \
           -Dquarkus.native.resources.excludes="$RESOURCES_EXCLUDES"
     - name: Test Native Image
-      if: ${{ matrix.arch == "amd64" }}
+      if: ${{ matrix.arch == 'amd64' }}
       run: |-
         mvn -pl commons,${{ inputs.module }} test-compile failsafe:integration-test -Pnative
     - name: Upload Build Artifact


### PR DESCRIPTION
There is error in current workflow so native images are not being built. Unexpected symbol: '"amd64"'. Located at position 16 within expression: matrix.arch == "amd64"  It could be an issue with using double quote around string, though I am not sure.