### PR TITLE
Fix NPE when preparing notification template

### DIFF
--- a/notification-publisher/src/main/java/org/hyades/notification/publisher/Publisher.java
+++ b/notification-publisher/src/main/java/org/hyades/notification/publisher/Publisher.java
@@ -88,7 +88,7 @@ public interface Publisher {
             context.put("timestampEpochSecond", epochSecond);
             context.put("timestamp", notification.getTimestamp().toString());
             context.put("notification", notification);
-            if (baseUrlProperty != null) {
+            if (baseUrlProperty != null && baseUrlProperty.getPropertyValue() != null) {
                 context.put("baseUrl", baseUrlProperty.getPropertyValue().replaceAll("/$", ""));
             } else {
                 context.put("baseUrl", "");


### PR DESCRIPTION
When no base URL was set, the notification publisher would fail with a `NullPointerException` due to a missing `null` check.