### PR TITLE
Increase timeout for arm64 native builds to 75 minutes

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -16,7 +16,7 @@ jobs:
         - name: amd64
           build-timeout: 15
         - name: arm64
-          build-timeout: 60
+          build-timeout: 75
       fail-fast: true
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
Apparently 60min was a little bit too optimistic.