### PR TITLE
enable compression

### DIFF
--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -15,6 +15,7 @@ quarkus.kafka-streams.topics=\
   ${api.topic.prefix}dtrack.vuln-analysis.result
 
 quarkus.log.category."org.apache.kafka".level=WARN
+quarkus.kafka.snappy.enabled=true
 kafka.retry-attempts=2
 kafka-streams.topology.optimization=all
 kafka-streams.default.deserialization.exception.handler=org.apache.kafka.streams.errors.LogAndContinueExceptionHandler
@@ -25,6 +26,7 @@ kafka-streams.auto.offset.reset=earliest
 kafka-streams.metrics.recording.level=DEBUG
 kafka-streams.num.stream.threads=3
 kafka-streams.max.task.idle.ms=1000
+kafka-streams.compression.type=snappy
 
 ## Dev Services for Kafka
 #

--- a/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerIT.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerIT.java
@@ -39,7 +39,8 @@ class VulnerabilityAnalyzerIT {
                     "scanner.internal.enabled", "true",
                     "scanner.ossindex.enabled", "false",
                     "scanner.snyk.enabled", "false",
-                    "quarkus.flyway.migrate-at-start", "true"
+                    "quarkus.flyway.migrate-at-start", "true",
+                    "quarkus.kafka.snappy.enabled", "true"
             );
         }
     }

--- a/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerTestProfile.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerTestProfile.java
@@ -1,0 +1,14 @@
+package org.hyades;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class VulnerabilityAnalyzerTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("quarkus.kafka.snappy.enabled", "false");
+    }
+}

--- a/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerTopologyTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerTopologyTest.java
@@ -58,7 +58,8 @@ class VulnerabilityAnalyzerTopologyTest {
                 return Map.of(
                         "scanner.internal.enabled", "true",
                         "scanner.ossindex.enabled", "true",
-                        "scanner.snyk.enabled", "true"
+                        "scanner.snyk.enabled", "true",
+                        "quarkus.kafka.snappy.enabled", "false"
                 );
             }
         }
@@ -119,7 +120,7 @@ class VulnerabilityAnalyzerTopologyTest {
 
             final List<ConsumerRecord<ScanKey, ScanResult>> results = kafkaCompanion
                     .consume(new KafkaProtobufSerde<>(ScanKey.parser()), new KafkaProtobufSerde<>(ScanResult.parser()))
-                    .fromTopics(KafkaTopic.VULN_ANALYSIS_RESULT.getName(), 4, Duration.ofSeconds(5))
+                    .fromTopics(KafkaTopic.VULN_ANALYSIS_RESULT.getName(), 4, Duration.ofSeconds(8))
                     .awaitCompletion()
                     .getRecords();
 
@@ -160,7 +161,8 @@ class VulnerabilityAnalyzerTopologyTest {
                 return Map.of(
                         "scanner.internal.enabled", "true",
                         "scanner.ossindex.enabled", "true",
-                        "scanner.snyk.enabled", "true"
+                        "scanner.snyk.enabled", "true",
+                        "quarkus.kafka.snappy.enabled", "false"
                 );
             }
         }
@@ -187,7 +189,7 @@ class VulnerabilityAnalyzerTopologyTest {
 
             final List<ConsumerRecord<ScanKey, ScanResult>> results = kafkaCompanion
                     .consume(new KafkaProtobufSerde<>(ScanKey.parser()), new KafkaProtobufSerde<>(ScanResult.parser()))
-                    .fromTopics(KafkaTopic.VULN_ANALYSIS_RESULT.getName(), 1, Duration.ofSeconds(5))
+                    .fromTopics(KafkaTopic.VULN_ANALYSIS_RESULT.getName(), 1, Duration.ofSeconds(7))
                     .awaitCompletion()
                     .getRecords();
 
@@ -213,7 +215,8 @@ class VulnerabilityAnalyzerTopologyTest {
                 return Map.of(
                         "scanner.internal.enabled", "false",
                         "scanner.ossindex.enabled", "false",
-                        "scanner.snyk.enabled", "false"
+                        "scanner.snyk.enabled", "false",
+                        "quarkus.kafka.snappy.enabled", "false"
                 );
             }
         }
@@ -242,7 +245,7 @@ class VulnerabilityAnalyzerTopologyTest {
 
             final List<ConsumerRecord<ScanKey, ScanResult>> results = kafkaCompanion
                     .consume(new KafkaProtobufSerde<>(ScanKey.parser()), new KafkaProtobufSerde<>(ScanResult.parser()))
-                    .fromTopics(KafkaTopic.VULN_ANALYSIS_RESULT.getName(), 1, Duration.ofSeconds(5))
+                    .fromTopics(KafkaTopic.VULN_ANALYSIS_RESULT.getName(), 1, Duration.ofSeconds(7))
                     .awaitCompletion()
                     .getRecords();
 

--- a/vulnerability-analyzer/src/test/java/org/hyades/client/snyk/SnykClientTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/client/snyk/SnykClientTest.java
@@ -61,7 +61,8 @@ class SnykClientTest {
             return Map.of(
                     "scanner.snyk.enabled", "true",
                     "scanner.snyk.api.org-id", "test-org-id",
-                    "scanner.snyk.api.tokens", "token-1,token-2"
+                    "scanner.snyk.api.tokens", "token-1,token-2",
+                    "quarkus.kafka.snappy.enabled", "false"
             );
         }
     }

--- a/vulnerability-analyzer/src/test/java/org/hyades/persistence/VulnerableSoftwareRepositoryTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/persistence/VulnerableSoftwareRepositoryTest.java
@@ -2,6 +2,8 @@ package org.hyades.persistence;
 
 import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.hyades.VulnerabilityAnalyzerTestProfile;
 import org.hyades.model.Component;
 import org.hyades.model.VulnerableSoftware;
 import org.junit.jupiter.api.Assertions;
@@ -13,6 +15,7 @@ import java.util.List;
 import java.util.UUID;
 
 @QuarkusTest
+@TestProfile(VulnerabilityAnalyzerTestProfile.class)
 public class VulnerableSoftwareRepositoryTest {
 
     @Inject

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/internal/InternalScannerProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/internal/InternalScannerProcessorTest.java
@@ -4,6 +4,7 @@ import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheName;
 import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.TestInputTopic;
@@ -11,6 +12,7 @@ import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.test.TestRecord;
+import org.hyades.VulnerabilityAnalyzerTestProfile;
 import org.hyades.model.VulnerableSoftware;
 import org.hyades.proto.KafkaProtobufDeserializer;
 import org.hyades.proto.KafkaProtobufSerializer;
@@ -33,6 +35,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
+@TestProfile(VulnerabilityAnalyzerTestProfile.class)
 class InternalScannerProcessorTest {
 
     @Inject

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/ossindex/OssIndexProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/ossindex/OssIndexProcessorTest.java
@@ -9,6 +9,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheName;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -18,6 +19,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.test.TestRecord;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.hyades.VulnerabilityAnalyzerTestProfile;
 import org.hyades.client.ossindex.ComponentReport;
 import org.hyades.client.ossindex.ComponentReportRequest;
 import org.hyades.client.ossindex.OssIndexClient;
@@ -54,6 +56,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
+@TestProfile(VulnerabilityAnalyzerTestProfile.class)
 class OssIndexProcessorTest {
 
     @Inject

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/snyk/SnykProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/snyk/SnykProcessorTest.java
@@ -69,7 +69,8 @@ class SnykProcessorTest {
                     "scanner.snyk.enabled", "true",
                     "scanner.snyk.api.org-id", "test-org-id",
                     "scanner.snyk.api.tokens", "token-1,token-2",
-                    "scanner.snyk.batch-size", "100"
+                    "scanner.snyk.batch-size", "100",
+                    "quarkus.kafka.snappy.enabled", "false"
             );
         }
     }


### PR DESCRIPTION
This change will enable compression on topics in vulnerability analyser service. 

It addresses issue  https://github.com/DependencyTrack/hyades/issues/353 