### PR TITLE
Add protobuf serializers and schemas for vulnerability analysis domain

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -51,7 +51,7 @@ jobs:
         fi
         echo "Including resources: ${RESOURCES_INCLUDES:-None}"
         echo "Excluding resources: ${RESOURCES_EXCLUDES:-None}"
-        mvn clean package -Pnative -pl commons,${{ inputs.module }} -DskipTests \
+        mvn clean package -Pnative -pl commons,proto,${{ inputs.module }} -DskipTests \
           -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17 \
           -Dquarkus.native.container-build=true \
           -Dquarkus.native.container-runtime-options='--platform=linux/${{ matrix.arch }}' \
@@ -60,7 +60,7 @@ jobs:
     - name: Test Native Image
       if: ${{ matrix.arch == 'amd64' }}
       run: |-
-        mvn -pl commons,${{ inputs.module }} test-compile failsafe:integration-test -Pnative
+        mvn -pl commons,proto,${{ inputs.module }} test-compile failsafe:integration-test -Pnative
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v3.1.2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build Native Image
       run: |-
-        mvn -pl commons,${{ matrix.module }} clean install -Pnative -DskipTests
+        mvn -pl commons,proto,${{ matrix.module }} clean install -Pnative -DskipTests
     - name: Test Native Image
       run: |-
-        mvn -pl commons,${{ matrix.module }} test-compile failsafe:integration-test -Pnative
+        mvn -pl commons,proto,${{ matrix.module }} test-compile failsafe:integration-test -Pnative

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <module>mirror-service</module>
     <module>notification-publisher</module>
     <module>repository-meta-analyzer</module>
+    <module>proto</module>
     <module>vulnerability-analyzer</module>
   </modules>
     
@@ -44,6 +45,10 @@
 
     <!-- Plugin Versions -->
     <plugin.jacoco.version>0.8.8</plugin.jacoco.version>
+    <plugin.protoc-jar.version>3.11.4</plugin.protoc-jar.version>
+
+    <!-- Tool Versions -->
+    <tool.protoc.version>3.21.12</tool.protoc.version>
 
     <!-- SonarCloud -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -69,6 +74,11 @@
       <dependency>
         <groupId>org.hyades</groupId>
         <artifactId>commons</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hyades</groupId>
+        <artifactId>proto</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -167,6 +177,12 @@
               <arg>-parameters</arg>
             </compilerArgs>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>com.github.os72</groupId>
+          <artifactId>protoc-jar-maven-plugin</artifactId>
+          <version>${plugin.protoc-jar.version}</version>
         </plugin>
 
         <plugin>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hyades</groupId>
+        <artifactId>hyades</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>proto</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>protobuf</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <includeMavenTypes>direct</includeMavenTypes>
+                            <inputDirectories>
+                                <inputDirectory>src/main/proto</inputDirectory>
+                            </inputDirectories>
+                            <includeDirectories>
+                                <includeDirectory>src/main/proto</includeDirectory>
+                            </includeDirectories>
+                            <protocVersion>${tool.protoc.version}</protocVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -66,6 +71,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/proto/src/main/java/org/hyades/proto/JacksonProtobufDeserializer.java
+++ b/proto/src/main/java/org/hyades/proto/JacksonProtobufDeserializer.java
@@ -1,6 +1,5 @@
 package org.hyades.proto;
 
-import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -23,7 +22,7 @@ public class JacksonProtobufDeserializer<T extends MessageOrBuilder> extends Std
 
     @Override
     @SuppressWarnings("unchecked")
-    public T deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException, JacksonException {
+    public T deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException {
         final Message.Builder builder;
         try {
             final Object builderObject = clazz.getMethod("newBuilder").invoke(null);

--- a/proto/src/main/java/org/hyades/proto/JacksonProtobufDeserializer.java
+++ b/proto/src/main/java/org/hyades/proto/JacksonProtobufDeserializer.java
@@ -1,0 +1,40 @@
+package org.hyades.proto;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+public class JacksonProtobufDeserializer<T extends MessageOrBuilder> extends StdDeserializer<T> {
+
+    private final Class<T> clazz;
+
+    public JacksonProtobufDeserializer(final Class<T> clazz) {
+        super(clazz);
+        this.clazz = clazz;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException, JacksonException {
+        final Message.Builder builder;
+        try {
+            final Object builderObject = clazz.getMethod("newBuilder").invoke(null);
+            builder = (Message.Builder) builderObject;
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+            throw new JsonMappingException(jsonParser, "Failed to create builder from class " + clazz.getName(), e);
+        }
+
+        JsonFormat.parser().ignoringUnknownFields().merge(jsonParser.readValueAsTree().toString(), builder);
+
+        return (T) builder.build();
+    }
+
+}

--- a/proto/src/main/java/org/hyades/proto/JacksonProtobufSerializer.java
+++ b/proto/src/main/java/org/hyades/proto/JacksonProtobufSerializer.java
@@ -1,0 +1,22 @@
+package org.hyades.proto;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+
+import java.io.IOException;
+
+public class JacksonProtobufSerializer<T extends MessageOrBuilder> extends StdSerializer<T> {
+
+    public JacksonProtobufSerializer(final Class<T> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(final T t, final JsonGenerator jsonGenerator, final SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeRawValue(JsonFormat.printer().print(t));
+    }
+
+}

--- a/proto/src/main/java/org/hyades/proto/KafkaProtobufDeserializer.java
+++ b/proto/src/main/java/org/hyades/proto/KafkaProtobufDeserializer.java
@@ -1,0 +1,26 @@
+package org.hyades.proto;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.Parser;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class KafkaProtobufDeserializer<T extends MessageLite> implements Deserializer<T> {
+
+    private final Parser<T> parser;
+
+    public KafkaProtobufDeserializer(final Parser<T> parser) {
+        this.parser = parser;
+    }
+
+    @Override
+    public T deserialize(final String topic, final byte[] data) {
+        try {
+            return parser.parseFrom(data);
+        } catch (InvalidProtocolBufferException e) {
+            throw new SerializationException(e);
+        }
+    }
+
+}

--- a/proto/src/main/java/org/hyades/proto/KafkaProtobufSerde.java
+++ b/proto/src/main/java/org/hyades/proto/KafkaProtobufSerde.java
@@ -1,0 +1,29 @@
+package org.hyades.proto;
+
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.Parser;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class KafkaProtobufSerde<T extends MessageLite> implements Serde<T> {
+
+    private final Serializer<T> serializer;
+    private final Deserializer<T> deserializer;
+
+    public KafkaProtobufSerde(final Parser<T> parser) {
+        this.serializer = new KafkaProtobufSerializer<>();
+        this.deserializer = new KafkaProtobufDeserializer<>(parser);
+    }
+
+    @Override
+    public Serializer<T> serializer() {
+        return serializer;
+    }
+
+    @Override
+    public Deserializer<T> deserializer() {
+        return deserializer;
+    }
+
+}

--- a/proto/src/main/java/org/hyades/proto/KafkaProtobufSerializer.java
+++ b/proto/src/main/java/org/hyades/proto/KafkaProtobufSerializer.java
@@ -1,0 +1,18 @@
+package org.hyades.proto;
+
+import com.google.protobuf.MessageLite;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class KafkaProtobufSerializer<T extends MessageLite> implements Serializer<T> {
+
+    @Override
+    public byte[] serialize(final String topic, final T data) {
+        try {
+            return data.toByteArray();
+        } catch (RuntimeException e) {
+            throw new SerializationException(e);
+        }
+    }
+
+}

--- a/proto/src/main/proto/vuln-analysis-internal_v1.proto
+++ b/proto/src/main/proto/vuln-analysis-internal_v1.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+// Internal API for Hyades vulnerability analysis.
+package org.hyades.vulnanalysis.v1.internal;
+
+option java_multiple_files = true;
+option java_package = "org.hyades.proto.vulnanalysis.v1.internal";
+
+import "vuln-analysis_v1.proto";
+
+message ExpectedScans {
+  // Scanners for which a scan result is expected.
+  repeated Scanner scanners = 1;
+
+  // Whether this event represents a tombstone.
+  bool tombstone = 2;
+}
+
+message Scans {
+  // Scan statuses per scanner.
+  map<string, ScanStatus> statuses = 1;
+
+  // Whether this event represents a tombstone.
+  bool tombstone = 2;
+}
+
+message ScanTask {
+  // Key of the scan.
+  ScanKey key = 1;
+
+  // The scanner that shall process this event.
+  Scanner scanner = 2;
+
+  // The component that shall be scanned.
+  optional Component component = 3;
+
+  // Whether this event represents a tombstone.
+  bool tombstone = 4;
+}

--- a/proto/src/main/proto/vuln-analysis-internal_v1.proto
+++ b/proto/src/main/proto/vuln-analysis-internal_v1.proto
@@ -13,7 +13,7 @@ message ExpectedScans {
   repeated Scanner scanners = 1;
 
   // Whether this event represents a tombstone.
-  bool tombstone = 2;
+  optional bool tombstone = 2;
 }
 
 message Scans {
@@ -21,7 +21,7 @@ message Scans {
   map<string, ScanStatus> statuses = 1;
 
   // Whether this event represents a tombstone.
-  bool tombstone = 2;
+  optional bool tombstone = 2;
 }
 
 message ScanTask {
@@ -35,5 +35,5 @@ message ScanTask {
   optional Component component = 3;
 
   // Whether this event represents a tombstone.
-  bool tombstone = 4;
+  optional bool tombstone = 4;
 }

--- a/proto/src/main/proto/vuln-analysis_v1.proto
+++ b/proto/src/main/proto/vuln-analysis_v1.proto
@@ -19,9 +19,12 @@ message Component {
   // Package URL (PURL) of the component.
   optional string purl = 3;
 
+  // Software Identification (SWID) Tag ID of the component.
+  optional string swid_tag_id = 4;
+
   // Whether the component is internal to the organization.
   // Internal components should not be looked up in external sources.
-  bool internal = 4;
+  bool internal = 5;
 }
 
 enum Scanner {

--- a/proto/src/main/proto/vuln-analysis_v1.proto
+++ b/proto/src/main/proto/vuln-analysis_v1.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+// Public API for Hyades vulnerability analysis.
+package org.hyades.vulnanalysis.v1;
+
+option java_multiple_files = true;
+option java_package = "org.hyades.proto.vulnanalysis.v1";
+
+import "vuln_v1.proto";
+
+message Component {
+  // UUID of the component in the Dependency-Track database.
+  // In case of an untracked component, a random UUID may be used.
+  string uuid = 1;
+
+  // Common Platform Enumeration (CPE) of the component.
+  optional string cpe = 2;
+
+  // Package URL (PURL) of the component.
+  optional string purl = 3;
+
+  // Whether the component is internal to the organization.
+  // Internal components should not be looked up in external sources.
+  bool internal = 4;
+}
+
+enum Scanner {
+  SCANNER_NONE = 0;
+  SCANNER_INTERNAL = 1;
+  SCANNER_OSSINDEX = 2;
+  SCANNER_SNYK = 3;
+}
+
+message ScanCommand {
+  // Component that shall be scanned.
+  Component component = 1;
+}
+
+message ScanKey {
+  // A (preferably) random correlation ID in arbitrary format.
+  string correlation_id = 1;
+
+  // UUID of the component in the Dependency-Track database.
+  string component_uuid = 2;
+}
+
+message ScanResult {
+  // Key of the scan that produced this result.
+  ScanKey key = 1;
+
+  // The scanner that produced this result.
+  Scanner scanner = 2;
+
+  // Status of the scan.
+  ScanStatus status = 3;
+
+  // Vulnerabilities identified in the scan.
+  repeated org.hyades.vuln.v1.Vulnerability vulnerabilities = 4;
+
+  // Reason for scan failure.
+  optional string failureReason = 5;
+}
+
+enum ScanStatus {
+  SCAN_STATUS_UNKNOWN = 0;
+  SCAN_STATUS_SUCCESSFUL = 1;
+  SCAN_STATUS_FAILED = 2;
+  SCAN_STATUS_PENDING = 3;
+  SCAN_STATUS_COMPLETE = 4;
+}

--- a/proto/src/main/proto/vuln_v1.proto
+++ b/proto/src/main/proto/vuln_v1.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+// Public API for communicating vulnerability details.
+// Heavily inspired by the CycloneDX schema: https://github.com/CycloneDX/specification/blob/master/schema/bom-1.4.proto
 package org.hyades.vuln.v1;
 
 option java_multiple_files = true;
@@ -45,9 +47,15 @@ enum Severity {
   SEVERITY_NONE = 6;
 }
 
-message Source {
-  string name = 1;
-  optional string url = 2;
+enum Source {
+  SOURCE_UNKNOWN = 0;
+  SOURCE_GITHUB = 1;
+  SOURCE_INTERNAL = 2;
+  SOURCE_NVD = 3;
+  SOURCE_OSSINDEX = 4;
+  SOURCE_OSV = 5;
+  SOURCE_SNYK = 6;
+  SOURCE_VULNDB = 7;
 }
 
 message Vulnerability {

--- a/proto/src/main/proto/vuln_v1.proto
+++ b/proto/src/main/proto/vuln_v1.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package org.hyades.vuln.v1;
+
+option java_multiple_files = true;
+option java_package = "org.hyades.proto.vuln.v1";
+
+import "google/protobuf/timestamp.proto";
+
+message Alias {
+  string id = 1;
+  Source source = 2;
+}
+
+message Rating {
+  Source source = 1;
+  optional double score = 2;
+  optional Severity severity = 3;
+  optional ScoreMethod method = 4;
+  optional string vector = 5;
+  optional string justification = 6;
+}
+
+message Reference {
+  string url = 1;
+  optional string display_name = 2;
+}
+
+enum ScoreMethod {
+  SCORE_METHOD_NULL = 0;
+  SCORE_METHOD_CVSSV2 = 1;
+  SCORE_METHOD_CVSSV3 = 2;
+  SCORE_METHOD_CVSSV31 = 3;
+  SCORE_METHOD_OWASP = 4;
+  SCORE_METHOD_OTHER = 5;
+}
+
+enum Severity {
+  SEVERITY_UNKNOWN = 0;
+  SEVERITY_CRITICAL = 1;
+  SEVERITY_HIGH = 2;
+  SEVERITY_MEDIUM = 3;
+  SEVERITY_LOW = 4;
+  SEVERITY_INFO = 5;
+  SEVERITY_NONE = 6;
+}
+
+message Source {
+  string name = 1;
+  optional string url = 2;
+}
+
+message Vulnerability {
+  string id = 1;
+  Source source = 2;
+  optional string title = 3;
+  optional string description = 4;
+  repeated Rating ratings = 5;
+  optional google.protobuf.Timestamp created = 6;
+  optional google.protobuf.Timestamp published = 7;
+  optional google.protobuf.Timestamp updated = 8;
+  repeated Reference references = 9;
+  repeated int32 cwes = 10;
+  repeated Alias aliases = 11;
+}

--- a/proto/src/test/java/org/hyades/proto/JacksonProtobufDeserializerTest.java
+++ b/proto/src/test/java/org/hyades/proto/JacksonProtobufDeserializerTest.java
@@ -1,0 +1,34 @@
+package org.hyades.proto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hyades.proto.vulnanalysis.v1.Component;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacksonProtobufDeserializerTest {
+
+    @Test
+    void testDeserialize() throws Exception {
+        final var objectMapper = new ObjectMapper();
+        final var deserializationContext = objectMapper.getDeserializationContext();
+        final var jsonParser = objectMapper.createParser("""
+                {
+                  "uuid": "786b9343-9b98-477d-82b5-4b12ac5f5cec",
+                  "cpe": "cpe:/a:acme:application:9.1.1",
+                  "purl": "pkg:maven/acme/a@9.1.1",
+                  "internal": true,
+                  "unknownProperty": []
+                }
+                """);
+
+        final var deserializer = new JacksonProtobufDeserializer<>(Component.class);
+        final Component component = deserializer.deserialize(jsonParser, deserializationContext);
+        assertThat(component).isNotNull();
+        assertThat(component.getUuid()).isEqualTo("786b9343-9b98-477d-82b5-4b12ac5f5cec");
+        assertThat(component.getCpe()).isEqualTo("cpe:/a:acme:application:9.1.1");
+        assertThat(component.getPurl()).isEqualTo("pkg:maven/acme/a@9.1.1");
+        assertThat(component.getInternal()).isTrue();
+    }
+
+}

--- a/proto/src/test/java/org/hyades/proto/JacksonProtobufDeserializerTest.java
+++ b/proto/src/test/java/org/hyades/proto/JacksonProtobufDeserializerTest.java
@@ -28,6 +28,7 @@ class JacksonProtobufDeserializerTest {
         assertThat(component.getUuid()).isEqualTo("786b9343-9b98-477d-82b5-4b12ac5f5cec");
         assertThat(component.getCpe()).isEqualTo("cpe:/a:acme:application:9.1.1");
         assertThat(component.getPurl()).isEqualTo("pkg:maven/acme/a@9.1.1");
+        assertThat(component.hasSwidTagId()).isFalse();
         assertThat(component.getInternal()).isTrue();
     }
 

--- a/proto/src/test/java/org/hyades/proto/JacksonProtobufSerializerTest.java
+++ b/proto/src/test/java/org/hyades/proto/JacksonProtobufSerializerTest.java
@@ -1,0 +1,45 @@
+package org.hyades.proto;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
+import org.hyades.proto.vulnanalysis.v1.Component;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+
+class JacksonProtobufSerializerTest {
+
+    @Test
+    void testSerialize() throws Exception {
+        final var stringWriter = new StringWriter();
+        final var jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+        final var serializerProvider = new ObjectMapper().getSerializerProvider();
+
+        final var serializer = new JacksonProtobufSerializer<>(Component.class);
+        serializer.serialize(Component.newBuilder()
+                        .setUuid("786b9343-9b98-477d-82b5-4b12ac5f5cec")
+                        .setCpe("cpe:/a:acme:application:9.1.1")
+                        .setPurl("pkg:maven/acme/a@9.1.1")
+                        .setInternal(true)
+                        .build(),
+                jsonGenerator,
+                serializerProvider
+        );
+
+        jsonGenerator.flush();
+
+        JsonAssertions.assertThatJson(stringWriter.toString())
+                .isEqualTo(json("""
+                        {
+                          "uuid": "786b9343-9b98-477d-82b5-4b12ac5f5cec",
+                          "cpe": "cpe:/a:acme:application:9.1.1",
+                          "purl": "pkg:maven/acme/a@9.1.1",
+                          "internal": true
+                        }
+                        """));
+    }
+
+}

--- a/proto/src/test/java/org/hyades/proto/KafkaProtobufSerdeTest.java
+++ b/proto/src/test/java/org/hyades/proto/KafkaProtobufSerdeTest.java
@@ -1,0 +1,53 @@
+package org.hyades.proto;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.hyades.proto.vulnanalysis.v1.Component;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class KafkaProtobufSerdeTest {
+
+    @Test
+    @SuppressWarnings("resource")
+    void testRoundTrip() {
+        final var serde = new KafkaProtobufSerde<>(Component.parser());
+
+        final byte[] componentBytes = serde.serializer().serialize("topic", Component.newBuilder()
+                .setUuid("786b9343-9b98-477d-82b5-4b12ac5f5cec")
+                .setCpe("cpe:/a:acme:application:9.1.1")
+                .setPurl("pkg:maven/acme/a@9.1.1")
+                .setInternal(true)
+                .build());
+        assertThat(componentBytes).isNotNull();
+
+        final Component component = serde.deserializer().deserialize("topic", componentBytes);
+        assertThat(component).isNotNull();
+        assertThat(component.getUuid()).isEqualTo("786b9343-9b98-477d-82b5-4b12ac5f5cec");
+        assertThat(component.getCpe()).isEqualTo("cpe:/a:acme:application:9.1.1");
+        assertThat(component.getPurl()).isEqualTo("pkg:maven/acme/a@9.1.1");
+        assertThat(component.getInternal()).isTrue();
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void testSerializationException() {
+        final var serde = new KafkaProtobufSerde<>(Component.parser());
+
+        assertThatExceptionOfType(SerializationException.class)
+                .isThrownBy(() -> serde.serializer().serialize("topic", null));
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void testDeserializationException() {
+        final var serde = new KafkaProtobufSerde<>(Component.parser());
+
+        assertThatExceptionOfType(SerializationException.class)
+                .isThrownBy(() -> serde.deserializer().deserialize("topic", "[]".getBytes(StandardCharsets.UTF_8)));
+    }
+
+}

--- a/proto/src/test/java/org/hyades/proto/KafkaProtobufSerdeTest.java
+++ b/proto/src/test/java/org/hyades/proto/KafkaProtobufSerdeTest.java
@@ -29,6 +29,7 @@ class KafkaProtobufSerdeTest {
         assertThat(component.getUuid()).isEqualTo("786b9343-9b98-477d-82b5-4b12ac5f5cec");
         assertThat(component.getCpe()).isEqualTo("cpe:/a:acme:application:9.1.1");
         assertThat(component.getPurl()).isEqualTo("pkg:maven/acme/a@9.1.1");
+        assertThat(component.hasSwidTagId()).isFalse();
         assertThat(component.getInternal()).isTrue();
     }
 

--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>commons</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hyades</groupId>
+            <artifactId>proto</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-docker</artifactId>
         </dependency>

--- a/vulnerability-analyzer/src/main/java/org/hyades/client/snyk/SnykClientConfiguration.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/client/snyk/SnykClientConfiguration.java
@@ -1,8 +1,5 @@
 package org.hyades.client.snyk;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hyades.config.SnykConfig;
 import org.hyades.util.RoundRobinAccessor;
 
@@ -12,16 +9,6 @@ import javax.inject.Named;
 import java.util.function.Supplier;
 
 class SnykClientConfiguration {
-
-    @Produces
-    @ApplicationScoped
-    @Named("snykObjectMapper")
-    ObjectMapper objectMapper() {
-        return new ObjectMapper()
-                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
-
-    }
 
     @Produces
     @ApplicationScoped

--- a/vulnerability-analyzer/src/main/java/org/hyades/serde/ObjectMapperCustomizer.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/serde/ObjectMapperCustomizer.java
@@ -1,0 +1,31 @@
+package org.hyades.serde;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.hyades.proto.JacksonProtobufDeserializer;
+import org.hyades.proto.JacksonProtobufSerializer;
+import org.hyades.proto.vulnanalysis.v1.ScanKey;
+import org.hyades.proto.vulnanalysis.v1.internal.ScanTask;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ObjectMapperCustomizer implements io.quarkus.jackson.ObjectMapperCustomizer {
+
+    @Override
+    public void customize(final ObjectMapper objectMapper) {
+        final var protoModule = new SimpleModule()
+                .addSerializer(ScanKey.class, new JacksonProtobufSerializer<>(ScanKey.class))
+                .addDeserializer(ScanKey.class, new JacksonProtobufDeserializer<>(ScanKey.class))
+                .addSerializer(ScanTask.class, new JacksonProtobufSerializer<>(ScanTask.class))
+                .addDeserializer(ScanTask.class, new JacksonProtobufDeserializer<>(ScanTask.class));
+
+        objectMapper
+                .registerModule(protoModule)
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+
+}

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/snyk/SnykProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/snyk/SnykProcessorTest.java
@@ -77,7 +77,6 @@ class SnykProcessorTest {
     SnykProcessorSupplier processorSupplier;
 
     @Inject
-    @Named("snykObjectMapper")
     ObjectMapper objectMapper;
 
     @Inject


### PR DESCRIPTION
This PR adds an initial draft of [Protobuf](https://protobuf.dev/) schemas for use with the vulnerability analyzer, along with some serialization logic.

Custom serialization logic was needed, as the [official Protobuf serializers](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/serdes-protobuf.html) require use of a schema registry, which we decided to not use for now.

Both serialization logic and generated Java classes reside in the new `proto` module, which is intended to be used by modules within the Hyades project. Applications living outside this repo are intended to pick the `.proto` files they're interested in (e.g. `vuln-analysis_v1.proto`), and generate the corresponding code by themselves.

In later PRs, existing code in `vulnerability-analyzer` and `mirror-service` will be updated to use these schemas.

Relates to #244 