### PR TITLE
Prevent Quarkus datasource dev services from starting for metrics service

### DIFF
--- a/metrics-service/pom.xml
+++ b/metrics-service/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.hyades</groupId>
             <artifactId>commons</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-postgresql</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
As long as a JDBC driver is on the classpath, Quarkus will launch a testcontainer for the respective RDBMs in test- and dev-mode. By excluding the JDBC driver, this behavior can be stopped.

This is also how it's currently done for the mirror service.