### PR TITLE
Avoid erroneous WARN logs during Snyk analysis

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/snyk/SnykProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/snyk/SnykProcessor.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -139,9 +140,11 @@ public class SnykProcessor extends RetryingBatchProcessor<String, ScanTask, Stri
         LOGGER.info("Analyzing batch of {} records", batch.size());
         super.analyzeBatch(batch);
 
+        final Set<String> purls = new HashSet<>();
         final MultivaluedMap<String, RetryableRecord<String, ScanTask>> purlRecords = new MultivaluedHashMap<>();
         for (final RetryableRecord<String, ScanTask> record : batch) {
             purlRecords.add(record.key(), record);
+            purls.add(record.key());
         }
 
         final Page<Issue> page;
@@ -174,7 +177,14 @@ public class SnykProcessor extends RetryingBatchProcessor<String, ScanTask, Stri
             Report mappedReport = getMappedReport(page, purlInReportedIssue);
             final List<RetryableRecord<String, ScanTask>> affectedRecords = purlRecords.get(purlInReportedIssue);
             if (affectedRecords == null) {
-                LOGGER.warn("Reported coordinates do not match any records: {}", pageData.attributes().coordinates());
+                // We either already processed all vulnerabilities for the PURL already,
+                // or we're not able to correlate the PURL returned by Snyk.
+                if (!purls.contains(purlInReportedIssue)) {
+                    // Can't correlate the reported coordinates to any PURL that we
+                    // submitted for analysis. It's likely that Snyk returned the coordinates
+                    // in a different format than what we submitted. Issue a warning.
+                    LOGGER.warn("Reported coordinates do not match any records: {}", pageData.attributes().coordinates());
+                }
                 continue;
             } else {
                 purlRecords.remove(purlInReportedIssue);


### PR DESCRIPTION
We currently log a warning when the same PURL appears in multiple issues of the Snyk response.