### PR TITLE
Log retryable exceptions in `debug` level instead of `warn`

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/ossindex/OssIndexProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/ossindex/OssIndexProcessor.java
@@ -113,7 +113,7 @@ public class OssIndexProcessor extends RetryingBatchProcessor<String, ScanTask, 
         } catch (Throwable e) {
             if (ProcessorUtils.isRetryable(e)) {
                 batch.forEach(record -> {
-                    LOGGER.warn("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
+                    LOGGER.debug("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
                     scheduleForRetry(record);
                 });
             } else {

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/snyk/SnykProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/snyk/SnykProcessor.java
@@ -152,7 +152,7 @@ public class SnykProcessor extends RetryingBatchProcessor<String, ScanTask, Stri
         } catch (Throwable e) {
             if (isRetryable(e)) {
                 batch.forEach(record -> {
-                    LOGGER.warn("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
+                    LOGGER.debug("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
                     scheduleForRetry(record);
                 });
             } else {


### PR DESCRIPTION
They are flooding the CI logs, and in normal operation retries are tracked via Prometheus metrics. Retryable exceptions are also "business as usual" to some extent, it's not something we need to warn about every time.