### PR TITLE
Enable compaction for metrics topics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,8 @@ services:
     user: "0" # Ensure user can read create-topics.sh
     environment:
       REDPANDA_BROKERS: "dt-redpanda:29092"
+      # METRICS_COMPONENT_TOPIC_PARTITIONS: "3"
+      # METRICS_PROJECT_TOPIC_PARTITIONS: "3"
       # NOTIFICATION_TOPICS_PARTITIONS: "3"
       # NOTIFICATION_TOPICS_RETENTION_MS: "43200000" # 12h
       # REPO_META_ANALYSIS_TOPICS_PARTITIONS: "3"

--- a/scripts/create-topics.sh
+++ b/scripts/create-topics.sh
@@ -56,13 +56,6 @@ create_topic "${API_TOPIC_PREFIX:-}dtrack.vulnerability.mirror.osv" "${VULN_MIRR
 create_topic "${API_TOPIC_PREFIX:-}dtrack.vulnerability.mirror.nvd" "${VULN_MIRROR_TOPICS_PARTITIONS:-1}" "retention.ms=${VULN_MIRROR_TOPICS_RETENTION_MS:-43200000}"
 create_topic "${API_TOPIC_PREFIX:-}dtrack.vulnerability" "${VULN_MIRROR_TOPICS_PARTITIONS:-3}" "cleanup.policy=compact"
 
-
-
-metrics_topics=(
-  "${API_TOPIC_PREFIX:-}dtrack.metrics.component"
-  "${API_TOPIC_PREFIX:-}dtrack.metrics.project"
-  "${API_TOPIC_PREFIX:-}dtrack.metrics.portfolio"
-)
-for topic_name in "${metrics_topics[@]}"; do
-  create_topic "$topic_name" "${METRIC_TOPICS_PARTITIONS:-3}" "retention.ms=${METRICS_TOPICS_RETENTION_MS:-43200000}"
-done
+create_topic "${API_TOPIC_PREFIX:-}dtrack.metrics.component" "${METRICS_COMPONENT_TOPIC_PARTITIONS:-3}" "cleanup.policy=compact"
+create_topic "${API_TOPIC_PREFIX:-}dtrack.metrics.project" "${METRICS_PROJECT_TOPIC_PARTITIONS:-3}" "cleanup.policy=compact"
+create_topic "${API_TOPIC_PREFIX:-}dtrack.metrics.portfolio" "1" "cleanup.policy=compact"


### PR DESCRIPTION
Also hardcode partitions of portfolio metrics topic to `1`, as there will only ever be one key.