### PR TITLE
Map description of OSS Index vulnerabilities

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/client/ossindex/ModelConverter.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/client/ossindex/ModelConverter.java
@@ -58,29 +58,40 @@ public final class ModelConverter {
             vulnBuilder.addReferences(Reference.newBuilder().setUrl(externalReference));
         }
 
-        if (reportedVuln.cvssVector() != null) {
-            final Cvss cvss = Cvss.fromVector(reportedVuln.cvssVector());
-            if (cvss != null) {
-                final Score score = cvss.calculateScore();
-                if (cvss instanceof CvssV3) {
-                    vulnBuilder.addRatings(Rating.newBuilder()
-                            .setSource(SOURCE_OSSINDEX)
-                            .setMethod(SCORE_METHOD_CVSSV3)
-                            .setScore(score.getBaseScore())
-                            .setVector(cvss.getVector())
-                            .setSeverity(convert(normalizedCvssV3Score(score.getBaseScore()))));
-                } else if (cvss instanceof CvssV2) {
-                    vulnBuilder.addRatings(Rating.newBuilder()
-                            .setSource(SOURCE_OSSINDEX)
-                            .setMethod(SCORE_METHOD_CVSSV2)
-                            .setScore(score.getBaseScore())
-                            .setVector(cvss.getVector())
-                            .setSeverity(convert(normalizedCvssV2Score(score.getBaseScore()))));
-                }
-            }
+        final Rating rating = convertRating(reportedVuln.cvssVector());
+        if (rating != null) {
+            vulnBuilder.addRatings(rating);
         }
 
         return vulnBuilder.build();
+    }
+
+    private static Rating convertRating(final String cvssVector) {
+        final Cvss cvss = Cvss.fromVector(cvssVector);
+        if (cvss == null) {
+            return null;
+        }
+
+        final Score score = cvss.calculateScore();
+        if (cvss instanceof CvssV3) {
+            return Rating.newBuilder()
+                    .setSource(SOURCE_OSSINDEX)
+                    .setMethod(SCORE_METHOD_CVSSV3)
+                    .setScore(score.getBaseScore())
+                    .setVector(cvss.getVector())
+                    .setSeverity(convert(normalizedCvssV3Score(score.getBaseScore())))
+                    .build();
+        } else if (cvss instanceof CvssV2) {
+            return Rating.newBuilder()
+                    .setSource(SOURCE_OSSINDEX)
+                    .setMethod(SCORE_METHOD_CVSSV2)
+                    .setScore(score.getBaseScore())
+                    .setVector(cvss.getVector())
+                    .setSeverity(convert(normalizedCvssV2Score(score.getBaseScore())))
+                    .build();
+        }
+
+        return null;
     }
 
     private static Severity convert(final org.hyades.model.Severity severity) {

--- a/vulnerability-analyzer/src/main/java/org/hyades/client/ossindex/ModelConverter.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/client/ossindex/ModelConverter.java
@@ -3,7 +3,7 @@ package org.hyades.client.ossindex;
 import org.hyades.model.Cwe;
 import org.hyades.proto.vuln.v1.Rating;
 import org.hyades.proto.vuln.v1.Reference;
-import org.hyades.proto.vuln.v1.ScoreMethod;
+import org.hyades.proto.vuln.v1.Severity;
 import org.hyades.proto.vuln.v1.Source;
 import org.hyades.proto.vuln.v1.Vulnerability;
 import org.hyades.resolver.CweResolver;
@@ -11,6 +11,18 @@ import us.springett.cvss.Cvss;
 import us.springett.cvss.CvssV2;
 import us.springett.cvss.CvssV3;
 import us.springett.cvss.Score;
+
+import static org.hyades.commonutil.VulnerabilityUtil.normalizedCvssV2Score;
+import static org.hyades.commonutil.VulnerabilityUtil.normalizedCvssV3Score;
+import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV2;
+import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV3;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_CRITICAL;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_HIGH;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_INFO;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_LOW;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_MEDIUM;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_UNKNOWN;
+import static org.hyades.proto.vuln.v1.Source.SOURCE_OSSINDEX;
 
 public final class ModelConverter {
 
@@ -20,12 +32,11 @@ public final class ModelConverter {
             vulnBuilder.setSource(Source.SOURCE_NVD);
             vulnBuilder.setId(reportedVuln.cve());
         } else {
-            vulnBuilder.setSource(Source.SOURCE_OSSINDEX);
+            vulnBuilder.setSource(SOURCE_OSSINDEX);
             vulnBuilder.setId(reportedVuln.id());
-            vulnBuilder.setTitle(reportedVuln.title());
         }
-        //vulnerability.setDescription(reportedVuln.description());//FIXME : the size of description TBD
-        vulnBuilder.setDescription("");
+        vulnBuilder.setTitle(reportedVuln.title());
+        vulnBuilder.setDescription(reportedVuln.description());
         if (reportedVuln.cwe() != null) {
             CweResolver cweResolver = CweResolver.getInstance();
             Cwe cwe = cweResolver.resolve(reportedVuln.cwe());
@@ -45,23 +56,36 @@ public final class ModelConverter {
             final Cvss cvss = Cvss.fromVector(reportedVuln.cvssVector());
             if (cvss != null) {
                 final Score score = cvss.calculateScore();
-                if (cvss instanceof CvssV2) {
+                if (cvss instanceof CvssV3) {
                     vulnBuilder.addRatings(Rating.newBuilder()
-                            .setSource(Source.SOURCE_OSSINDEX)
-                            .setMethod(ScoreMethod.SCORE_METHOD_CVSSV2)
+                            .setSource(SOURCE_OSSINDEX)
+                            .setMethod(SCORE_METHOD_CVSSV3)
                             .setScore(score.getBaseScore())
-                            .setVector(cvss.getVector()));
-                } else if (cvss instanceof CvssV3) {
+                            .setVector(cvss.getVector())
+                            .setSeverity(convert(normalizedCvssV3Score(score.getBaseScore()))));
+                } else if (cvss instanceof CvssV2) {
                     vulnBuilder.addRatings(Rating.newBuilder()
-                            .setSource(Source.SOURCE_OSSINDEX)
-                            .setMethod(ScoreMethod.SCORE_METHOD_CVSSV3)
+                            .setSource(SOURCE_OSSINDEX)
+                            .setMethod(SCORE_METHOD_CVSSV2)
                             .setScore(score.getBaseScore())
-                            .setVector(cvss.getVector()));
+                            .setVector(cvss.getVector())
+                            .setSeverity(convert(normalizedCvssV2Score(score.getBaseScore()))));
                 }
             }
         }
 
         return vulnBuilder.build();
+    }
+
+    private static Severity convert(final org.hyades.model.Severity severity) {
+        return switch (severity) {
+            case CRITICAL -> SEVERITY_CRITICAL;
+            case HIGH -> SEVERITY_HIGH;
+            case MEDIUM -> SEVERITY_MEDIUM;
+            case LOW -> SEVERITY_LOW;
+            case INFO -> SEVERITY_INFO;
+            default -> SEVERITY_UNKNOWN;
+        };
     }
 
 }

--- a/vulnerability-analyzer/src/main/java/org/hyades/client/ossindex/ModelConverter.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/client/ossindex/ModelConverter.java
@@ -1,6 +1,7 @@
 package org.hyades.client.ossindex;
 
 import org.hyades.model.Cwe;
+import org.hyades.proto.vuln.v1.Alias;
 import org.hyades.proto.vuln.v1.Rating;
 import org.hyades.proto.vuln.v1.Reference;
 import org.hyades.proto.vuln.v1.Severity;
@@ -22,18 +23,23 @@ import static org.hyades.proto.vuln.v1.Severity.SEVERITY_INFO;
 import static org.hyades.proto.vuln.v1.Severity.SEVERITY_LOW;
 import static org.hyades.proto.vuln.v1.Severity.SEVERITY_MEDIUM;
 import static org.hyades.proto.vuln.v1.Severity.SEVERITY_UNKNOWN;
+import static org.hyades.proto.vuln.v1.Source.SOURCE_NVD;
 import static org.hyades.proto.vuln.v1.Source.SOURCE_OSSINDEX;
 
 public final class ModelConverter {
 
     public static Vulnerability convert(final ComponentReportVulnerability reportedVuln) {
         Vulnerability.Builder vulnBuilder = Vulnerability.newBuilder();
-        if (reportedVuln.cve() != null) {
+        vulnBuilder.setId(reportedVuln.id());
+        if (vulnBuilder.getId().toLowerCase().startsWith("cve-")) {
             vulnBuilder.setSource(Source.SOURCE_NVD);
-            vulnBuilder.setId(reportedVuln.cve());
         } else {
             vulnBuilder.setSource(SOURCE_OSSINDEX);
-            vulnBuilder.setId(reportedVuln.id());
+            if (reportedVuln.cve() != null) {
+                vulnBuilder.addAliases(Alias.newBuilder()
+                        .setId(reportedVuln.cve())
+                        .setSource(SOURCE_NVD));
+            }
         }
         vulnBuilder.setTitle(reportedVuln.title());
         vulnBuilder.setDescription(reportedVuln.description());

--- a/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
@@ -3,19 +3,22 @@ package org.hyades.client.ossindex;
 import org.hyades.proto.vuln.v1.Vulnerability;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyades.client.ossindex.ModelConverter.convert;
+import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV2;
 import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV3;
 import static org.hyades.proto.vuln.v1.Severity.SEVERITY_CRITICAL;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_HIGH;
 import static org.hyades.proto.vuln.v1.Source.SOURCE_NVD;
 import static org.hyades.proto.vuln.v1.Source.SOURCE_OSSINDEX;
 
 public class ModelConverterTest {
 
     @Test
-    public void testModelConverter() {
+    public void testConvert() {
         var componentReportVulnerability = new ComponentReportVulnerability(
                 "CVE-2020-7471",
                 "CVE-2020-7471",
@@ -72,6 +75,61 @@ public class ModelConverterTest {
                 reference -> {
                     assertThat(reference.getUrl()).isEqualTo("https://www.openwall.com/lists/oss-security/2020/02/03/1");
                     assertThat(reference.hasDisplayName()).isFalse();
+                }
+        );
+    }
+
+    @Test
+    void testConvertWithAlias() {
+        var componentReportVulnerability = new ComponentReportVulnerability(
+                "sonatype-123",
+                "sonatype-123",
+                "title",
+                "description",
+                7.8f,
+                "(AV:N/AC:L/Au:N/C:N/I:N/A:C)",
+                "CWE-666",
+                "cve-123",
+                "reference",
+                Collections.emptyList()
+        );
+
+        Vulnerability vulnerability = convert(componentReportVulnerability);
+        assertThat(vulnerability).isNotNull();
+        assertThat(vulnerability.getId()).isEqualTo("sonatype-123");
+        assertThat(vulnerability.getSource()).isEqualTo(SOURCE_OSSINDEX);
+        assertThat(vulnerability.getAliasesList()).satisfiesExactly(
+                alias -> {
+                    assertThat(alias.getId()).isEqualTo("cve-123");
+                    assertThat(alias.getSource()).isEqualTo(SOURCE_NVD);
+                }
+        );
+    }
+
+    @Test
+    void testConvertWithCvssV2() {
+        var componentReportVulnerability = new ComponentReportVulnerability(
+                "cve",
+                "cve",
+                "title",
+                "description",
+                7.8f,
+                "(AV:N/AC:L/Au:N/C:N/I:N/A:C)",
+                "CWE-666",
+                "cve",
+                "reference",
+                Collections.emptyList()
+        );
+
+        Vulnerability vulnerability = convert(componentReportVulnerability);
+        assertThat(vulnerability).isNotNull();
+        assertThat(vulnerability.getRatingsList()).satisfiesExactly(
+                rating -> {
+                    assertThat(rating.getSource()).isEqualTo(SOURCE_OSSINDEX);
+                    assertThat(rating.getMethod()).isEqualTo(SCORE_METHOD_CVSSV2);
+                    assertThat(rating.getScore()).isEqualTo(7.8);
+                    assertThat(rating.getVector()).isEqualTo("(AV:N/AC:L/Au:N/C:N/I:N/A:C)");
+                    assertThat(rating.getSeverity()).isEqualTo(SEVERITY_HIGH);
                 }
         );
     }

--- a/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
@@ -1,30 +1,79 @@
 package org.hyades.client.ossindex;
 
-import org.hyades.proto.vuln.v1.Source;
 import org.hyades.proto.vuln.v1.Vulnerability;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyades.client.ossindex.ModelConverter.convert;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV3;
+import static org.hyades.proto.vuln.v1.Severity.SEVERITY_CRITICAL;
+import static org.hyades.proto.vuln.v1.Source.SOURCE_NVD;
+import static org.hyades.proto.vuln.v1.Source.SOURCE_OSSINDEX;
 
 public class ModelConverterTest {
 
     @Test
     public void testModelConverter() {
-
-        ComponentReportVulnerability componentReportVulnerability = new ComponentReportVulnerability(
-                "test-id", "", "", "", 7.3f, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
-                "CWE-300", "CVE-test", "", List.of("")
+        var componentReportVulnerability = new ComponentReportVulnerability(
+                "CVE-2020-7471",
+                "CVE-2020-7471",
+                "[CVE-2020-7471] CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')",
+                """
+                        Django 1.11 before 1.11.28, 2.2 before 2.2.10, and 3.0 before 3.0.3 allows
+                        SQL Injection if untrusted data is used as a StringAgg delimiter (e.g., in Django
+                        applications that offer downloads of data as a series of rows with a user-specified
+                        column delimiter). By passing a suitably crafted delimiter to a
+                        contrib.postgres.aggregates.StringAgg instance, it was possible to break escaping
+                        and inject malicious SQL.
+                        """,
+                9.8f,
+                "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "CWE-89",
+                "CVE-2020-7471",
+                "https://ossindex.sonatype.org/vulnerability/CVE-2020-7471?component-type=pypi&component-name=django",
+                List.of(
+                        "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-7471",
+                        "https://www.djangoproject.com/weblog/2020/feb/03/security-releases/",
+                        "https://www.openwall.com/lists/oss-security/2020/02/03/1"
+                )
         );
 
         Vulnerability vulnerability = convert(componentReportVulnerability);
-        assertNotNull(vulnerability);
-        assertEquals("CVE-test", vulnerability.getId());
-        assertEquals(Source.SOURCE_NVD, vulnerability.getSource());
-        assertEquals(300, vulnerability.getCwesList().get(0));
-        assertEquals(7.3, vulnerability.getRatings(0).getScore());
+        assertThat(vulnerability).isNotNull();
+        assertThat(vulnerability.getId()).isEqualTo("CVE-2020-7471");
+        assertThat(vulnerability.getSource()).isEqualTo(SOURCE_NVD);
+        assertThat(vulnerability.getTitle()).startsWith("[CVE-2020-7471] CWE-89: Improper").hasSize(108);
+        assertThat(vulnerability.getDescription()).startsWith("Django 1.11 before 1.11.28").hasSize(413);
+        assertThat(vulnerability.getCwesList()).containsOnly(89);
+        assertThat(vulnerability.getRatingsList()).satisfiesExactly(
+                rating -> {
+                    assertThat(rating.getSource()).isEqualTo(SOURCE_OSSINDEX);
+                    assertThat(rating.getMethod()).isEqualTo(SCORE_METHOD_CVSSV3);
+                    assertThat(rating.getScore()).isEqualTo(9.8);
+                    assertThat(rating.getVector()).isEqualTo("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+                    assertThat(rating.getSeverity()).isEqualTo(SEVERITY_CRITICAL);
+                }
+        );
+        assertThat(vulnerability.getReferencesList()).satisfiesExactly(
+                reference -> {
+                    assertThat(reference.getUrl()).isEqualTo("https://ossindex.sonatype.org/vulnerability/CVE-2020-7471?component-type=pypi&component-name=django");
+                    assertThat(reference.hasDisplayName()).isFalse();
+                },
+                reference -> {
+                    assertThat(reference.getUrl()).isEqualTo("http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-7471");
+                    assertThat(reference.hasDisplayName()).isFalse();
+                },
+                reference -> {
+                    assertThat(reference.getUrl()).isEqualTo("https://www.djangoproject.com/weblog/2020/feb/03/security-releases/");
+                    assertThat(reference.hasDisplayName()).isFalse();
+                },
+                reference -> {
+                    assertThat(reference.getUrl()).isEqualTo("https://www.openwall.com/lists/oss-security/2020/02/03/1");
+                    assertThat(reference.hasDisplayName()).isFalse();
+                }
+        );
     }
+
 }

--- a/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
@@ -18,7 +18,7 @@ import static org.hyades.proto.vuln.v1.Source.SOURCE_OSSINDEX;
 public class ModelConverterTest {
 
     @Test
-    public void testConvert() {
+    void testConvert() {
         var componentReportVulnerability = new ComponentReportVulnerability(
                 "CVE-2020-7471",
                 "CVE-2020-7471",

--- a/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/client/ossindex/ModelConverterTest.java
@@ -134,4 +134,24 @@ public class ModelConverterTest {
         );
     }
 
+    @Test
+    void testConvertWithoutCvss() {
+        var componentReportVulnerability = new ComponentReportVulnerability(
+                "cve",
+                "cve",
+                "title",
+                "description",
+                null,
+                null,
+                "CWE-666",
+                "cve",
+                "reference",
+                Collections.emptyList()
+        );
+
+        Vulnerability vulnerability = convert(componentReportVulnerability);
+        assertThat(vulnerability).isNotNull();
+        assertThat(vulnerability.getRatingsCount()).isZero();
+    }
+
 }


### PR DESCRIPTION
We previously had concerns that including the description would blow the 1MB limit of Kafka events. But now that we use Protobuf AND Snappy compression, even events with ~30 vulnerabilities end up being only ~80kiB. We'll not have any issues whatsoever with event size.