### PR TITLE
Fix JVM-based container images for arm64

### DIFF
--- a/metrics-service/src/main/docker/Dockerfile.jvm
+++ b/metrics-service/src/main/docker/Dockerfile.jvm
@@ -3,8 +3,9 @@ FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# libstdc++ is required by RocksDB
-RUN apk --no-cache add libstdc++
+# libstdc++ is required for librocksdbjndi (RocksDB)
+# gcompat is required for libsnappy (Snappy compression)
+RUN apk --no-cache add gcompat libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/metrics-service/src/main/docker/Dockerfile.jvm
+++ b/metrics-service/src/main/docker/Dockerfile.jvm
@@ -1,7 +1,10 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.6
+FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# libstdc++ is required by RocksDB
+RUN apk --no-cache add libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/mirror-service/src/main/docker/Dockerfile.jvm
+++ b/mirror-service/src/main/docker/Dockerfile.jvm
@@ -3,8 +3,9 @@ FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# libstdc++ is required by RocksDB
-RUN apk --no-cache add libstdc++
+# libstdc++ is required for librocksdbjndi (RocksDB)
+# gcompat is required for libsnappy (Snappy compression)
+RUN apk --no-cache add gcompat libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/mirror-service/src/main/docker/Dockerfile.jvm
+++ b/mirror-service/src/main/docker/Dockerfile.jvm
@@ -1,7 +1,10 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.6
+FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# libstdc++ is required by RocksDB
+RUN apk --no-cache add libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/notification-publisher/src/main/docker/Dockerfile.jvm
+++ b/notification-publisher/src/main/docker/Dockerfile.jvm
@@ -3,8 +3,9 @@ FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# libstdc++ is required by RocksDB
-RUN apk --no-cache add libstdc++
+# libstdc++ is required for librocksdbjndi (RocksDB)
+# gcompat is required for libsnappy (Snappy compression)
+RUN apk --no-cache add gcompat libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/notification-publisher/src/main/docker/Dockerfile.jvm
+++ b/notification-publisher/src/main/docker/Dockerfile.jvm
@@ -1,7 +1,10 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.6
+FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# libstdc++ is required by RocksDB
+RUN apk --no-cache add libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/repository-meta-analyzer/src/main/docker/Dockerfile.jvm
+++ b/repository-meta-analyzer/src/main/docker/Dockerfile.jvm
@@ -3,8 +3,9 @@ FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# libstdc++ is required by RocksDB
-RUN apk --no-cache add libstdc++
+# libstdc++ is required for librocksdbjndi (RocksDB)
+# gcompat is required for libsnappy (Snappy compression)
+RUN apk --no-cache add gcompat libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/repository-meta-analyzer/src/main/docker/Dockerfile.jvm
+++ b/repository-meta-analyzer/src/main/docker/Dockerfile.jvm
@@ -1,7 +1,10 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.6
+FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# libstdc++ is required by RocksDB
+RUN apk --no-cache add libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/vulnerability-analyzer/src/main/docker/Dockerfile.jvm
+++ b/vulnerability-analyzer/src/main/docker/Dockerfile.jvm
@@ -3,8 +3,9 @@ FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# libstdc++ is required by RocksDB
-RUN apk --no-cache add libstdc++
+# libstdc++ is required for librocksdbjndi (RocksDB)
+# gcompat is required for libsnappy (Snappy compression)
+RUN apk --no-cache add gcompat libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/vulnerability-analyzer/src/main/docker/Dockerfile.jvm
+++ b/vulnerability-analyzer/src/main/docker/Dockerfile.jvm
@@ -1,7 +1,10 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.6
+FROM bellsoft/liberica-openjdk-alpine-musl:17.0.6
 
 ENV JAVA_OPTS=""
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# libstdc++ is required by RocksDB
+RUN apk --no-cache add libstdc++
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/


### PR DESCRIPTION
It turned out that `librocksdbjndi` (brought in by RocksDB) couldn't load `libstdc++` when running the container images on arm64. It works fine on amd64 though. 

Not sure why exactly this is happening. Potentially because the [base image](https://hub.docker.com/r/bellsoft/liberica-openjdk-alpine) is a modified version of Alpine that ships with `glibc` instead of `musl`. Switching to the [`musl`-based base image](https://hub.docker.com/r/bellsoft/liberica-openjre-alpine-musl) resolves the issue, but then requires additional packages to be installed to work on amd64.

This PR has been tested on `linux/amd64` and `darwin/arm64` platforms.
