### PR TITLE
Initial work for end-to-end tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,34 @@
+name: E2E
+
+on:
+  # As e2e tests depend on the latest container images,
+  # only trigger them after building the images completed.
+  workflow_run:
+    workflows:
+    - "Publish Jar"
+    types:
+    - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    # The workflow completion event will be triggered for both
+    # failures and successes, so we need to check the status.
+    # https://github.com/orgs/community/discussions/26238
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Test
+      run: mvn -pl e2e clean verify -Pe2e-all

--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ To execute the unit tests for all Hyades modules:
 ./mvnw clean verify
 ```
 
+#### End-To-End Testing 🧟
+
+> **Note**  
+> End-to-end tests are based on container images. The tags of those images are currently hardcoded.
+> For the Hyades services, the tags are set to `latest`. If you want to test local changes, you'll have
+> to first:
+> * Build container images locally
+> * Update the tags in [`AbstractE2ET`](https://github.com/DependencyTrack/hyades/blob/main/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java)
+
+To execute end-to-end tests as part of the build:
+
+```shell
+./mvnw clean verify -Pe2e-all
+```
+
+To execute *only* the end-to-end tests:
+
+```shell
+./mvnw -pl e2e clean verify -Pe2e-all
+```
+
 #### Load Testing 🚀
 
 See [`load-tests`](load-tests).

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -69,6 +69,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -36,11 +36,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>redpanda</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
             <scope>test</scope>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hyades</groupId>
+        <artifactId>hyades</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>e2e</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>redpanda</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -26,6 +26,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
@@ -33,6 +38,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>redpanda</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>wiremock-jre8-standalone</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -52,4 +52,32 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>e2e-none</id>
+            <properties>
+                <skipITs>true</skipITs>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+
+        <profile>
+            <id>e2e-all</id>
+            <properties>
+                <skipITs>false</skipITs>
+            </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/e2e/src/main/java/org/hyades/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/hyades/apiserver/ApiServerClient.java
@@ -4,11 +4,15 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.hyades.apiserver.model.BomProcessingResponse;
 import org.hyades.apiserver.model.BomUploadRequest;
 import org.hyades.apiserver.model.BomUploadResponse;
+import org.hyades.apiserver.model.CreateNotificationRuleRequest;
 import org.hyades.apiserver.model.CreateTeamRequest;
 import org.hyades.apiserver.model.CreateVulnerabilityRequest;
 import org.hyades.apiserver.model.Finding;
+import org.hyades.apiserver.model.NotificationPublisher;
+import org.hyades.apiserver.model.NotificationRule;
 import org.hyades.apiserver.model.Project;
 import org.hyades.apiserver.model.Team;
+import org.hyades.apiserver.model.UpdateNotificationRuleRequest;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -85,5 +89,23 @@ public interface ApiServerClient {
     @Produces(MediaType.WILDCARD)
     @Consumes(MediaType.APPLICATION_JSON)
     Project lookupProject(@QueryParam("name") final String name, @QueryParam("version") final String version);
+
+    @GET
+    @Path("/notification/publisher")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<NotificationPublisher> getAllNotificationPublishers();
+
+    @PUT
+    @Path("/notification/rule")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    NotificationRule createNotificationRule(final CreateNotificationRuleRequest request);
+
+    @POST
+    @Path("/notification/rule")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    NotificationRule updateNotificationRule(final UpdateNotificationRuleRequest request);
 
 }

--- a/e2e/src/main/java/org/hyades/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/hyades/apiserver/ApiServerClient.java
@@ -1,0 +1,89 @@
+package org.hyades.apiserver;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.hyades.apiserver.model.BomProcessingResponse;
+import org.hyades.apiserver.model.BomUploadRequest;
+import org.hyades.apiserver.model.BomUploadResponse;
+import org.hyades.apiserver.model.CreateTeamRequest;
+import org.hyades.apiserver.model.CreateVulnerabilityRequest;
+import org.hyades.apiserver.model.Finding;
+import org.hyades.apiserver.model.Project;
+import org.hyades.apiserver.model.Team;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.UUID;
+
+@Path("/api/v1")
+@RegisterClientHeaders(ApiServerClientHeaderFactory.class)
+public interface ApiServerClient {
+
+    @POST
+    @Path("/user/forceChangePassword")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    void forcePasswordChange(@FormParam("username") final String username,
+                             @FormParam("password") final String password,
+                             @FormParam("newPassword") final String newPassword,
+                             @FormParam("confirmPassword") final String confirmPassword);
+
+    @POST
+    @Path("/user/login")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    String login(@FormParam("username") final String username,
+                 @FormParam("password") final String password);
+
+    @PUT
+    @Path("/team")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Team createTeam(final CreateTeamRequest request);
+
+    @POST
+    @Path("/permission/{permission}/team/{uuid}")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Team addPermissionToTeam(@PathParam("uuid") final UUID teamUuid,
+                             @PathParam("permission") final String permission);
+
+    @PUT
+    @Path("/bom")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    BomUploadResponse uploadBom(final BomUploadRequest request);
+
+    @GET
+    @Path("/bom/token/{token}")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.WILDCARD)
+    BomProcessingResponse isBomBeingProcessed(@PathParam("token") final String token);
+
+    @PUT
+    @Path("/vulnerability")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    void createVulnerability(final CreateVulnerabilityRequest request);
+
+    @GET
+    @Path("/finding/project/{uuid}")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<Finding> getFindings(@PathParam("uuid") final UUID projectUuid);
+
+    @GET
+    @Path("/project/lookup")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Project lookupProject(@QueryParam("name") final String name, @QueryParam("version") final String version);
+
+}

--- a/e2e/src/main/java/org/hyades/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/hyades/apiserver/ApiServerClient.java
@@ -4,6 +4,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.hyades.apiserver.model.BomProcessingResponse;
 import org.hyades.apiserver.model.BomUploadRequest;
 import org.hyades.apiserver.model.BomUploadResponse;
+import org.hyades.apiserver.model.ConfigProperty;
 import org.hyades.apiserver.model.CreateNotificationRuleRequest;
 import org.hyades.apiserver.model.CreateTeamRequest;
 import org.hyades.apiserver.model.CreateVulnerabilityRequest;
@@ -107,5 +108,11 @@ public interface ApiServerClient {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     NotificationRule updateNotificationRule(final UpdateNotificationRuleRequest request);
+
+    @POST
+    @Path("/configProperty")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    ConfigProperty updateConfigProperty(final ConfigProperty configProperty);
 
 }

--- a/e2e/src/main/java/org/hyades/apiserver/ApiServerClientHeaderFactory.java
+++ b/e2e/src/main/java/org/hyades/apiserver/ApiServerClientHeaderFactory.java
@@ -17,7 +17,7 @@ public class ApiServerClientHeaderFactory implements ClientHeadersFactory {
         if (apiKey != null) {
             headers.putSingle("X-Api-Key", apiKey);
         } else if (bearerToken != null) {
-            headers.putSingle("Authorization ", "Bearer " + bearerToken);
+            headers.putSingle("Authorization", "Bearer " + bearerToken);
         }
         return headers;
     }

--- a/e2e/src/main/java/org/hyades/apiserver/ApiServerClientHeaderFactory.java
+++ b/e2e/src/main/java/org/hyades/apiserver/ApiServerClientHeaderFactory.java
@@ -7,8 +7,8 @@ import javax.ws.rs.core.MultivaluedMap;
 
 public class ApiServerClientHeaderFactory implements ClientHeadersFactory {
 
-    public static String bearerToken;
-    public static String apiKey;
+    private static String bearerToken;
+    private static String apiKey;
 
     @Override
     public MultivaluedMap<String, String> update(final MultivaluedMap<String, String> incomingHeaders,
@@ -22,9 +22,17 @@ public class ApiServerClientHeaderFactory implements ClientHeadersFactory {
         return headers;
     }
 
+    public static void setBearerToken(final String bearerToken) {
+        ApiServerClientHeaderFactory.bearerToken = bearerToken;
+    }
+
+    public static void setApiKey(final String apiKey) {
+        ApiServerClientHeaderFactory.apiKey = apiKey;
+    }
+
     public static void reset() {
-        bearerToken = null;
-        apiKey = null;
+        ApiServerClientHeaderFactory.bearerToken = null;
+        ApiServerClientHeaderFactory.apiKey = null;
     }
 
 }

--- a/e2e/src/main/java/org/hyades/apiserver/ApiServerClientHeaderFactory.java
+++ b/e2e/src/main/java/org/hyades/apiserver/ApiServerClientHeaderFactory.java
@@ -1,0 +1,30 @@
+package org.hyades.apiserver;
+
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+public class ApiServerClientHeaderFactory implements ClientHeadersFactory {
+
+    public static String bearerToken;
+    public static String apiKey;
+
+    @Override
+    public MultivaluedMap<String, String> update(final MultivaluedMap<String, String> incomingHeaders,
+                                                 final MultivaluedMap<String, String> clientOutgoingHeaders) {
+        final var headers = new MultivaluedHashMap<String, String>();
+        if (apiKey != null) {
+            headers.putSingle("X-Api-Key", apiKey);
+        } else if (bearerToken != null) {
+            headers.putSingle("Authorization ", "Bearer " + bearerToken);
+        }
+        return headers;
+    }
+
+    public static void reset() {
+        bearerToken = null;
+        apiKey = null;
+    }
+
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/ApiKey.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/ApiKey.java
@@ -1,0 +1,7 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ApiKey(String key) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/BomProcessingResponse.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/BomProcessingResponse.java
@@ -1,0 +1,7 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BomProcessingResponse(Boolean processing) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/BomUploadRequest.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/BomUploadRequest.java
@@ -1,0 +1,4 @@
+package org.hyades.apiserver.model;
+
+public record BomUploadRequest(String projectName, String projectVersion, Boolean autoCreate, String bom) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/BomUploadResponse.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/BomUploadResponse.java
@@ -1,0 +1,7 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BomUploadResponse(String token) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/ConfigProperty.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/ConfigProperty.java
@@ -1,0 +1,7 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ConfigProperty(String groupName, String propertyName, String propertyValue) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/CreateNotificationRuleRequest.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/CreateNotificationRuleRequest.java
@@ -1,0 +1,10 @@
+package org.hyades.apiserver.model;
+
+import java.util.UUID;
+
+public record CreateNotificationRuleRequest(String name, String scope, String notificationLevel, Publisher publisher) {
+
+    public record Publisher(UUID uuid) {
+    }
+
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/CreateTeamRequest.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/CreateTeamRequest.java
@@ -1,0 +1,4 @@
+package org.hyades.apiserver.model;
+
+public record CreateTeamRequest(String name) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/CreateVulnerabilityRequest.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/CreateVulnerabilityRequest.java
@@ -1,0 +1,10 @@
+package org.hyades.apiserver.model;
+
+import java.util.List;
+
+public record CreateVulnerabilityRequest(String vulnId, List<AffectedComponent> affectedComponents) {
+
+    public record AffectedComponent(String identityType, String identity, String versionType) {
+    }
+
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/Finding.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/Finding.java
@@ -1,0 +1,22 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Finding(Component component, Project project, Vulnerability vulnerability) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Component(UUID uuid, String name, String version) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Project(UUID uuid, String name, String version) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Vulnerability(UUID uuid, String vulnId, String source) {
+    }
+
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/NotificationPublisher.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/NotificationPublisher.java
@@ -1,0 +1,9 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NotificationPublisher(UUID uuid, String name) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/NotificationRule.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/NotificationRule.java
@@ -1,0 +1,9 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NotificationRule(UUID uuid, String name, boolean enabled) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/Project.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/Project.java
@@ -1,0 +1,9 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Project(UUID uuid, String name, String version) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/Team.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/Team.java
@@ -1,0 +1,10 @@
+package org.hyades.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Team(UUID uuid, String name, List<ApiKey> apiKeys) {
+}

--- a/e2e/src/main/java/org/hyades/apiserver/model/UpdateNotificationRuleRequest.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/UpdateNotificationRuleRequest.java
@@ -1,0 +1,8 @@
+package org.hyades.apiserver.model;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record UpdateNotificationRuleRequest(UUID uuid, String name, boolean enabled, String notificationLevel,
+                                            Set<String> notifyOn, String publisherConfig) {
+}

--- a/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
@@ -80,7 +80,8 @@ public class AbstractE2ET {
     private GenericContainer<?> createRedpandaContainer() {
         return new GenericContainer<>(DockerImageName.parse(REDPANDA_IMAGE))
                 .withCommand(
-                        "redpanda", "start", "--mode", "dev-container",
+                        "redpanda", "start", "--smp", "1", "--mode", "dev-container",
+                        "--reserve-memory", "0M", "--memory", "512M", "--overprovisioned",
                         "--kafka-addr", "PLAINTEXT://0.0.0.0:29092",
                         "--advertise-kafka-addr", "PLAINTEXT://redpanda:29092"
                 )
@@ -106,6 +107,7 @@ public class AbstractE2ET {
         return new GenericContainer<>(DockerImageName.parse(API_SERVER_IMAGE))
                 .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("EXTRA_JAVA_OPTIONS", "-Xmx2g")
+                .withEnv("SYSTEM_REQUIREMENT_CHECK_ENABLED", "false")
                 .withEnv("ALPINE_DATABASE_MODE", "external")
                 .withEnv("ALPINE_DATABASE_URL", "jdbc:postgresql://postgres:5432/dtrack")
                 .withEnv("ALPINE_DATABASE_DRIVER", "org.postgresql.Driver")

--- a/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import static org.testcontainers.lifecycle.Startables.deepStart;
 
-public class AbstractE2eTest {
+public class AbstractE2ET {
 
     protected static String POSTGRES_IMAGE = "postgres:15-alpine";
     protected static String REDPANDA_IMAGE = "docker.redpanda.com/vectorized/redpanda:v23.1.2";

--- a/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
@@ -29,9 +29,9 @@ public class AbstractE2ET {
     protected static String POSTGRES_IMAGE = "postgres:15-alpine";
     protected static String REDPANDA_IMAGE = "docker.redpanda.com/vectorized/redpanda:v23.1.2";
     protected static String API_SERVER_IMAGE = "ghcr.io/dependencytrack/hyades-apiserver:snapshot";
-    protected static String NOTIFICATION_PUBLISHER_IMAGE = "ghcr.io/dependencytrack/hyades-notification-publisher:latest-native";
-    protected static String REPO_META_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-repository-meta-analyzer:latest-native";
-    protected static String VULN_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-vulnerability-analyzer:latest-native";
+    protected static String NOTIFICATION_PUBLISHER_IMAGE = "ghcr.io/dependencytrack/hyades-notification-publisher:latest";
+    protected static String REPO_META_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-repository-meta-analyzer:latest";
+    protected static String VULN_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-vulnerability-analyzer:latest";
 
     protected Logger logger;
     private Network internalNetwork;
@@ -105,6 +105,7 @@ public class AbstractE2ET {
     private GenericContainer<?> createApiServerContainer() {
         return new GenericContainer<>(DockerImageName.parse(API_SERVER_IMAGE))
                 .withImagePullPolicy(PullPolicy.alwaysPull())
+                .withEnv("EXTRA_JAVA_OPTIONS", "-Xmx2g")
                 .withEnv("ALPINE_DATABASE_MODE", "external")
                 .withEnv("ALPINE_DATABASE_URL", "jdbc:postgresql://postgres:5432/dtrack")
                 .withEnv("ALPINE_DATABASE_DRIVER", "org.postgresql.Driver")
@@ -159,7 +160,7 @@ public class AbstractE2ET {
     @SuppressWarnings("resource")
     private GenericContainer<?> createVulnAnalyzerContainer() {
         final var container = new GenericContainer<>(DockerImageName.parse(VULN_ANALYZER_IMAGE))
-                // .withImagePullPolicy(PullPolicy.alwaysPull())
+                .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS", "redpanda:29092")
                 .withEnv("QUARKUS_DATASOURCE_JDBC_URL", "jdbc:postgresql://postgres:5432/dtrack")
                 .withEnv("QUARKUS_DATASOURCE_USERNAME", "dtrack")

--- a/e2e/src/test/java/org/hyades/e2e/AbstractE2eTest.java
+++ b/e2e/src/test/java/org/hyades/e2e/AbstractE2eTest.java
@@ -1,0 +1,197 @@
+package org.hyades.e2e;
+
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.hyades.apiserver.ApiServerClient;
+import org.hyades.apiserver.ApiServerClientHeaderFactory;
+import org.hyades.apiserver.model.CreateTeamRequest;
+import org.hyades.apiserver.model.Team;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.URI;
+import java.util.Set;
+
+import static org.testcontainers.lifecycle.Startables.deepStart;
+
+public class AbstractE2eTest {
+
+    protected Logger logger;
+    private Network internalNetwork;
+    protected PostgreSQLContainer<?> postgresContainer;
+    protected GenericContainer<?> redpandaContainer;
+    protected GenericContainer<?> apiServerContainer;
+    protected GenericContainer<?> repoMetaAnalyzerContainer;
+    protected GenericContainer<?> vulnAnalyzerContainer;
+    protected ApiServerClient apiServerClient;
+
+    @BeforeEach
+    void beforeEach() {
+        logger = LoggerFactory.getLogger(getClass());
+
+        internalNetwork = Network.newNetwork();
+
+        postgresContainer = createPostgresContainer();
+        redpandaContainer = createRedpandaContainer();
+        deepStart(postgresContainer, redpandaContainer).join();
+
+        initializeRedpanda();
+
+        apiServerContainer = createApiServerContainer();
+        apiServerContainer.start();
+
+        repoMetaAnalyzerContainer = createRepoMetaAnalyzerContainer();
+        vulnAnalyzerContainer = createVulnAnalyzerContainer();
+        deepStart(repoMetaAnalyzerContainer, vulnAnalyzerContainer);
+
+        apiServerClient = initializeApiServerClient();
+    }
+
+    private PostgreSQLContainer<?> createPostgresContainer() {
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"))
+                .withDatabaseName("dtrack")
+                .withUsername("dtrack")
+                .withPassword("dtrack")
+                .withNetworkAliases("postgres")
+                .withNetwork(internalNetwork);
+    }
+
+    private GenericContainer<?> createRedpandaContainer() {
+        return new GenericContainer<>(DockerImageName.parse("docker.redpanda.com/vectorized/redpanda:v22.3.10"))
+                .withCommand(
+                        "redpanda", "start", "--mode", "dev-container",
+                        "--kafka-addr", "PLAINTEXT://0.0.0.0:29092",
+                        "--advertise-kafka-addr", "PLAINTEXT://redpanda:29092"
+                )
+                .waitingFor(Wait.forLogMessage(".*Started Kafka API server.*", 1))
+                .withNetworkAliases("redpanda")
+                .withExposedPorts(9092)
+                .withNetwork(internalNetwork);
+    }
+
+    private void initializeRedpanda() {
+        new GenericContainer<>(DockerImageName.parse("docker.redpanda.com/vectorized/redpanda:v22.3.10"))
+                .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("/bin/bash"))
+                .withCommand("/tmp/create-topics.sh")
+                .withEnv("REDPANDA_BROKERS", "redpanda:29092")
+                .withFileSystemBind("../scripts/create-topics.sh", "/tmp/create-topics.sh")
+                .waitingFor(Wait.forLogMessage(".*All topics created successfully.*", 1))
+                .withNetwork(internalNetwork)
+                .start();
+    }
+
+    private GenericContainer<?> createApiServerContainer() {
+        return new GenericContainer<>(DockerImageName.parse("ghcr.io/dependencytrack/hyades-apiserver:snapshot"))
+                .withImagePullPolicy(PullPolicy.alwaysPull())
+                .withEnv("ALPINE_DATABASE_MODE", "external")
+                .withEnv("ALPINE_DATABASE_URL", "jdbc:postgresql://postgres:5432/dtrack")
+                .withEnv("ALPINE_DATABASE_DRIVER", "org.postgresql.Driver")
+                .withEnv("ALPINE_DATABASE_USERNAME", "dtrack")
+                .withEnv("ALPINE_DATABASE_PASSWORD", "dtrack")
+                .withEnv("KAFKA_BOOTSTRAP_SERVERS", "redpanda:29092")
+                // .withLogConsumer(new Slf4jLogConsumer(logger))
+                .waitingFor(Wait.forLogMessage(".*Dependency-Track is ready.*", 1))
+                .withNetworkAliases("apiserver")
+                .withNetwork(internalNetwork)
+                .withExposedPorts(8080);
+    }
+
+    private GenericContainer<?> createRepoMetaAnalyzerContainer() {
+        return new GenericContainer<>(DockerImageName.parse("ghcr.io/dependencytrack/hyades-repository-meta-analyzer:latest-native"))
+                .withImagePullPolicy(PullPolicy.alwaysPull())
+                .withEnv("QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS", "redpanda:29092")
+                .withEnv("QUARKUS_DATASOURCE_JDBC_URL", "jdbc:postgresql://postgres:5432/dtrack")
+                .withEnv("QUARKUS_DATASOURCE_USERNAME", "dtrack")
+                .withEnv("QUARKUS_DATASOURCE_PASSWORD", "dtrack")
+                // .withLogConsumer(new Slf4jLogConsumer(logger))
+                .withNetworkAliases("repo-meta-analyzer")
+                .withNetwork(internalNetwork)
+                .withStartupAttempts(3);
+    }
+
+    private GenericContainer<?> createVulnAnalyzerContainer() {
+        final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("ghcr.io/dependencytrack/hyades-vulnerability-analyzer:latest-native"))
+                .withImagePullPolicy(PullPolicy.alwaysPull())
+                .withEnv("QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS", "redpanda:29092")
+                .withEnv("QUARKUS_DATASOURCE_JDBC_URL", "jdbc:postgresql://postgres:5432/dtrack")
+                .withEnv("QUARKUS_DATASOURCE_USERNAME", "dtrack")
+                .withEnv("QUARKUS_DATASOURCE_PASSWORD", "dtrack")
+                // .withLogConsumer(new Slf4jLogConsumer(logger))
+                .withNetworkAliases("vuln-analyzer")
+                .withNetwork(internalNetwork)
+                .withStartupAttempts(3);
+        customizeVulnAnalyzerContainer(container);
+        return container;
+    }
+
+    protected void customizeVulnAnalyzerContainer(final GenericContainer<?> container) {
+    }
+
+    private ApiServerClient initializeApiServerClient() {
+        final ApiServerClient client = RestClientBuilder.newBuilder()
+                .baseUri(URI.create("http://localhost:%d".formatted(apiServerContainer.getFirstMappedPort())))
+                .register(new JacksonJsonProvider(), 1)
+                // .proxyAddress("localhost", 8083)
+                .build(ApiServerClient.class);
+
+        logger.info("Changing API server admin password");
+        client.forcePasswordChange("admin", "admin", "admin123", "admin123");
+
+        logger.info("Authenticating as admin");
+        ApiServerClientHeaderFactory.bearerToken = client.login("admin", "admin123");
+
+        logger.info("Creating e2e team");
+        final Team team = client.createTeam(new CreateTeamRequest("e2e"));
+
+        logger.info("Assigning permissions to e2e team");
+        for (final String permission : Set.of(
+                "VIEW_PORTFOLIO",
+                "VIEW_VULNERABILITY",
+                "BOM_UPLOAD",
+                "PROJECT_CREATION_UPLOAD",
+                "PORTFOLIO_MANAGEMENT",
+                "VULNERABILITY_MANAGEMENT"
+        )) {
+            client.addPermissionToTeam(team.uuid(), permission);
+        }
+
+        ApiServerClientHeaderFactory.apiKey = team.apiKeys().get(0).key();
+
+        return client;
+    }
+
+    @AfterEach
+    void afterEach() {
+        ApiServerClientHeaderFactory.reset();
+
+        if (postgresContainer != null) {
+            postgresContainer.stop();
+        }
+
+        if (redpandaContainer != null) {
+            redpandaContainer.stop();
+        }
+
+        if (apiServerContainer != null) {
+            apiServerContainer.stop();
+        }
+
+        if (repoMetaAnalyzerContainer != null) {
+            repoMetaAnalyzerContainer.close();
+        }
+
+        if (vulnAnalyzerContainer != null) {
+            vulnAnalyzerContainer.stop();
+        }
+    }
+
+
+}

--- a/e2e/src/test/java/org/hyades/e2e/AbstractE2eTest.java
+++ b/e2e/src/test/java/org/hyades/e2e/AbstractE2eTest.java
@@ -14,7 +14,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
 
 import java.net.URI;
@@ -104,7 +103,7 @@ public class AbstractE2eTest {
     @SuppressWarnings("resource")
     private GenericContainer<?> createApiServerContainer() {
         return new GenericContainer<>(DockerImageName.parse(API_SERVER_IMAGE))
-                .withImagePullPolicy(PullPolicy.alwaysPull())
+                // .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("ALPINE_DATABASE_MODE", "external")
                 .withEnv("ALPINE_DATABASE_URL", "jdbc:postgresql://postgres:5432/dtrack")
                 .withEnv("ALPINE_DATABASE_DRIVER", "org.postgresql.Driver")
@@ -121,7 +120,7 @@ public class AbstractE2eTest {
     @SuppressWarnings("resource")
     private GenericContainer<?> createNotificationPublisherContainer() {
         final var container = new GenericContainer<>(DockerImageName.parse(NOTIFICATION_PUBLISHER_IMAGE))
-                .withImagePullPolicy(PullPolicy.alwaysPull())
+                // .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS", "redpanda:29092")
                 .withEnv("QUARKUS_DATASOURCE_JDBC_URL", "jdbc:postgresql://postgres:5432/dtrack")
                 .withEnv("QUARKUS_DATASOURCE_USERNAME", "dtrack")
@@ -140,7 +139,7 @@ public class AbstractE2eTest {
     @SuppressWarnings("resource")
     private GenericContainer<?> createRepoMetaAnalyzerContainer() {
         final var container = new GenericContainer<>(DockerImageName.parse(REPO_META_ANALYZER_IMAGE))
-                .withImagePullPolicy(PullPolicy.alwaysPull())
+                // .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS", "redpanda:29092")
                 .withEnv("QUARKUS_DATASOURCE_JDBC_URL", "jdbc:postgresql://postgres:5432/dtrack")
                 .withEnv("QUARKUS_DATASOURCE_USERNAME", "dtrack")
@@ -159,7 +158,7 @@ public class AbstractE2eTest {
     @SuppressWarnings("resource")
     private GenericContainer<?> createVulnAnalyzerContainer() {
         final var container = new GenericContainer<>(DockerImageName.parse(VULN_ANALYZER_IMAGE))
-                .withImagePullPolicy(PullPolicy.alwaysPull())
+                // .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS", "redpanda:29092")
                 .withEnv("QUARKUS_DATASOURCE_JDBC_URL", "jdbc:postgresql://postgres:5432/dtrack")
                 .withEnv("QUARKUS_DATASOURCE_USERNAME", "dtrack")

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
@@ -199,7 +199,7 @@ public class BomUploadProcessingE2ET extends AbstractE2ET {
                               },
                               "vulnerability": {
                                 "uuid": "${json-unit.any-string}",
-                                "id": "INT-123",
+                                "vulnId": "INT-123",
                                 "source": "INTERNAL",
                                 "severity": "UNASSIGNED"
                               },
@@ -210,7 +210,7 @@ public class BomUploadProcessingE2ET extends AbstractE2ET {
                                   "version": "bar"
                                 }
                               ],
-                              "analysisLevel": "VULNERABILITY_ANALYSIS_LEVEL_BOM_UPLOAD"
+                              "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS"
                             }
                           }
                         }

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @WireMockTest
-public class BomUploadProcessingTest extends AbstractE2eTest {
+public class BomUploadProcessingE2ET extends AbstractE2ET {
 
     @RegisterExtension
     static GreenMailExtension greenMail = new GreenMailExtension(ServerSetup.SMTP.dynamicPort());

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingTest.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingTest.java
@@ -1,21 +1,36 @@
 package org.hyades.e2e;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.hyades.apiserver.model.BomProcessingResponse;
 import org.hyades.apiserver.model.BomUploadRequest;
 import org.hyades.apiserver.model.BomUploadResponse;
+import org.hyades.apiserver.model.CreateNotificationRuleRequest;
+import org.hyades.apiserver.model.CreateNotificationRuleRequest.Publisher;
 import org.hyades.apiserver.model.CreateVulnerabilityRequest;
 import org.hyades.apiserver.model.CreateVulnerabilityRequest.AffectedComponent;
 import org.hyades.apiserver.model.Finding;
+import org.hyades.apiserver.model.NotificationPublisher;
+import org.hyades.apiserver.model.NotificationRule;
 import org.hyades.apiserver.model.Project;
+import org.hyades.apiserver.model.UpdateNotificationRuleRequest;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
 
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
+import java.util.Set;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
+@WireMockTest
 public class BomUploadProcessingTest extends AbstractE2eTest {
 
     @Override
@@ -28,31 +43,49 @@ public class BomUploadProcessingTest extends AbstractE2eTest {
     }
 
     @Test
-    void test() throws Exception {
+    void test(final WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        // Find the webhook notification publisher.
+        final NotificationPublisher webhookPublisher = apiServerClient.getAllNotificationPublishers().stream()
+                .filter(publisher -> publisher.name().equals("Outbound Webhook"))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("Unable to find webhook notification publisher"));
+
+        // Create a webhook alert for NEW_VULNERABILITY notifications and point it to WireMock.
+        final NotificationRule rule = apiServerClient.createNotificationRule(new CreateNotificationRuleRequest(
+                "foo", "PORTFOLIO", "INFORMATIONAL", new Publisher(webhookPublisher.uuid())));
+        apiServerClient.updateNotificationRule(new UpdateNotificationRuleRequest(rule.uuid(), rule.name(), true,
+                "INFORMATIONAL", Set.of("NEW_VULNERABILITY"), """
+                {
+                  "destination": "http://host.docker.internal:%d/notification"
+                }
+                """.formatted(wireMockRuntimeInfo.getHttpPort())));
+
+        // Create a new internal vulnerability for jackson-databind.
         apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-123", List.of(
                 new AffectedComponent("PURL", "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.2", "EXACT")
         )));
 
+        // Parse and base64 encode a BOM.
         final byte[] bomBytes = IOUtils.resourceToByteArray("/dtrack-apiserver-4.5.0.bom.json");
         final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
 
+        // Upload the BOM
         final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
         assertThat(response.token()).isNotEmpty();
 
-        boolean completed = false;
-        for (int i = 0; i < 15; i++) {
-            final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
-            if (Boolean.FALSE.equals(processingResponse.processing())) {
-                completed = true;
-                break;
-            }
+        // Wait up to 15sec for the BOM processing to complete.
+        await("BOM processing")
+                .atMost(Duration.ofSeconds(15))
+                .pollDelay(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    assertThat(processingResponse.processing()).isFalse();
+                });
 
-            Thread.sleep(1000);
-        }
-
-        assertThat(completed).isTrue();
-
+        // Lookup the project we just created.
         final Project project = apiServerClient.lookupProject("foo", "bar");
+
+        // Ensure the internal vulnerability has been flagged.
         final List<Finding> findings = apiServerClient.getFindings(project.uuid());
         assertThat(findings).satisfiesExactly(
                 finding -> {
@@ -61,7 +94,59 @@ public class BomUploadProcessingTest extends AbstractE2eTest {
                     assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-123");
                 }
         );
+
+        // Verify that we received the alert about jackson-databind being vulnerable.
+        await("NEW_VULNERABILITY notification")
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(this::verifyNotification);
     }
 
+    private void verifyNotification() {
+        verify(postRequestedFor(urlPathEqualTo("/notification"))
+                .withRequestBody(equalToJson("""
+                        {
+                          "notification": {
+                            "level": "INFORMATIONAL",
+                            "scope": "PORTFOLIO",
+                            "group": "NEW_VULNERABILITY",
+                            "timestamp": "${json-unit.any-string}",
+                            "title": "${json-unit.any-string}",
+                            "content": "${json-unit.any-string}",
+                            "subject": {
+                              "component": {
+                                "uuid": "${json-unit.any-string}",
+                                "group": "com.fasterxml.jackson.core",
+                                "name": "jackson-databind",
+                                "version": "2.13.2.2",
+                                "purl": "${json-unit.any-string}",
+                                "md5": "${json-unit.any-string}",
+                                "sha1": "${json-unit.any-string}",
+                                "sha256": "${json-unit.any-string}",
+                                "sha512": "${json-unit.any-string}"
+                              },
+                              "project": {
+                                "uuid": "${json-unit.any-string}",
+                                "name": "foo",
+                                "version": "bar"
+                              },
+                              "vulnerability": {
+                                "uuid": "${json-unit.any-string}",
+                                "id": "INT-123",
+                                "source": "INTERNAL"
+                              },
+                              "affectedProjects": [
+                                {
+                                  "uuid": "${json-unit.any-string}",
+                                  "name": "foo",
+                                  "version": "bar"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                        """)
+                )
+        );
+    }
 
 }

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingTest.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingTest.java
@@ -1,0 +1,67 @@
+package org.hyades.e2e;
+
+import org.hyades.apiserver.model.BomProcessingResponse;
+import org.hyades.apiserver.model.BomUploadRequest;
+import org.hyades.apiserver.model.BomUploadResponse;
+import org.hyades.apiserver.model.CreateVulnerabilityRequest;
+import org.hyades.apiserver.model.CreateVulnerabilityRequest.AffectedComponent;
+import org.hyades.apiserver.model.Finding;
+import org.hyades.apiserver.model.Project;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BomUploadProcessingTest extends AbstractE2eTest {
+
+    @Override
+    protected void customizeVulnAnalyzerContainer(final GenericContainer<?> container) {
+        // Disable all scanners except the internal one.
+        container
+                .withEnv("SCANNER_INTERNAL_ENABLED", "true")
+                .withEnv("SCANNER_OSSINDEX_ENABLED", "false")
+                .withEnv("SCANNER_SNYK_ENABLED", "false");
+    }
+
+    @Test
+    void test() throws Exception {
+        apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-123", List.of(
+                new AffectedComponent("PURL", "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.2", "EXACT")
+        )));
+
+        final byte[] bomBytes = IOUtils.resourceToByteArray("/dtrack-apiserver-4.5.0.bom.json");
+        final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
+
+        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        assertThat(response.token()).isNotEmpty();
+
+        boolean completed = false;
+        for (int i = 0; i < 15; i++) {
+            final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+            if (Boolean.FALSE.equals(processingResponse.processing())) {
+                completed = true;
+                break;
+            }
+
+            Thread.sleep(1000);
+        }
+
+        assertThat(completed).isTrue();
+
+        final Project project = apiServerClient.lookupProject("foo", "bar");
+        final List<Finding> findings = apiServerClient.getFindings(project.uuid());
+        assertThat(findings).satisfiesExactly(
+                finding -> {
+                    assertThat(finding.component().name()).isEqualTo("jackson-databind");
+                    assertThat(finding.project().name()).isEqualTo("foo");
+                    assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-123");
+                }
+        );
+    }
+
+
+}

--- a/e2e/src/test/resources/dtrack-apiserver-4.5.0.bom.json
+++ b/e2e/src/test/resources/dtrack-apiserver-4.5.0.bom.json
@@ -1,0 +1,10194 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "serialNumber" : "urn:uuid:f400d0d1-3373-48e2-8dbe-2c67db867d7b",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2022-05-18T05:59:36Z",
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.6.2",
+        "hashes" : [
+          {
+            "alg" : "MD5",
+            "content" : "ff29fc50797fce0b33058a6b2b283f64"
+          },
+          {
+            "alg" : "SHA-1",
+            "content" : "597e59ebf21c3b8bfb1faeb622569df324eca956"
+          },
+          {
+            "alg" : "SHA-256",
+            "content" : "3cf9130fcac45a7beb6df2ae9c3fc9c062d1fddd0731d6a302968586f0aa586e"
+          },
+          {
+            "alg" : "SHA-384",
+            "content" : "8111a6788c959305af23daecbc79defd4478c1e274cba65bfe860e09b30cd9fe29822d5d3d3eea608e4926a9418f92e3"
+          },
+          {
+            "alg" : "SHA-512",
+            "content" : "2bea87b7bcd70897bf46a28a806b6064a6708d0a45e884e1ceddc25f97ca7bdf4ed190f30d9a28cc9416b6c66176d518c5876fd25bc06bdcb00d39367215e56e"
+          },
+          {
+            "alg" : "SHA3-256",
+            "content" : "f0f7b771749955e7898665c2fff8f4f2cd734d9cbe4d29883292db772f1be00e"
+          },
+          {
+            "alg" : "SHA3-384",
+            "content" : "a87d4c18bac4d48a46c0b8611ab92934e457fcd55bd4d39dbc9c4e5044d2736d3bda991c43d67b0987eddcf4c88510ff"
+          },
+          {
+            "alg" : "SHA3-512",
+            "content" : "90c38f168600787fc90b7e37e743b386b7296bceb10152190de6e30e0f251da3e01698d1b1e11ad84f207532b5a0743aac105f3c5006ff4607d21f30c9ea779f"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "publisher" : "OWASP",
+      "group" : "org.dependencytrack",
+      "name" : "dependency-track",
+      "version" : "4.5.0",
+      "description" : "Dependency-Track is an intelligent component analysis platform that allows organizations to identify and reduce risk in the software supply chain.",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/DependencyTrack/dependency-track/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/DependencyTrack/dependency-track/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/DependencyTrack/dependency-track.git"
+        }
+      ],
+      "type" : "application",
+      "bom-ref" : "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war"
+    }
+  },
+  "components" : [
+    {
+      "group" : "us.springett",
+      "name" : "alpine-common",
+      "version" : "2.0.0",
+      "description" : "An opinionated scaffolding library that jumpstarts Java projects with an API-first design, secure defaults, and minimal dependencies.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9a90508ff2cd192becb2d55c7ff1b7c9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7d386b11ca0c46e0e3d9af24e4d08f559ee25b9e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "19baa8e25b560dd836088babaae4aac4f9f94f87974089c009a4da3d851a17c1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "eb1f188081b75d9d215c8a1356f5b2a0c4675189859e57c7589391a5ef02b2f1565bd3333e12d3c26134888e145e756f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c1ee44a566d35f5728eee9c91e20de2c5f8bfcc0270823d095b13eb0387821ac538b5f811f7d277caca63ac435c2f6b22976a1aa7adf02a9efd6af8168547958"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6f126c8aa16a2a3e24a6abd7b1a16d4ac4acffa14a6f1f6a5b850321701390bf"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8e34112868470fd4bee890491a6357a697b91e9ee39f80a53e6411f1758147f1442b31e8f9073878dd190ca0efe38dfe"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b26b0acfbf214bdc8dc6a193a9f2fb9a0a45533935635a839969fd55f45d7df05d43abb13ae6b4cc517b2ceea6cda18b766950ffd9aba7f928552a07c180f038"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/us.springett/alpine-common@2.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/stevespringett/Alpine/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/stevespringett/Alpine/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/stevespringett/Alpine.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/us.springett/alpine-common@2.0.0?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-api",
+      "version" : "1.7.36",
+      "description" : "The slf4j API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "872da51f5de7f3923da4de871d57fd85"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6c62681a2f655b49963a5983b8b0950a6120ae14"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2b14ad035877087157e379d3277dcdcd79e58d6bdb147c47d29e377d75ce53ad42cafbf22f5fb7827c7e946ff4876b9a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f9b033fc019a44f98b16048da7e2b59edd4a6a527ba60e358f65ab88e0afae03a9340f1b3e8a543d49fa542290f499c5594259affa1ff3e6e7bf3b428d4c610b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ba2608179fcf46e2291a90b9cbb4aa30d718e481f59c350cc21c73b88d826881"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3bc3110dafb8d5be16a39f3b2671a466463cd99eb39610c0e4719a7bf2d928f2ea213c734887c6926a07c4cca7769e4b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "14c4edcd19702ef607d78826839d8a6d3a39157df54b89a801d3d3cbbe1307131a77671b041c761122730fb1387888c5ec2e46bdd80e1cb07f8f144676441824"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.qos.ch"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.12.0",
+      "description" : "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "19fe50567358922bdad277959ea69545"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c6842c86792ff03b9f1d1fe2aab8dc23aa6c6f0e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c34b8a0e0eba2168ad56fedeb7a1d710b6f1d3f1ce6aae99a4e0247bd120efbbadc8dcb2f731045b8a16e3efd30604dc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fbdbc0943cb3498b0148e86a39b773f97c8e6013740f72dbc727faeabea402073e2cc8c4d68198e5fc6b08a13b7700236292e99d4785f2c9989f2e5fac11fd81"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "18ef639b2aeeb5aedffb18dbf20c79f33e300d99fb31b131689639cc470e6e4c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8ad6ebe7754bf0caa8cda7e59c0e95360d76e06a7ad6aeec5637985519dbd1dd06e7eed04711039f36ec4c49de280def"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fbea96114dcf4f31cfaaa99987be756ddda3a6c74f8c835461997df794d54b92da1f60fe5c3f1f2a43cb8c5f5db7f4048bef77c70993673c7a93f3660fffc8da"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LANG"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-lang.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-annotations",
+      "version" : "2.13.2",
+      "description" : "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2352a291fc39d23cfe5c100728de1ea7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ec18851f1976d5b810ae1a5fcc32520d2d38f77a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7d3df5aafa2dc61ad1dbad30f411548c0184ed92d94628c63168721f08237cd4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "10a9917d2331845b923f43e723ccd8ad75dd54b03afad1225b06fb04f0670b65857d49f4fef5ff58b5b74eea224f3ae5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8da374687872fe37a0948e6f1b506ae7ad05c75006105c944182b3db8ce676f32794517953eb28beeba100e1ad8a059fd00164b43a19b026d3bf1b9743b5968b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "88086fb723bdd8630b0798c1068c192da2f3edd470240e2cb7a81fa42c9e4c82"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "811a4d45d3ed98e9d0186c7c1b8fc5d47b35ff7b4276ed35816dbd8ed0bec8bbba6614b72e99157f1ace4b89478e1644"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b1367a2b6a297fec04eff93808ddb34bc375d044c30c5165c3d55f28660e3b3086c0467ff4160343f62ce6f6bbaf4c90e4656ca72f14df72d03a8bd116931894"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-annotations"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2?type=jar"
+    },
+    {
+      "group" : "us.springett",
+      "name" : "alpine-model",
+      "version" : "2.0.0",
+      "description" : "An opinionated scaffolding library that jumpstarts Java projects with an API-first design, secure defaults, and minimal dependencies.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "764c3bb5de8775cf24a40d42ea0a545f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bca078ae852b08c46c7e77c2dfa39a145d880647"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4ee4423ad91b2fda625b779e6527e67dece87b9b08a6478b4bb48f65c6990327"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b3b2916b48747b3db9cf457ea364fe02511e6a53f1277571097655df843f7ffb2a0ef5683185e077fb18ad50e11366ad"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d4d419e67a235e8d16d6f85e944678d90c2a3fd7f5db26a34336c6ccd460dab0e76ddc009e421305491325c36f9920b0e1814c7d0f324881f4855c72952bfbd1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6fca87cc028f00c6967b324679c85601fa052ddc18667849392c056ccfca115d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5f819d5bd1d0cc579689fa36b21d97d0431e4bb0f8d52ba026d88814140aad04cc60cb94e9b4b58c46e4fc6ed1b420c4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "afee79f005c8ddc244f91ce3ef446daa0ac8a5bf28c3787ca9a6107f5241d14d59cd8c77cad65ae653ae0c33f9264194e94761f576536a0a9ee62c4f176c1060"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/us.springett/alpine-model@2.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/stevespringett/Alpine/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/stevespringett/Alpine/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/stevespringett/Alpine.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/us.springett/alpine-model@2.0.0?type=jar"
+    },
+    {
+      "group" : "org.datanucleus",
+      "name" : "datanucleus-api-jdo",
+      "version" : "5.2.7",
+      "description" : "Plugin providing DataNucleus implementation of the JDO API.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5fa82ecc876a68f3b04cfd94b825fd1b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9e4d99b1fed299c0f6325e50453172684e5834f5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a3caf977013bd9093e56cebe7fa6ff64989d33b61b650958ce714c90b5009e66"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c8a0af7c0b72f9b5c717a8238d186c700bdfe3c840eac2238dce6818bd8b58f5caf51bea691b8ad2bfe1d22f3609c538"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6827d977d47202bba95d5d9da54147d89647cc58c9afd634779ac7839525a7e508f3caf31a9bc0097be737f561f63a56ab4242d07dc9becfc2842fc85847161e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "eb43efccba75a478e9411aadee791972db6b0b2a42b751bd19dd1308c9c55f01"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a956dd9944b2bf285d80a8a2dcb954effaa37b137144f42cacddd251f5aab6c0548c583d711dfbdd46c56068a48d5496"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1608ef2d8f00cfc4a478b1d142ac44b36f124fe239a889db6495ff0d8eab6739f04fcaabeed1971f52e6b23c9c180f4eba657075f8345be6824a81ec59287d3b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.datanucleus/datanucleus-api-jdo@5.2.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/datanucleus/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.datanucleus/datanucleus-api-jdo@5.2.7?type=jar"
+    },
+    {
+      "group" : "org.datanucleus",
+      "name" : "datanucleus-core",
+      "version" : "5.2.7",
+      "description" : "DataNucleus Core provides the primary components of a heterogenous Java persistence solution. It supports persistence API's being layered on top of the core functionality.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "394aa0256ae4e5f8f227d7d4b373410b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a326c9fd5a0ce34e75ba954db7d418a7fc801e39"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4471cbb8d2915658f12cc05bc5b582a37f461cb18cb97ef55df7a81f3864f470"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7b87c2e63c57c5953041741839b8fd71a498999f16e09c5f6ddadb8e88237d0a7a0643418b02dc956a1c65c193fd620e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3c9b02b84e1a694ebf53842f8ba0a9050d06a8ec1e67b20e8d72f4c5c5630c37ca6c1c099382cdb55e264e71a93b8856dc8d87261e5d2ca7b3f1533e7f866db5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c427de23cc3fedd5286d3672dae08be81ac05400ad6d4ba918a8432bafa77fd0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3048e5fda59f24e1526768cc221f0171bb0e7f766d52ebdba86b6bd89a67b343494e76487654ce612ca1bacd713aab3c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b7920e3aa5c12ab9eb944c669143c7221c0b4e4fc71bf67f2837b5e7d697349e89cd872553c714367124d77256393fb995336a1f5d7c4037c685f4731c70e7da"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.datanucleus/datanucleus-core@5.2.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/datanucleus/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.datanucleus/datanucleus-core@5.2.7?type=jar"
+    },
+    {
+      "group" : "org.datanucleus",
+      "name" : "javax.jdo",
+      "version" : "3.2.0-release",
+      "description" : "The Java Data Objects API (JDO) : a standard interface-based Java model abstraction of persistence, developed by the JCP.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cb3230dd12d1ac95e347b5ddc7ba17f0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "729519f7ef20217cbbe47efd3f032a74686d14c0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "408c8cf0800e2ee29722fbca2b776bf233b96ec3e816f7cd5845eba6d680fbf1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d6a67d52875f174bda6bc71eb99127247a8ecef32617ab85d240d3ed316301eeac2178e251793c694c472fd46c6e9fad"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a38ba29ca5481435eb8345424ceff2dcdd35436b65ab35c0ef0ea052ccad7b5a927dc9275fd796888c308cf329316960f4a440e48e389c547e5c8f57c3998a70"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "afaf6e97a2e10040f1f71cb6ba097c03a1545807d653b22e11ec3c3d9df257ad"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7e46eb10cd1f2eae03765e2d5d78169572ab4cd4be6095e5821442d8d2523ce296eaed7b4c4698221ac001563a703669"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0be20b49764fed46a85d049c6533f6669fbd080780274e874239b76d05d418561573555b5743e77e5796f4f5e278c23e855e4a6ff3bee6601c03451ae643294a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.datanucleus/javax.jdo@3.2.0-release?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/datanucleus/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.datanucleus/javax.jdo@3.2.0-release?type=jar"
+    },
+    {
+      "publisher" : "GlassFish Community",
+      "group" : "javax.transaction",
+      "name" : "javax.transaction-api",
+      "version" : "1.3",
+      "description" : "Project GlassFish Java Transaction API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6e9cb1684621821248b6823143ae26c0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e006adf5cf3cca2181d16bd640ecb80148ec0fce"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "603df5e4fc1eeae8f5e5d363a8be6c1fa47d0df1df8739a05cbcb9fafd6df2da"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7044d8d5829a777d85e1a987c3e346eb535dd321366bdf32a9e8ed4f52facd0610ac2f3f58b4a1b001893f01fddc5eae"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3497cf77352aa1317c70ad1d28e8e7da51337d844c8227a35707209c750ba6f5d644a4ffdbdb10e5fbde204003aa43ff80e9e2ff3164584a7a34d8292266b2bc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c7c48884317a2d0e1596f201763acbca4ef76462af9172fd5e68aca3465303e1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d0c1807001e02ce47320be657be055b4777b8b5673c22a78b0574955f7a6105dacc42b46b86ab967dc382cf332da59d8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bf053d4fe995cb5c1d6c01320fc73530017ee364de6ae21eb98fa0372b2aa6eff2fa4ac2d9cd5f692c930ee573c2f6226441918123fcfc48b5b4a126d350928c"
+        }
+      ],
+      "licenses" : [ ],
+      "purl" : "pkg:maven/javax.transaction/javax.transaction-api@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://glassfish.java.net"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/javaee/javax.transaction/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javaee/javax.transaction"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.java.net/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/javax.transaction/javax.transaction-api@1.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.corba",
+      "name" : "glassfish-corba-omgapi",
+      "version" : "4.2.2",
+      "description" : "A CORBA ORB for Glassfish",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b2eb806fc90b71d6d15391a1c887ae1f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6e0f5735a51bda8f72dda0e58ba766d16678c7b8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2d964250e13aa77b5e687669ef4981d44c7b92496b28e439e5fbcc5c7882e0f5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "253cd42b07fd905e5c5651a0d78d1b33cac48abfdfa8fc2592e982c4e385481ccead57d8bcbe32407f498de1e26f3558"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0e99c7e659bf2613d0436805476c5ed265afbd35648f6367bcd8227c0052b024b675f4c9eb3ec590e24c8f0b989d0392a4c53ec3cb1ce666a7ae566489841482"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "76b8b17d5659c5638709d866cb78ee75b78cbaf53beb649f4ec1b15a47c65347"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cf14029429a406ec32481ac73a7580a4e34f1216f7f85ea29cb35dba8b8ca1e20b59b81b66778ac5b16a3975fcf6f2d8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2d8b9be6f6a7149663107ade523c8e274b1f24710132ae09d09591632ceb108296f26214f9c9ce4cec40f074bf97f715284d136cb01ce886e8745b38eb5b3f48"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "https://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.corba/glassfish-corba-omgapi@4.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/orb/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/orb-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/orb"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.corba/glassfish-corba-omgapi@4.2.2?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.ext",
+      "name" : "jersey-bean-validation",
+      "version" : "2.35",
+      "description" : "Jersey extension module providing support for Bean Validation (JSR-349) API.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "051f48090ffbb69f87a18d80668c7b46"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "25db0a3afa88b8e9f2995ca21f7dff7abc70c4b0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4f9f49bdf5106b207e44bc7fdd62bbb116359ae255e81bef134a7da3882db2cd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7edbc4f8e5fc883d5ccf83173ae239aff0dfa754ad80699ff685da5732735b0649ee1f972460652b6b227543b86df87d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a638dfd348366f2bd074a2e5269f485ccc80b4a521b80ee7d8182484593ced58198e2cea04e8a33d2b7b3e875be2e2001ab55c22e7491b93ea08ac5555c95db1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cc7c1f584bf97e1449d3bbc03690ce789576cd15b89a8e2f3f466c2429350f4d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "82ad767df321d254ff9dbd6b1000768cf7fda2e45dae0cc542dee76f468dfb15c722a0d76a5057bf749951b8f7f2bd4a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "18535375816afe013e64a32488c091194cfa856bd26d10f57937ee43aa39bd74646d641df25dc954a43067b161571674a9e65b13522def4ec18654790c4b3880"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "jQuery license",
+            "url" : "jquery.org/license"
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license" : {
+            "name" : "W3C license",
+            "url" : "https://www.w3.org/Consortium/Legal/copyright-documents-19990405"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.ext/jersey-bean-validation@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.ext/jersey-bean-validation@2.35?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "org.glassfish.hk2.external",
+      "name" : "jakarta.inject",
+      "version" : "2.6.1",
+      "description" : "Injection API (JSR 330) version ${javax.inject.version} repackaged as OSGi bundle",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4d7c80a1e3cd54531af03bef4537f7af"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8096ebf722902e75fbd4f532a751e514f02e1eb7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5e88c123b3e41bca788b2683118867d9b6dec714247ea91c588aed46a36ee24f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6b3ea9eeec5cbbc1fb3e6c89160af67b82ffbd68948dd4790e3fe3ce2fc495c063698a7d6a1998d5db51abafe3915e19"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fc8196ad9ee03a831dfff85c945e416c3906071a7aa8ebf6ab8b7008dfec0adccc1f1dca53ed6768ac5676cd4b3c43471674f97ff73e1f61f5a427aaed68e05"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "67f3b5a4b3006d07a33ccdbbb70f312c94d2d8cdd32598d471b079470574ab6d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b551e00861151233789c03cec07e162d90d1f377fb8f26d413f7015152188183d636e2837ceca131096c43511e618efa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a0b6c00df7f5b53f549193a7e6a26d632847957ad296aef2ee75a23a5ebdec970f793511641e6c63677b481c47ca67f4039a5ee5f4bb532a46093a201782198d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.hk2.external/jakarta.inject@2.6.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/glassfish-hk2-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.hk2.external/jakarta.inject@2.6.1?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.core",
+      "name" : "jersey-common",
+      "version" : "2.35",
+      "description" : "Jersey core common packages",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a0b9a2cea9ecbaf2170ed0757020ed05"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2f15ec1b3a3598d6b12d4b0c6ff6f0905f5e5b4c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "48f3d25c7f57c8feaad88143854ad37807b24a7701c739120b967dd37f382c8f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "82916252640243bb2f4cc012748ff8f8691a13225b1dbf07276c868cf1d33d346cf17f1ecbb80043db2153208357e6a9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d64d7094ccede507f9b0ee95eb32ed3ccf09a0cae0a16366426f2a0d15b0ec3a9d49d984b4b6a9261a7424e7a8f02f1ef5a47618ef9a7755251f5286387b0eac"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2863338149661645fba5f42cd684f182634d5088cb218c9ba3a7bc93801c3402"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "793f94a5263800aabb4780b957371016774b1df931caf4ef051dc5e4b2bbd5870b132691b641eafef8952b426216409f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ac137206b78791d30c5a68a717dc15e8d576a1ea0d5c9eb838c89d130f5da404976def4c248860771620d0d886f9949cf06aa54b2be9533bf122d951603d3805"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "The GNU General Public License (GPL), Version 2, With Classpath Exception",
+            "url" : "https://www.gnu.org/software/classpath/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.core/jersey-common@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.core/jersey-common@2.35?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.annotation",
+      "name" : "jakarta.annotation-api",
+      "version" : "1.3.5",
+      "description" : "Jakarta Annotations API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8b165cf58df5f8c2a222f637c0a07c97"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "59eb84ee0d616332ff44aba065f3888cf002cd2d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "004a4bde333c0575f72df1cb9cf95ee0c6c7f738a6f0f723a5ec545aaa1664abeb82f01627708a1377e3136754fb7859"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1acff146c0f9ea923a9325ad4c22ba2052ec474341ab8392abab7e8abd3ca010db2400ff9b5849fc4f1fa5c0a18830eb104da07a13bd26b4f0a43d167935878"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3d3ef16365e7a0357d82f874fa26b2b0a146cf7bf98a351c65ef1586444fa009"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "abcc5b1fbad59b3e9b6d2d6195ec11d6254f689116c534a964724b61f815cca60ba3a2c1489933403f3f78dc54fd20a6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "88625a8811be514851209291344df32478b527bc7838ddee58752269bf2457ae8f4e6b6a0d0b5c18522e287ba6df1def0cb19dee2b85e01ee21f0b48ac2630d3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/ca-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.hk2",
+      "name" : "osgi-resource-locator",
+      "version" : "1.0.3",
+      "description" : "Used by various API providers that rely on META-INF/services mechanism to locate providers.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e7e82b82118c5387ae45f7bf3892909b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "de3b21279df7e755e38275137539be5e2c80dd58"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aab5d7849f7cfcda2cc7c541ba1bd365151d42276f151c825387245dfde3dd74"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9f92002296c66cc8996d459b95a9c531ec71b98a8b819121abbc7d636a6c4ace04c88878ba6917f71650280a880d1ce2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4d84983a9b1c72f58661b576c78ca456a2106602c2ad211cd7e72d94464c8774173b34a35629c507c7c84c982f1de0c9bf48352458e8480be5f874d20d6e69a3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cf90e96adac2f1167ff71267db4a91c75d824f8a4b0359d2ab7d50b1c87c3952"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b27581d003ce715fba7e2958dbe73b64330b8586d94dd2f4b80b3d4861fd36415af6c2fe1005a798a7bd4f706d77e3d1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "75f9ff6c3ab03f4471ac04789c181b75edf4c5dbf985a5616b2c979de59aa478b02593036f740a6c7bb71afcb145c131a3ff3e5a6a53336abab22f2cc9825772"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.hk2/osgi-resource-locator@1.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2-extra"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/ee4j/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.hk2/osgi-resource-locator@1.0.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.core",
+      "name" : "jersey-server",
+      "version" : "2.35",
+      "description" : "Jersey core server implementation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "35b97c2f6cf76195628135cb9300d41e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c6efc2ee82d2550e6385a7f7b1c08651f71afb7a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f4190e52847c5bc6db1fd13ce34b1888e398e35bc9f090cbfad7997b8e9c8b65"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cdb8d2b77a6c2f2f949815e4d0af24ef19a84a8dfb08e048bdb33b97fc6f7c4d9d9655e8f2c784f0d06fa667e8122422"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "847b201c51c326cfb6fb1a3dbaa5e45bdd93ac24d368ac9145ffaa47e7744d42f33ed68ad072eb38d9d68861843920cea90dd053c68e18ef8114a51085349108"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8f9c414b9c6ec73dd2a5fa5fd28a1b3b03648309743282c8f7195e40bf92a82f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5ad4d4dd08759a84ccc26ee20c09f97abce1706e7b1a5e662df38819ce59b2b22ae79e020badac7a5d68451199eba5aa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5586f36e0d813cbec7f5f7863215d4d1bbf9ed1bf63251a3f7685cc3fe03092cd63528d1c70fbddd00a13a13d56512dc878ed9a5295cad4360a40e37aa3c5d24"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "The GNU General Public License (GPL), Version 2, With Classpath Exception",
+            "url" : "https://www.gnu.org/software/classpath/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.core/jersey-server@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.core/jersey-server@2.35?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.validation",
+      "name" : "jakarta.validation-api",
+      "version" : "2.0.2",
+      "description" : "Jakarta Bean Validation API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "77501d529c1928c9bac2500cc9f93fb0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5eacc6522521f7eacb081f95cee1e231648461e7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b42d42428f3d922c892a909fa043287d577c0c5b165ad9b7d568cebf87fc9ea4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6ae3963fd6a5e83b068a8344b88f6bfbd26d29cee64193025bc5e98195678e49826463da27a7a1c15cd83b2149d57a94"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3ca8556b80ca809b3a43fac31469702bbad62a00e63b11a304dad1e372d9f6c128357463a4c70c423055941c7e2e417f87a9474a204d189c8e4b62f42047c8eb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1ff48fdabab86a398b25e491e6ba4fd9b62d597314202628a3cfedf723c17f21"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55a570386718064b422f9ebc0c0c07f0b37259e44a14c9a16c20e945402339b1d01b7d6969ef40d6b5baf5bce3e1161d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c23bb0b43fb0c39d4c9d2cce0cd38334fa7c253130f0bda3007d9f7d2dd451c0896ff4265ee2cc35024fad282f9ccaa398c19874775d9cabbb786843fae155d7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/BVAL/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/beanvalidation-api"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar"
+    },
+    {
+      "group" : "org.hibernate.validator",
+      "name" : "hibernate-validator",
+      "version" : "6.2.0.Final",
+      "description" : "Hibernate's Jakarta Bean Validation reference implementation.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "59abb8e6d7c7590ae3bb9dd0685facd5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d6b0760dfffbf379cedd02f715ff4c9a2e215921"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7a694d0621e3007465718b95cee7fb3e40b5b77834e812380bbde79659a4d704"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "88ba70892ea1f9618060822ef6e930bff5a8d3c0a9715e4029c9f0f6e3e317dd1d9df975fbf5ecbdaabbab0c56308f4f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6305c1c0e23180b448385a484eb8d11fad75665cb9c6aaab197b958a7e7c2de26a97c6cc7761f4a632da2f3f2257424872e4bc4f715bc29b0fbaa585e649cfe1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "24468bb51f268f846b8e9c538e4d98f3ea329fff49372efe977b69021f5ddc7b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "705ad0ea9b1631c2854e24f7d919ba85999029c78474228ab17c8f6336f33e96afeeb481dd54b2b217342db15318f8f7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8221758094d6f7406e20fbc00723d75acd60212e49c557f866687db9aaee66f7c3a0592047ff431d952f020168492707282eebffd54f6b424ab345e4b77a5ed0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "http://ci.hibernate.org/view/Validator/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/HV/summary"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/hibernate/hibernate-validator"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.0.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "jboss-logging",
+      "version" : "3.4.1.Final",
+      "description" : "The JBoss Logging Framework",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "52ee373b84e39570c78c0815006375bc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "40fd4d696c55793e996d1ff3c475833f836c2498"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8efe877d93e5e1057a1388b2950503b88b0c28447364fde08adbec61e524eeb8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1a9a57638b6d9da1f50dc92da88405878885ccfc1cd6e3a66f5cee1fcef5af51a2d63294afd23f2300f550758af58469"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c17b8882481c0cb8fbcdf7ea33d268e2173b1bfe04be71e61d5f07c3040b1c33b58781063f8ebf27325979d02255e62d1df16a633ac22f9d08adeb5c6b83a32a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "447c31f632013a87e7e9e90a346b2011f2213df22a3844a502e813536f14611c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "aabecb31aaa548a5bf9ed6f540ad91e8f3c713a10c351c43aa71e845f6f80d81d673484e1c566ab246c80c8c77acfa74"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1b34af205a56d3f93d2070e335ef853090fb7dabe630b05beeee13c8596503c2f242fc93aa7a8763418771bc3593e65e8bd93c62288324e29caaf53ffbee27d0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss-logging/jboss-logging"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+    },
+    {
+      "publisher" : "fasterxml.com",
+      "group" : "com.fasterxml",
+      "name" : "classmate",
+      "version" : "1.5.1",
+      "description" : "Library for introspecting types with full generic information including resolving of field and method types.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e91fcd30ba329fd1b0b6dc5321fd067c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3fe0bed568c62df5e89f4f174c101eab25345b6c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aab4de3006808c09d25dd4ff4a3611cfb63c95463cfd99e73d2e1680d229a33b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "28b4780b2353ebc08dbc02c9a343527a9062a0455bfb4ab135cb639c03e5dfd9c2250a835c44d5f17d275667c2009694"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fc4764eb65227f5ba614698a5cf2f9430133f42ec6e2ae53b4c724ee53f258541a0109fe0659e0b9e45729b46c95c00227e696b8d1addcd772c85f877658c9a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50234c94efed4c816eb77bd2f70b869c9f89ddf8ee73dc25e354f4d0b81b3e1f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b194ace8f1f49f410286bd859866678b95a1b2c6f73e41f48291eb7438dffea57aaa9b177459038b6997771ce4d1cee1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9886421726066b313a62283a6811b76d904ea1c1e9b7b2d850cb47afa189b03cdef053c8f7f6b79e77f2269c45f8cc2ed75c3389e96594b50987fef311d5a25f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://fasterxml.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/java-classmate"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.el",
+      "name" : "jakarta.el-api",
+      "version" : "3.0.3",
+      "description" : "Jakarta Expression Language defines an expression language for Java applications",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "528ed6138395d22fb54912b2b889e88e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f311ab94bb1d4380690a53d737226a6b879dd4f1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "47ae0a91fb6dd32fdaa5d9bda63df043ac8148e00c297ccce8ab9c56b95cf261"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5796acb1f22b55e2713763584eaf2b62abbcfcee85530138006fbb55abb19b2c534b2887c28a2f5301168783416fb6c8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f76c94036f0f49d3cf9d1f90697fa96a97d94aba93a0dccad7b907d6c63ff3bceacc6fd40405ff68d6c248b13d056b3543ccb3d2b405917b2ccddaae78ad8900"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4fc4437d2638002741f4217003f3a9de47c037458dbeabee1a1a5bec96547466"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bdb09cc896874c0a4a3c470e355f2b23f954800510986753cfc2d4da41cb6c4de567b9014d618da3f89f04e36cfe620b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5857452b1eb5e9ad141717dd9e989763e99a98bf49150ebeb66c423daee8e890ae9b89737abdebedd7ef7e47e6c2fd8cfeaa9276014fb6dc88134ccd2234ab5f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/el-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/el-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/el-ri"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish",
+      "name" : "jakarta.el",
+      "version" : "3.0.4",
+      "description" : "Jakarta Expression Language provides a specification document, API, reference implementation and TCK that describes an expression language for Java applications.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a4ff0d711c405e054f8166c2ea893e0e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f48473482c0e3e714f87186d9305bcae30b7f5cb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3b8d4311b47fb47d168ad4338b6649a7cc21d5066b9765bd28ebca93148064be"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "14e457f2bbbabd02bbd6ddf8c9dd0c27ab7c50c4c7908c81a17660bc45de3a800119c00da8e799335fae4241adc2745a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "45b9142c3ba82abd44decd350257be6f951bfb23e3baa96e6e8a26b269881f96c4e50615fef06c3b27434d7cb346e87da913f90284e11614118699a8a3e883be"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "86bb8ff8f351449a2ac125c09914eebdd8ee4b8e5616477fd155a481aa98b6a8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "eaa1fa45a0f0d152f78dd000518c23edb1e31025cd0dbc86c3cccafab64bd89d6bfbd605c062b6e5aeabc259f0bf9aba"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f40a2b2fb4595a9aadc4e38b4dbd8b958bb303c4d90df4241cd1eaa1181ca0715bbff6e29c3bd5c424542392f351cf09329d772ae66d72608c272dd6f5042ede"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish/jakarta.el@3.0.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/el-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/el-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/el-ri"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish/jakarta.el@3.0.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.ws.rs",
+      "name" : "jakarta.ws.rs-api",
+      "version" : "2.1.6",
+      "description" : "Jakarta RESTful Web Services API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c3892382aeb5c54085b22b1890511d29"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1dcb770bce80a490dff49729b99c7a60e9ecb122"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4cea299c846c8a6e6470cbfc2f7c391bc29b9caa2f9264ac1064ba91691f4adf"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3fd05e2b167d927216d3b2fc9d1c5a70aa3911d075c2159f958ce755c6a41d93bd76f0ce79ccd22e5a60182aa91fdb07"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c1e2655269b9a32f9c0aec9edf12bf6d8b397d8cbcf60e28dd21ab13ecc2738800ebe5c2d49ed3c50d4dac6617671f0fae873daf8ec116a16ef7f7f0a3bef7fa"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "794fe21a9e2634744c65b299a232756391316c0b71e440973575bcde78907c17"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3a110ff82d6a0dba4adf024a6425e68689416dd8f0e841f2bade574dfaebcbcfede410116530714b68ef9d32a318c286"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fe482041b54c5f7a40d670af73c0c0c0a562bf74f4bfd684f8aef56decfbc5230901768814f7d0b0ec600828fea39bb8621cd121f616778278a03f67fd497310"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.ws.rs/jakarta.ws.rs-api@2.1.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repo.eclipse.org/content/repositories/jax-rs-api-releases/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxrs-api/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxrs-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.ws.rs/jakarta.ws.rs-api@2.1.6?type=jar"
+    },
+    {
+      "group" : "us.springett",
+      "name" : "alpine-infra",
+      "version" : "2.0.0",
+      "description" : "An opinionated scaffolding library that jumpstarts Java projects with an API-first design, secure defaults, and minimal dependencies.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5ce6dba5c9ba200e99423ddf28712e4d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "524f714a7f7c51a66cd7e40d79dcd6a581279378"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "145cff6cad72f16328b8f29811a8e61bba8951fd0bdeafa3c93c4a8e072b78ee"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c726aef87028db2d448e4cda76d21164c58d4cb2f901592e6b668130166082d25f5af5e2b38f6f6dfe3ce80c19afe758"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c44167d1352fffd89a2c562be650784b4cd6cbe14f0197ef6e8d90e813d038493053da3f5f30e07c2bd8b5f3976cd720c5858f95faf10e9f5ad76ab9d34e5dc0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ddd7f775ca56c0ee2b83920d076d37236bbefef363f7c2282d964581e7969c5d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f70f77017ceaeed3bc8bd626ee41e9ae6166fe366d2867d1973d8f80bc1c861e99a4e89fcb79f377e35b555f13d1ab79"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2a705acd3d1a06d2d0ca25b2d79c161f5de8977082659c7eead8624649461fa0aab64b95785e7a0683a225c9675248deb399755d55744896100d641978873123"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/us.springett/alpine-infra@2.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/stevespringett/Alpine/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/stevespringett/Alpine/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/stevespringett/Alpine.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/us.springett/alpine-infra@2.0.0?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-collections4",
+      "version" : "4.4",
+      "description" : "The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4a37023740719b391f10030362c86be6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "62ebe7544cb7164d87e0637a2a6a2bdc981395e8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1df8b9430b5c8ed143d7815e403e33ef5371b2400aadbe9bda0883762e0846d1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "74059fd8f61c366ed448e102256fdbd1db0d690501c2c296c80f3657a2c0d8ade3dd9533b1431cc29786bbb624195f46"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5939c9931eb9557caee3b45fe1dd9ce54cabdc4e6182ed7faac77e1a866dd0cb602bfa4ece2f3316d769913366106bd2b61bf3bb5faad1fa7d808124c06dec0f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1716630a207a8f4a83bf9ef19245f46c87d62bfebbcfa1227101e6dd51da8fa5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "15034fb39842620bf3b152cd90bce252644ebc6a29fafd6dcf5e1f3925f09ccea2ae4e195817450f996b25a7081a9a3f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c290c98c7b5825d024644ec1162804a1f9ad4da3bb5324d147ddffee6cc79e3c0ecc3825d6116502f2ca292ec80c4e7f8d49a03542dda8f4d58b0dc8228923c5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/COLLECTIONS"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://git-wip-us.apache.org/repos/asf?p=commons-collections.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar"
+    },
+    {
+      "group" : "org.datanucleus",
+      "name" : "datanucleus-rdbms",
+      "version" : "5.2.7",
+      "description" : "Plugin for DataNucleus providing persistence to RDBMS datastores.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a92833b61554f8f1e1db915b4505a502"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c7c0396b14b627543d0bfb8e29a49d3d52acf9d8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "998cfbe83762f4ffc915e62827844e81326439ee2a36c8f8ea0dcf43b892e6a7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fd76bf96e4220a886d126b4e24ca478f1bf981b2f200d5327d3d504a74d6a1956d90b1e288202f7a0878c85a7f22323c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "265a6c60d7a42049efce53ac2b578411b08f2239a56a343fec3275b205f15bf7f782826b8965bed5dcf1a19b6bd80b3d5b15b49692e6bb8a517e437e390a3d10"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d7890a41cc5a90a0f102ec53fb22d39fd8b7a3cee84f9dcc384cedeeeffb3417"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b0927121219e0271046342b88f79989da0d2ad09727563e1f4f96a15017df80513a69539e8aa87c507339de344537063"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3524999656120b515993b37a572632c5c2c73d3f367f1fb951abc11f89d87dde72213a1a0916ff707c93a84349900bedfccfd664c16fa05edf7d52f158562357"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.datanucleus/datanucleus-rdbms@5.2.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/datanucleus/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.datanucleus/datanucleus-rdbms@5.2.7?type=jar"
+    },
+    {
+      "publisher" : "Zaxxer.com",
+      "group" : "com.zaxxer",
+      "name" : "HikariCP",
+      "version" : "4.0.3",
+      "description" : "Ultimate JDBC Connection Pool",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e725642926105cd1bbf4ad7fdff5d5a9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "107cbdf0db6780a065f895ae9d8fbf3bb0e1c21f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7c024aeff1c1063576d74453513f9de6447d8e624d17f8e27f30a2e97688c6c9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9c49efde42b89a8cd2b119d666076bc9d532c4a835c640b77d8a5858d3325f9ba99f8cd19cd21b9df4f386d1c21855ae"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "34a9ee96c51ae070634cd0b642cad3c4c54b9d2ab7f1714f59dad805512ae27c9c69b8be83da473689f55474c4e2874c93e727f9f31d3bfc9b80ec37aeb68898"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "163e0d75894a0a4c2d36f4a992449e2dfd71bf495f5789813cd333ad1b571fc5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ccea43e68e6dcf0426c271640abf132575a9e28b439ac968b5608e3d04d7ec80dd948d33c474e31fb18bab9b80959c2b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bc20907f677b6fceaf8f81361d5a7e0099799561af550a2a49dfed531a3b8ee29f35ecc2c4419cd8eef9e25a147a2cf88cfb7ffc9218b8b35b0e0524caf56d8d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/brettwooldridge"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/trunk/oss/oss-parent-9"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar"
+    },
+    {
+      "publisher" : "Shigeru Chiba, www.javassist.org",
+      "group" : "org.javassist",
+      "name" : "javassist",
+      "version" : "3.28.0-GA",
+      "description" : "Javassist (JAVA programming ASSISTant) makes Java bytecode manipulation simple. It is a class library for editing bytecodes in Java.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1a2dd8c76321cef26cc2669fe70a2557"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9a958811a88381bb159cc2f5ed79c34a45c4af7a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "57d0a9e9286f82f4eaa851125186997f811befce0e2060ff0a15a77f5a9dd9a7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b71fc9564c478edebbf19b4044bb9cfb80996f779685d79f6a779d98ce3823b5aa234b91b9da35317ebf4534e1e65a31"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "49d3109104f01efda1ae8a6145fdb91d1b1331587e2981f6cc1a1b991c50af97e8febfea5d9d224a106cab877c1e4850d183eb3c7316b82e62e51b6ca3fc29e8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bf8cbfa03a6c53bb8aad510a7c6623d5e28f8189295f0dc2a0998993ca8df0d7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bd7f7f52a05aebf17286e7101cafdcb19eb52f14731ce9ad287c07a14f676a8bbba78238e636d2ff5585a90f02f57b82"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "30a7c36e4b4089a5586dd0cb0f8cba1260fbed95e221bd623a66b1d07ff9565227d31c0fd0d131cda9d97483441f08e619aa8bbc758c0df66f3345da7b5adf68"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MPL-1.1"
+          }
+        },
+        {
+          "license" : {
+            "id" : "LGPL-2.1-only"
+          }
+        },
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.javassist/javassist@3.28.0-GA?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.jboss.org/jira/browse/JASSIST/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.javassist/javassist@3.28.0-GA?type=jar"
+    },
+    {
+      "group" : "io.jsonwebtoken",
+      "name" : "jjwt",
+      "version" : "0.9.1",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "32b17377c70abef64a8b8203d2520932"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "54d2abfc3e63a28824d35bf600d6a5d627da681a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "56e254d6a8d2306dc93e9ae2d81bf841481637f98b84847470c06cf71160d143"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "254a9822f640ea9aa6f6ea2b48337684b01cf7a14d48acc9fbbb472c090919f7e241f7455d70b90e1ed223df4815cded"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ab8e3e49904fd2e852f720af46acce0b550b99ee4be593944a6c00f8781ed141c7f19cad0614cabad7194e0a0d970a3a1605525ce244167d5fdbf961aa6a093b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "696478922c79f183e6e2656bd523fbb2a8830f084f9d278d5cce4d2216bdf702"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "041a871e7c44449e86fda7fb2fc9df5d262ef64e511be0fd167b4a2a0c0f2e230bb3e09dc8074f2eca9911d519cad4bd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1fe621ebdfdbab8fa8cd59878c171826a6c06de8e2f0416128c47b82bdcdfe9ad2bb9a59e157f96c170df919000fb009cd596b649a6aae4ed0ec6433cf9c2c79"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.jsonwebtoken/jjwt@0.9.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/jwtk/jjwt"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/jwtk/jjwt/issues"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.jsonwebtoken/jjwt@0.9.1?type=jar"
+    },
+    {
+      "group" : "us.springett",
+      "name" : "alpine-server",
+      "version" : "2.0.0",
+      "description" : "An opinionated scaffolding library that jumpstarts Java projects with an API-first design, secure defaults, and minimal dependencies.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fa706be33e0b369cb6940331159b1692"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0fce15ab41ac882339e575456a061434064d2ad9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "93fbdac19e5011c357526d10dea921c700040457ce0c8c4536af35e543ebc8c6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5a44bfb76c849d5cb044999214b5cff747ea039ee491b712e9cceb4af80645fafe6d3a96d2660239be9640bdfb9e0f84"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6c03595a8772e3bd89a681dc154f0e548399e462cb256cb9371b413b49181eb77da068f8602da96e76a33e80fa50d8ea491c5cd70bcfbd5db1e9a301be1940c6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ccf19b37262eefdf957541a6bef09041343cf5f8ac6cdbdf7839d24d059e6032"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3d7430a012803fef514caaae5af2127a8c349ad62e7946469e6b697ffd984f19a0c7f33524fadc3d2cd314ac7d7b89fc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "44e75200d3d7e2df21e72853efa9d592403767b269a4f0c84230688ed400ff9444446d55326091f3ddf2924bc5d57b49c2c0f8fe7728be240a6adc7bd3ee1ccd"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/us.springett/alpine-server@2.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/stevespringett/Alpine/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/stevespringett/Alpine/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/stevespringett/Alpine.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/us.springett/alpine-server@2.0.0?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-io",
+      "name" : "commons-io",
+      "version" : "2.11.0",
+      "description" : "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3b4b7ccfaeceeac240b804839ee1a1ca"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a2503f302b11ebde7ebc3df41daebe0e4eea3689"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "114f1e324d90ad887c177876d410f5787a8e8da6c48d4b2862d365802c0efded3a88cb24046976bf6276cadad3712f0f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5bd78eed456ede30119319c5bed8e3e4c443b6fd7bdb3a7a5686647bd83094d0c3e2832a7575cfb60e4ef25f08106b93476939d3adcfecf5533cc030b3039e10"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5adfb5ccaf5f21a549422f426118a9542673926fcd18c68390cf813e791dcf6c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "80288c03ad4d80d69f91d056ffc5570d49a9c76bf54ad2dff0121ecde26a560df76d05156f281f5c6db2a38ff07a873d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7573f47f0babb53cefdc7c2309a0b982d800139064537b0797da442853d081010ad7c3c74a500598a0f800639a5d540eca21963ea652c68613907059bd4278c2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/IO"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-io.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-io/commons-io@2.11.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.core",
+      "name" : "jersey-client",
+      "version" : "2.35",
+      "description" : "Jersey core client implementation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "690961343e41659f42bb0190e65cb5ef"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ea92be0dd34d0b298930a7514e715783f4eaba97"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "62cc4f316b1924d2e6323045d35a5ca114904b167e8f8745c9004cbe2b608f8b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "81f72674f96fc201cbd6d7149a5c09ae681759c011b96c0847f9610090465da5c15f805b7a5e082cb4c646dee1fc44d2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "32b413458efea652c0d4e92920fdb46473644768e87d92825457c59a7ce06ae6bcf9608081758a191079a735aa6f47fbf11d396b2fb4afacc6f0d884b8dfc938"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bddd86cf99d80df51a6c673c97bfda9d1d1c7242b9e03a5ba05eeb0cb8eff2d8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3df857ea9aa2d886111bcd4d39c67872b0e39243720221e317f7dc88bfc2034f800cffc3f080df87da378d17b8805be8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0fed755b314954b4d7e9c552c965374dc03c260b6c502f07a05cb71a9658a1b8278d0cebddf010452e2d3e27f46044d7e46bfde1a4053ab1c9dbd9b18cb30045"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "jQuery license",
+            "url" : "jquery.org/license"
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license" : {
+            "name" : "W3C license",
+            "url" : "https://www.w3.org/Consortium/Legal/copyright-documents-19990405"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.core/jersey-client@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.core/jersey-client@2.35?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.containers",
+      "name" : "jersey-container-servlet",
+      "version" : "2.35",
+      "description" : "Jersey core Servlet 3.x implementation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "706016b04013bb0b488d3759b8e39646"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "898ef84b72e75788811dd709fe7c7051f61a943e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "05dc471810860bfa642ca153313bd82c3594b86b5dca7088bc5d4aacdd709dae"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e6ee2afd21cb7cf1f0acef3cadb4307a5482d4c0aea43d2e95638f452778c526316010d8a30939b563c9198f77899b4c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0490791bd5cf55f9f7990e432009e3ce43eabca07b0fad414a2afb0e650433ed6494c479d7c5922314a8bedd42b086733befc0a19ebdf6fcdae55145b40dbda5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "42b1f5611e0c865ed593eeb3a7b542c72c8689837708a20191a215abfe8f8c82"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6a5346801facc703c4d8b5a426bea037df8323595914b39931c67afed56ec95af24a7e59a3bf0e2e857b81ccd8e9d80e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "43af1c5bb95382d3f1f2dc189b47c5a28d4499c1a5738e131852f9d411896fa6f9e3739f01c285b8ed9b64669b2129dfe5162b1bb4f5c56ff41ac69748dd869b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "jQuery license",
+            "url" : "jquery.org/license"
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license" : {
+            "name" : "W3C license",
+            "url" : "https://www.w3.org/Consortium/Legal/copyright-documents-19990405"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet@2.35?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.containers",
+      "name" : "jersey-container-servlet-core",
+      "version" : "2.35",
+      "description" : "Jersey core Servlet 2.x implementation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bfb76674b6d9a0c9cebca33e981b62ab"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7cc48f2529b921f25a020c821dde23753f6e60bb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f96811262dee0b0dc6e919da74b3172635d1ba53789e3c9ec1767429bcea6879"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6216cc830c63a7e5e3d7f79f75658806628e0ebdb31e1a844bdb334e220e8e9ffcbc091c1b96ff1355f894d0e0cb8482"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0e9581416028ffb64d6d338de43123c6f8fe635caca799eb9b859d15f435b46d206dc3baa7c470863c8350cabc40c8b1e916b7bb9d0a170c928f88c495ee25be"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "faf7419eef20e680d1d09b19e565b14f76fa9fefc180578996fe97becd6bbb5b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ea85ea05481f9d0ec8eae3b8685aaddaa3a1e1c45753cc53d2afaa4eb755e7f7457f86ac0821482c84835a8a015f250e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cff8861f79405ea4c344630d418acb0150a2c88c7ce7e95f6784a7315020c61b60105345aff9ecc36b59f0aa30e5b42aa47bc6b9cefefc9c5b1da7fb39ebb0c9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "jQuery license",
+            "url" : "jquery.org/license"
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license" : {
+            "name" : "W3C license",
+            "url" : "https://www.w3.org/Consortium/Legal/copyright-documents-19990405"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet-core@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet-core@2.35?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.media",
+      "name" : "jersey-media-json-jackson",
+      "version" : "2.35",
+      "description" : "Jersey JSON Jackson (2.x) entity providers support module.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "358d8222ad61a17e21315ffe9215fd1d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6383927e15ecb4baeef2cf0d3373b1ff1795c062"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ecff85e7df77067bfa05de5a183347f36be0cf04967787fb88d5e78df0963c9e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3aae13260fc87d06a6f8d2e3ca1c9e0b1a03c7cd3567826b6977ff403b6836255b02c9dbeb065fe2c39fc281732fef2a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4ff94e7c0ea8b87034e921f4d1fd3203c64ecde4c1f3422d5bef2147ecad89368c21a2678c7e5cb1b3884d91036329eb323bf3152dcb3bdd880f23a8d8f69b76"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "75457d9708c8b618cb9b90ed08982366a99ab2461752792cda0ecac5eca9c3b5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "28c554737f7951a12d6a4aece4464b9d1d71a6cfad1de3f04e63535ba439fb0df22fe8e1b31af876ce54c609742a8868"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8702f870aaff0828e3d80350a45d5e27ce9a40037b88a40c9f764aec00e079a046e6b52e6b473db63113f5fef50f53fe413f776d59da2d68713f834fdd723f11"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "The GNU General Public License (GPL), Version 2, With Classpath Exception",
+            "url" : "https://www.gnu.org/software/classpath/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.media/jersey-media-json-jackson@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.media/jersey-media-json-jackson@2.35?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.ext",
+      "name" : "jersey-entity-filtering",
+      "version" : "2.35",
+      "description" : "Jersey extension module providing support for Entity Data Filtering.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "57c92e30f2c77fea91fa843ec35b7441"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2fbe9e89f6597e10976d1431dde64b282a761aeb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0bbfb49179e37fa20324cbd695be2794bea8999442fbcaa0f44760cf33bd3fcf"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b159d5027c2519584fa0b76a211e05c0e3b368bcbb9e1488801565fe65b2294effa280a850889dba8f50035185bcdf1d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "63bd4d3c633301878c32bc78e1d2437df2aa5265c639148990287b54f23d31089d6cd69afd1747119a9e193d3294cf785b2667dc2efa1877b7b718cd63d3b48b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d51cecdc6e1463ab9317117e5aeaf79b661a15c6901f9c69c1f0aeb96743dc07"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fb306e184737039fc9f1da901a6c2198e75f42da8b2843c51a1902a4453703100b3f454a8caf818f3834ddaa372ec968"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "babba8c53ed37cf156d2ee32fab12af6fd5e7d4d94135d7c1685f73b1a6f44da861428bc38117aae93addf2049dcd5c6eb94d39dcee4b740b812b082501b0984"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "jQuery license",
+            "url" : "jquery.org/license"
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license" : {
+            "name" : "W3C license",
+            "url" : "https://www.w3.org/Consortium/Legal/copyright-documents-19990405"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.ext/jersey-entity-filtering@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.ext/jersey-entity-filtering@2.35?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.module",
+      "name" : "jackson-module-jaxb-annotations",
+      "version" : "2.12.2",
+      "description" : "Support for using JAXB annotations as an alternative to \"native\" Jackson annotations, for configuring data-binding.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "27650ab7486832e408b0cfe894525c5b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f226bd0766b4e81493822e8c81eaa6cab27e589f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b6aca0666efc3b49a2715e78752e28d35ead80c671d898706091945e2ea1909f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9120fcd5b0c46c5d680ecb9977a5cf9930804e8473f40fd7591c5a2030380f68ee9786620c49f6c2df5e2f7eda50ca3a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6ff95c56dd80ec5dda127ada204da0cb592edea60208d0e868fe8d281094c514a37f86ce34fdf621694843ae2ccc67f8d5d8f23690def0b5f8bb967a7a06cebc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "99ffd3ab87009d329f763d6e10fd6a5e922371b03bc5d0fc32d557d0e4e1a3e2"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3842de61d32f71443f1d829c3c3ac366b796ae43d5d09854a2c789535e24f0c8346576382c322c217301cd7f8f3c8b8b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a91927b02288a89c8cc6829bbc56b2bdc6c442c31d0cf8aea31fdd790038b68e4682fce54eba08497f2d8ce41382a3a5d6b78f73bd115cfecc5f309db0d9b7df"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-base/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-base"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.2?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.activation",
+      "name" : "jakarta.activation-api",
+      "version" : "1.2.1",
+      "description" : "${project.name}",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9b647398add993324d3d9e5effa6005a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "562a587face36ec7eff2db7f2fc95425c6602bc1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8b0a0f52fa8b05c5431921a063ed866efaa41dadf2e3a7ee3e1961f2b0d9645b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "07422d64a103aacb8956c2067175f2cc257494d2cc8dbde29ddf8d93778a2d4b3903565b17173a0b5230b59d535bd474"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c60edc99f119b9e0df0cf527e2512f2b7ab9db0e17c54e83850695f80f652c981eaae90a296db671cf7ed88a044c150224e030df333feb30f346e8a31fb794c6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "880a91ff9e978ac9208c84babd820dc2ded42e601d8a17688eb30883b598dec0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fe6be5e1fb1c0ee5236b2866c1e5058c84043fb4dc3dd5ad8f04e61c01c019c96e92ffdf1de0eaf7e657b2c02c6d898e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "91c0b8cb956bdb06e79738a9db624022887b3d83838b708dd3c654f231ab6f9b4a27be2556fd14683cd6158bf8534b96acd2481054e0c946d6e9f641cc5af55b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaf/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaf"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.media",
+      "name" : "jersey-media-multipart",
+      "version" : "2.35",
+      "description" : "Jersey Multipart entity providers support module.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ce7dd4eef19a9b236f75fe742918ebcd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5181de4ae2c81147cb788e946e96c06a9765e84f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "abb9230ce23d7b80a4d1766f3f5647f9e386344c2d200113d16c438a4b6d0bbe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5aaca73196f28df16a2469ae2b998c16ef94263d9dc34194fe52aec96e771553e2c4023fde9744a1e48ec7d1f019d853"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1dba4f846f3cf29f81f9cae522874eb52049dfb003dff92aacc03ac223a0cbeae7099b1dcc8df377d294541bf1828d4938dc10dd84b6136295947ba4470dc87d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7febff0f4b9428508ad8be49d1dee2d678a756ce1c88b3b56da119ed51815735"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9929a3f0d9b032ca9b846c2f47173bdc616d4c05ac6a8ed280d68116f311e7e443f13bc27bb00baf1a9ead2b495d69af"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8dbb32490627f257cf5d0c37fe6b3f650d788c2ee628e4095fedd2337b9359272e68ff95c5642e57585b0076ba40fb7932c6b8ec03c915f500327002e4c0fb15"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "jQuery license",
+            "url" : "jquery.org/license"
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license" : {
+            "name" : "W3C license",
+            "url" : "https://www.w3.org/Consortium/Legal/copyright-documents-19990405"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.media/jersey-media-multipart@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.media/jersey-media-multipart@2.35?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.jvnet.mimepull",
+      "name" : "mimepull",
+      "version" : "1.9.13",
+      "description" : "Provides a streaming API to access attachments parts in a MIME message.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8f213b6360a3efd030cf48ad45edaade"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a4f12d0da986cae55dd5c4a735b4fefc700eb266"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5518bd3c5d88bea3b303952b22618313d6bf0ca7f131f78368108a04ebba3f17"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8c6516e08603a372e89b32c826a710ecb2333b40718ec99aac4cf0b7ad049769e62cff4c1336fa1d53be930c04b3f162"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7a9e6946db77a24c6c78afa2cf1173006742fb7caaec94bc27510b60d731eb6f8fe1395eb31ab52854aa3479ba9258656986e4cc7009f1e0c56533fa9e22244f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c2563c0d7228868b88a699fc2460ac1c48bb9fad01adace21d8d9a47f95c0688"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "53a7f9d0fcf0fec25fac06c1413933d8a4d279d445e355a2de9b0566aa30ced0559d89d99e5452fee7d96b1aa0556bb6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cba11d011018bf1259c401a5a87bf4461934f2f0531f0ba240d86a1a8672c70815cec79924e686b596d87673527bdefda9a555e89e53ac1da072b3e8eb07d28b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Eclipse Distribution License - v 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jvnet.mimepull/mimepull@1.9.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/metro-mimepull/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://www.eclipse.org/lists/metro-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/metro-mimepull"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jvnet.mimepull/mimepull@1.9.13?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jersey.inject",
+      "name" : "jersey-hk2",
+      "version" : "2.35",
+      "description" : "HK2 InjectionManager implementation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3b6630c199f38793d8c654c09f4a3e09"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2be6d2227081028566e8e2b0fc6a1abbaecf56f7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a402bf76ce4289a817643a2d7634a0e78ab9058eab6861d75d5452cc51c6ef07"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c312a7fe07b5f627493bf575af927ab2ac7e4f189fc5eacbf8d2e067c0dc249e96178445501be2a20bd2a4df5a09a0d7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "75505acecf573edc0a74d20f563fd3309e2d205fc2205e2d923b71561babcb280a8023c13182f6062ace1a77a4e05f9b16e7ca63b819b728130ef166bc563dff"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a6189315974f14ee94c0f8f67aceb4dd83e1d8e78fae3aede2c5d3a54b0c373c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f75484cc13904ab8c06196c887c85c21bf8ff81131627a5e23ae98de7d951390f32aeb12b24220af7e41b07fb674bf2c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cf6d4d9b4c146d429a48a2911d4d6c6ae8edf0103178cb4efccd2eaa83c93c048068ebd4c0a2e8662ab500d1c270c2c665998a62ecd2b294d3c5336c890b472c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Apache License, 2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Public Domain",
+            "url" : "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Modified BSD",
+            "url" : "http://asm.objectweb.org/license.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "jQuery license",
+            "url" : "jquery.org/license"
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        },
+        {
+          "license" : {
+            "name" : "W3C license",
+            "url" : "https://www.w3.org/Consortium/Legal/copyright-documents-19990405"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jersey.inject/jersey-hk2@2.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/org/foundation/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jersey/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jersey"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jersey.inject/jersey-hk2@2.35?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "org.glassfish.hk2",
+      "name" : "hk2-locator",
+      "version" : "2.6.1",
+      "description" : "${project.name}",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dfd358720393d83b01747928db6e3912"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9dedf9d2022e38ec0743ed44c1ac94ad6149acdd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "febc668deb9f2000c76bd4918d8086c0a4c74d07bd0c60486b72c6bd38b62874"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "05afff9ebfdbdaed71770a58fe334751b9ac7476eb4114e08fc376bf4e16226b5016784c99c3dd8cb04c79d954068402"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e2c87a265f114042f4c04397db4adca7291fd68e08e97129576ceb603287b57ccf5b03d0c285727ebb8cd7f88009280bdeab4254475d59da1ac41ba57b7cdecb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "20def735fc2d01276b1c9e0961c68aac17722eff6e224ca43fb062ba592a2131"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6d7b53bb3939b45c75ef11a899bde1b7acf6ef1e3f3285687060c830505e540f1843d4f631b949fc8727c2a58cf0cfda"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "07822cb6669f8387a4b56cc28709347197b1d4c3ac36e2cd8f2e5dc36d50937aeabdc1dea47b8028d0e91a700aeed6d18066280b66101a43bb4ca00f6ca2181f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.hk2/hk2-locator@2.6.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/glassfish-hk2-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.hk2/hk2-locator@2.6.1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "org.glassfish.hk2.external",
+      "name" : "aopalliance-repackaged",
+      "version" : "2.6.1",
+      "description" : "Dependency Injection Kernel",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0237846ebdaa7db36b356044a373ffba"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b2eb0a83bcbb44cc5d25f8b18f23be116313a638"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bad77f9278d753406360af9e4747bd9b3161554ea9cd3d62411a0ae1f2c141fd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f481e2a4e18308a1a0bd85e79f95711434436fa69a504fe98a3d7ea899eaed505a5cb2bfe08f41d1b2af56e150ec0741"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2d9e5395ba887fa5bb6a8209b731292d440f5c1db2fccaf56c41b1f1d9f774733da28aa8b9b769e765fe62f3640d7bcb2cf6140f0044a8b576e9e45144038c46"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7c15e6095397160fe1c26a56964a42b85e23062644866a9ca93f6c24ccfe5212"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "df0d777477b068b3a3a6d368b8a647401f1531fd4bdce623c22b06b5fb6153cbeccaec9afcafb1c65efbdc49b73399ea"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "da354a243056157b800aae44d0a6b9697399a37f3ea805ec192debd47f9ea493e224794a392786d54608324a01b6e1745210ffe4d8ef1e956b941adfe820fe52"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.hk2.external/aopalliance-repackaged@2.6.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/glassfish-hk2-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.hk2.external/aopalliance-repackaged@2.6.1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "org.glassfish.hk2",
+      "name" : "hk2-api",
+      "version" : "2.6.1",
+      "description" : "${project.name}",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "23e8c18dae0c7b776bed756763d5153f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "114bd7afb4a1bd9993527f52a08a252b5d2acac5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c2cb80a01e58440ae57d5ee59af4d4d94e5180e04aff112b0cb611c07d61e773"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2236ca10af39c4f4f6f1ac63c3652eaa4124bce8f557f8ebaa78576e00c25b986ee9d7e417db6edb9a06aa46b36f4d24"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9abe9f78d7f6c805b6c7b515579230e5fa573abbcd818bed56068080d6458608e2e99d5937eb959cf1e4f4cfdc4f790059dfc1231313cd8f30aaefbf518eb1c7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "422eb417b817a7e9af62e36c6657fc9e10b461df59985f436970d75e9db4ca04"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a836a3bdd7e94c1c69fe3aa7692989b404f3e249224e70382f4ab88d3ef64c51b57a539a7fc9253f93d43665d7de70c3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "489625c546c34b7c6e395522843be55419706c3a951bc4e494002853dc913e175fbf3a6b7acb4ba581fd6995b56c2cc1431055e5b5416f71ea5519a0b8d5ce56"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.hk2/hk2-api@2.6.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/glassfish-hk2-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.hk2/hk2-api@2.6.1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "org.glassfish.hk2",
+      "name" : "hk2-utils",
+      "version" : "2.6.1",
+      "description" : "${project.name}",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "75ccb55538a77bf878996497ffeb86f3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "396513aa96c1d5a10aa4f75c4dcbf259a698d62d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "30727f79086452fdefdab08451d982c2082aa239d9f75cdeb1ba271e3c887036"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "94fb55c1f57b96fd84e717fbf3c254f16e2308bc33976addb71d26bf367b7c2ec63e657a953f30f55d7046dd07510e50"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8da7cd88de45270b1fcfd2c471ae092b3972af78a6e0ecc76ed4ac10b6bd6712d2a538bd163a457f21cea4e7e5c52f547108f44aaa791ed0fd069f697f1282c1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4169734272046ce681790cbbb553652c3ada2af1a5201a2ab9ab6210451e3e70"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b2d1842c0e31c8a83179b3a4d8aa08953747a868d8e1d599201feb8cc3f6e694adcd355581dc58bcad7cec515898eb7e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f2bea2fee534c92fc6ae2322696ac97d7e62654cb7ce635342c7f0234d0562f1f8537677a0263d9a76bdaeb57248d37bce537f9b36506db75d0e31024d6e8789"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.hk2/hk2-utils@2.6.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/glassfish-hk2-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/glassfish-hk2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.hk2/hk2-utils@2.6.1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "javax.xml.bind",
+      "name" : "jaxb-api",
+      "version" : "2.3.1",
+      "description" : "JAXB (JSR 222) API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bcf270d320f645ad19f5edb60091e87f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8531ad5ac454cc2deb9d4d32c40c4d7451939b5d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1eb2d7f307bda8cbf6a4ab5b2b97d830d33ca48ad94eb4bb1cbce860c54fca96285dbcb1ce9b164dbf37d4475f9a198f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "93a47b245ab830d664a48c9d14e86198a38809ce94f72ca66b3d68746ae1d7b902f6fef2d1ac1a92c01701549ae80a07db69bd822ffd831a95d8dbffad435790"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "41338683257d5ecead579ccc137bdef7bc4fea685d039a3d894e1d6730425e1d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8df7409d3f60888f3a80f4d49af66c2cab6dc9f00e79c87c17703faad19d8ba6c8fc96ad897434170ce2686952921cdd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3371a96171f69876b0e6b8354674d252680e6d52c509a2645b1a0b0d7f9e176274bde6c89edb40986264733ffb6794cb7b2cba417666b1e82075bd4fd51197b6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CDDL-1.1"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/javax.xml.bind/jaxb-api@2.3.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/javaee/jaxb-spec/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javaee/jaxb-spec.git"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.java.net/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/javax.xml.bind/jaxb-api@2.3.1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "com.sun.xml.bind",
+      "name" : "jaxb-core",
+      "version" : "2.3.0.1",
+      "description" : "Old JAXB Core module. Contains sources required by XJC, JXC and Runtime modules with dependencies.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1025d4fdc74ea30f15f06203ed9cdf2d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "23574ca124d0a694721ce3ef13cd720095f18fdd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d2ecba63615f317a11fb55c6468f6a9480f6411c10951d9881bafd9a9a8d0467"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4e48d9695a5e946aae21f3399a8d9e87ef25154a0bc11744a3cc88ce3287c2b495053001a555b06b6969ecf1445b0d92"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fda51767b175ab5b12c7438b9a11873fe570fa4b5ffa2c3d10eebca9d1dcada6a8ff2d287ac76017c6a546e1f5cb02988fb7e2fac32a4a95ad443e1a1b4ade35"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b7b2fa99dc3329bb950015c81fe1d2d1abb458e9e60b12b212ad1c9069342407"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1ecf6333c5c9dea54c8118d1b4706d1e904bdfbd8759e893e804880ad8285002a5a373840b0f0531032f59a2110520d3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c589a58840423bd22319bf45719559a3928ed8243fea454f6f20d5a2c67746dd40df310ca7c34bfd08da25f9e1ffcbb3385aa6c90b3678faec6bf6a22b257ece"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CDDL-1.1",
+            "url" : "http://glassfish.java.net/public/CDDL+GPL_1_1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.xml.bind/jaxb-core@2.3.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://java.net/jira/browse/JAXB"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://java.net/projects/jaxb/lists/users/archive"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://java.net/projects/jaxb/sources/v2/show"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.java.net/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.xml.bind/jaxb-core@2.3.0.1?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.xml.bind",
+      "name" : "jaxb-impl",
+      "version" : "2.3.6",
+      "description" : "Old JAXB Runtime module. Contains sources required for runtime processing.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd03551237ce80b1f8359a7657a70453"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9614f6c0cfad418a2e91a2b2b5cb98b0a1fcbd03"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5f02b1c45f8193ffa3798f5575ab6244c9ac2a7db4638040939680e994438422"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4404633909e05b240a4956048086760666838bea6118af621790619db3c62797a089bc58f57c8db080e1d0d413604e5d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e05d90890d67fec1ebcb1f5dfbc1ce673d4e4fc0f11eac3dcf189c298816b36c110fb1184ec2816a7daf790ecfc15c03fca7ffc1fdd237efc2cd4f821a1f83e7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e8d9b277aa83d9ad8b2b7ecde16932cb31613cff495833e51f9a89803f38c7c8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1e9e814a7effe1b866a06fd15625b338374cf558e097801978b0a93b108f302edda077aa58ff3fc13f9def545fec86d5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f74bda346cbf257bb38ec96a40b8d190ea82a9f4ff933dfc88b1acf66d7160febc06ef620cc221749d607345f5ecb8d8596c775bb5c7f13c5640dae8e1320c94"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Eclipse Distribution License - v 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.xml.bind/jaxb-impl@2.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://accounts.eclipse.org/mailing-list/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri.git"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.xml.bind/jaxb-impl@2.3.6?type=jar"
+    },
+    {
+      "publisher" : "Oracle",
+      "group" : "javax.json",
+      "name" : "javax.json-api",
+      "version" : "1.1.4",
+      "description" : "API module of JSR 374:Java API for Processing JSON",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6128da383f9a4a45593650fc263a0998"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c8efa3cfaeee2b05c2dfd54cba21548a081b1746"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0bdb79a0a5e0cce2d8d2d339ad53453cdf90045fe34c5e4b19b064bb1aee5876"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "67ebbd3a88e00f9723520fa70a63868e0b30f8cc63305a8c5777cea4b4a52b26818dcde9b8e8408b35a98d61b7bd8089"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5daa6155f1a9cf34657ed3b0163109dd550a3a8f1ab6b92cdbbe6473dcd6ba77a353272c17546d4f788b87abd5fd3a332a725a6f1b5f99c311dc05f851de2e3e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e4163d03ba00d439137c448baa853ca32543e5ab9873580d6dd3a96cabc0c0db"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cc2797949bde1069ccaad3fc4a15c628dfce02393823bb25ccaae6ffa0d0222b193ccd1e9ff8fc71c98606d173d326bb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "af54fa4e5fb9146097f18a9bc5acd492d118fa8b8ab292a864dcb8d1e37370d68b21f746ede20be060abe7cef6b02b575337445f858fc638485ef81795e7acb9"
+        }
+      ],
+      "licenses" : [ ],
+      "purl" : "pkg:maven/javax.json/javax.json-api@1.1.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javaee/jsonp"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.java.net/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/javax.json/javax.json-api@1.1.4?type=jar"
+    },
+    {
+      "publisher" : "Oracle",
+      "group" : "org.glassfish",
+      "name" : "javax.json",
+      "version" : "1.1.4",
+      "description" : "Default provider for JSR 374:Java API for Processing JSON",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ac67218fb9716fec512be8d0d877bde2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "943f240a509d3c70b448a55c6735591ecbd37c88"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "17fdeb7e22375a7fb40bb0551306f6dcf2b5743078668adcdf6c642c9a9ec955"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "afdfb09bce2bf863e68774ed5a66ca36927cb2e8da04c9f1946999528c9e253af3ee2d32c887660fd7a1076b906cd23e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "63f45ca81a86cce050a3096ed6d7eb7e6db7a9251095abfc7badc956e5d0d8f59ffb880b6ade8f461e655cbeac324c7a3c5a01af6e30639a9f0cb8c807552f9d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "755a7153b6feb575dd105166d615f81064e2d78d43aa497950852f6dcb282bac"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d174b22190bb75a23dfce71ef70d692ea00a662aa49b96feb3fb4a7b41241f13fea8f3f3581442b35bfdf9645cac8f99"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4a37342f7d9a787f46e4b891b24d3c4162f3d6f1f0985a65a2096355ef87831d608a5e2efac8c321581cbf626255b0e307fb2fcc13d39af9ee1922cf1acec357"
+        }
+      ],
+      "licenses" : [ ],
+      "purl" : "pkg:maven/org.glassfish/javax.json@1.1.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javaee/jsonp"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.java.net/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish/javax.json@1.1.4?type=jar"
+    },
+    {
+      "group" : "io.swagger",
+      "name" : "swagger-jersey2-jaxrs",
+      "version" : "1.6.6",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8f3c348efb8e4640bea86a229fe45c31"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2fe0639369846c9f431d36f3ffe92baa558360dd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "50b59ce76a00fa5b9dab4ee41d0a08de13f3a5a7e861f1d6d09011a4509c12a2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ea8e7d361bbbad4555e14bc17a548bfb72966626d2dc3ba4f9cc62c23efcc8c008a30f7a7b5f272a50b0d8b6579fc617"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6545e6c2f83f033ebc2572d521c9ba1fd0d3e0224bd6ef980ddaa34bfc3edba1ee000ceabab8fd1f4014b38c205a2ef8aa91060eeab9ad0c36a05d115598cc63"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7526eb205c218687c7cc59398210135191232e27812561c9486f100eb043b5dd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5c5f77c11cbf0f9cce87016b872c8175cda7b03e52aa8ddecfb91d8040c423adbfd21bb27b5a42a445e481c2e9335ba6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "457e51b9d78e43486f4116830b4d45877a32ab152596165dc0a9fde39543d6a22f78ee54c6e2099c05ff0d23fc9efb2a1c3b05d8e30dc75f007c5bc73dc144b3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger/swagger-jersey2-jaxrs@1.6.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger/swagger-jersey2-jaxrs@1.6.6?type=jar"
+    },
+    {
+      "group" : "io.swagger",
+      "name" : "swagger-jaxrs",
+      "version" : "1.6.6",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "24841484f7ba9cacb1f758b4af788c16"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "58ee98e01af20c67ef2b652c157b9786ec9c71dd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3dde693308336320ea91c8ae4cc7aa74b9116363cded286985d5582a1203bc74"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a9c743f4612fd919df831a3e1887beb39296ac3d014c183768483803269a243c6801c2c476e9496e40cb65d68ae9a4d4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "da485d20b088a085e252c2bb6e7accaed29a0e9205d7e2514409eaefad84edbb78eb709dc15ece0b1dbfb31154f12d7aaf036f5c409ce7cb53b6632e06d08e14"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "148c2994f279ca0defccdc9774e30602a3e559d49d703ea91344391d34ac222b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a4c657e333e100e2248353ea131560a9430084db8a5acda0b089c00134169ffaaf682df015cf49e77a86a57a45e637ef"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f732e1567322ec9eafbf6e6d251e212f380db81c59a45704acd69d53503ba3a9625704b24197a5dc62ac7838cd93da4aa3fa475295005ad7bf5f507b4af221d1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger/swagger-jaxrs@1.6.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger/swagger-jaxrs@1.6.6?type=jar"
+    },
+    {
+      "group" : "io.swagger",
+      "name" : "swagger-core",
+      "version" : "1.6.6",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6a15610969db99ac3ad3ca63861ad906"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "928ba12e146fab5526204d2f42f5d2f9e71527e3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "594486bc3802221204c1e1cad44e00183d18e7c7aedc68ababb1829ca969f2ff"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3e2b3d855b9690672571ad799daa683964576a8b2eba3746e3c546956dab8a8273e601020b7dbf4257d64177c77aae2f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fa6435609abbd77a6a634d4718bf8c4ec7964a82162550b5ab49e6aac097c198b558256758da88432be335a66464ebbd7c57b9c15b842dfe5d45ad552f3a11c5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "73a3c0c80599c8390b86ee6ceb1c491ffcd21a531396f82e53ccd51fa8fef9c9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "de260b7185cd4ad16c168e94a647e6780515bd291eb9ee93e474213ac6b9f8097d44e09f311ab043e9e3439182e25a5a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a985b53a210381e07bf86941fe130d3dab5db82b20e03842c9d3e219a4e5991b3ca9c5666586a4856505452a2296010aa11f11a18f425b3375a9fb886a31d8d1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger/swagger-core@1.6.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger/swagger-core@1.6.6?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.dataformat",
+      "name" : "jackson-dataformat-yaml",
+      "version" : "2.13.2",
+      "description" : "Support for reading and writing YAML-encoded data via Jackson abstractions.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4288aca5a6da299c3da07ef9b28bd515"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5601496b5b6e43d947aeeffbffadb2b18961c731"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e0a4d674e5aaf30ed3cd045e7fd94e9b82f0a7fbe94b25c8c496f70977966ba3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6504d4f255694897b8ea7eb2314d752f46b595b22605e145572ba06449c267ca30bdd497e0636388acfa740c54ad242f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ecc16dcd8d1bd8d0d4fb48d4a270e61a15c3855ad89091b110d61efad9e0d10e98f4f33104226692833e1c2837d141b3bf3d96e1cef3ed2bdc7fdfe342ebc7f1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fa3e03c75620e06491ee12c157345319ea7087c77e8bc12c3b3ad9303c4f819d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "56d02b23cb8e25d9a4a9d17c55791b722f26b2d713a99b3c2064a6ddd7d2d660b3005dcbafd583e28f599031b8a5eaac"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "464384560c85e47374bdcb64b1e4b00825ce743dd10494fda79fbba58cb34ba8ec9d3aed0b2b07c3737fcb17a88ccc5b5fb61361aaba238ba15702fec45d6151"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-dataformats-text/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-dataformats-text"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.13.2?type=jar"
+    },
+    {
+      "group" : "org.yaml",
+      "name" : "snakeyaml",
+      "version" : "1.30",
+      "description" : "YAML 1.1 parser and emitter for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ba063b8ef3a8bfd591a1b56451166b14"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8fde7fe2586328ac3c68db92045e1c8759125000"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f43a4e40a946b8cdfd0321bc1c9a839bc3f119c57e4ca84fb87c367f51c8b2b3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "aa4f7b90b3a2a83274664f78ca54b523e26ea2f96750c336a8802a6f68fc0842e3e8d36ce4f7e277e7d959aba3bb3246"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b00f52326cae804d0dbb48c0ed7f3a98cdebbce9b145f685c616e4049b65183a18e98ca29b7b0275971f9ece52138d0015bb9771902532084cb2cc07a264cfc6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4a3c20ddae5c74b381476c491716e01f847e76e28fe82dc46819e9ef122c70fa"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d3cd269127dca6042237f66cf3c3557f87f395d0286712e74da908d11ffb5d4ee7c4960e29e61db346a8376e515d59af"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d1e848c74efd4dd2ba5d4878c0f9df6144926b1d413f44ba2881614cc557a18479eb74c8f1c3392375cc166c94acf2adb7f211f902a7e5acfd7b2966bec70f26"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/src"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar"
+    },
+    {
+      "group" : "io.swagger",
+      "name" : "swagger-models",
+      "version" : "1.6.6",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "54bfbc7c7337a0e5dd280ea37dc174e9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "77b33deda8155ba6aa71081a29777daf25f8b805"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4f1f89c247ea00c1d23e64ccfb8c8cc53b3f40aa31ad2ca6d73e83052f13a666"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cb8fc20a71f14b8a14d8cbe1be4e367b499c69d336707a60a1c89973fccd1d3a2c985cca337d790cc31cc29202f5c431"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "728527396a37cc15ea25cac958259a81522240d0f603d53589d382f5dc3ecf24c8082ac5bf4b29d4ef927e1a997f9d7b00870f6b6f9ecb22c6f5187a7ce055ab"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fe75225dbc49fbfd4ff33a9cc50439bb9cd04b4b7048ccdd6e52a430ea4422d6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c85968ddfbefd9a39366dcda557d003b591d1811415acbf860abdc808d340ff5658fa5772a75d3b31441865318033c72"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b8b170668c0cead6823d5d9342a49e88e280a3455a6b4934ae07c7472bcdc0a34208e11792223ef95a4f480ec5e2d75242532226853fe092eb13bef1d5952b80"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger/swagger-models@1.6.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger/swagger-models@1.6.6?type=jar"
+    },
+    {
+      "group" : "io.swagger",
+      "name" : "swagger-annotations",
+      "version" : "1.6.6",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cbb8a08e3a8f61c392adfb42d19d3d03"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "35dc351ef7d38a647d0b64aeef203984437ecff7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b0e63c6a637ffdbe75f8beaf98068b0bb947b6941783211651ce205bc633f762"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3907b5eb8228c88ebf28b9fd9996744777aa0794142643a323d09ba06f0ccf6568a641f00bf2335fc4f72357b0fa89ad"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b01e0a027136aa09eb56199f3334a083a8f46608ac1e22d233e1bbcb220bb8921197642e4fa12c23a554532560c80fec32cebe95c3005e31adc18d0272f5ba19"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "19c161ac749fa6f38164309b3e1c7a1b9fa1f63732b954761281da8e272bc42a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "02c556ae7bae2c0f66b4fba912243f8637b16dff209b5e504128dabf2e3efe578202b7b543326184d4fc5031b508bfdf"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c09d1d65fd9aa42299b008e8700b881319c705217c0d101e06835a7d0bf4bd0fb2520dddd3058df321c0a75d2503cc53c4ac6e8cfb199056ccde425a8814623d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger/swagger-annotations@1.6.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger/swagger-annotations@1.6.6?type=jar"
+    },
+    {
+      "group" : "org.reflections",
+      "name" : "reflections",
+      "version" : "0.9.11",
+      "description" : "Reflections - a Java runtime metadata analysis",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "aca303b243a6c2225685b992ceea1cb3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4c686033d918ec1727e329b7222fcb020152e32b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cca88428f8a8919df885105833d45ff07bd26f985f96ee55690551216b58b4a1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a1abf286e701b99c877d4904031f5954e7c2ec314615b7fefec4763e404b9c5364fe0f972f9e2d609fcd761898711ff2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2bf16b69319ef2a3374f4170629fe7652bafb83971a81a55f16e15735c688f6942dc82be5a2da9debbd1316a05f6192a020d1097571275bf7a0d266ee5c063d8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bb3bfe0d12dcfe428e88b13cadfb9954b9f3327e84bffd6a856efb3f8aec8473"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "13704be7f40599e4dfa56d9e1368b8df98f09e157203b5d83e11c676755313f68ae95e565f15d5adf3775c7fcbaf76ba"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "448c13aa105204ba1f41246c81457a6d8e78c6a14355a384e6c2fa114dde64fa717b317c6cedae8afe5a9bd8d0b77309121a7f3233df90f8f9f32d82ddcfdb97"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "WTFPL",
+            "url" : "http://www.wtfpl.net/about/"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.reflections/reflections@0.9.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/ronmamo/reflections/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://groups.google.com/group/google-code-reflections"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ronmamo/reflections/issues"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.reflections/reflections@0.9.11?type=jar"
+    },
+    {
+      "group" : "com.h2database",
+      "name" : "h2",
+      "version" : "1.4.200",
+      "description" : "H2 Database Engine",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "18c05829a03b92c0880f22a3c4d1d11d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f7533fe7cb8e99c87a43d325a77b4b678ad9031a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3ad9ac4b6aae9cd9d3ac1c447465e1ed06019b851b893dd6a8d76ddb6d85bca6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "78b5bd1e6505df20eff87804133dd4d79b942d7081e523cac83865167e608f89693a60cdc9f65b8eacd8e7e13ce6a9c3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1ed996ff57ac22ab10cfcd1831633de20be80982f127f8ab4fdd59bef37457c0882c67ae825d8070c4d9599de93e80ff3860ae9ab66f1102f3b9e8eddb4d883"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "28be5b162c8180ca7b407e32f8d6c39b631040358ade461952292227e0b53031"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "32db56197f859d91c943e569138bb396112c318a004a518a2f4dece60390343593b892b033db0f4a3434c9a071826a07"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "02349318b92c2125a1baf5049be24720e16859efc203dd9e9454c37afd710dec9e6f8a6ecfeaa575d6d51fb34001eafb1b242775ee9bc8cd7e502159d6243ae7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "MPL 2.0 or EPL 1.0",
+            "url" : "https://h2database.com/html/license.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.h2database/h2@1.4.200?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/h2database/h2database"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.h2database/h2@1.4.200?type=jar"
+    },
+    {
+      "group" : "org.mindrot",
+      "name" : "jbcrypt",
+      "version" : "0.4",
+      "description" : "OpenBSD-style Blowfish password hashing for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d2b39d874e0d512f85386a72b0083682"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "af7e61017f73abb18ac4e036954f9f28c6366c07"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e183f6f59404fc1e12073cfea4ace7ea103c900463cd21fb609a7c617ecdf624"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "66a24af2134e6fcee1f4232c2c4bab43ab97d0c8ffbbc009f9bb0e5ef2a7d8795a6da3c6b47c583675b98036958aa729"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "95ffe1f6593f83da047ff289a52b5ef73adcaca4a9a990a47744fbd50a52fce39958c17ed393e95d64093b2acbcaba39ba0b5b983a2e0ad98ce5c6e9282a67cd"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a347c842385e1d76780f9afe2200a7b9815bcd873b2a9fdd2652d0b0a5e0d324"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "33cf5e13897f25c525017888e7fcd2faf9a0f25135be03a65dd154feb11455e33c1df31963470b2ecaaba5267f6ad652"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5a71c6f1fde98865302e8c9ee6c99ace9efa220c0193bcdd56423015d1c73e54bd65f19a9a3ba3199b242589eb9ccc96b1d6c0d413387f8e8fbed7c691fc8790"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "ISC",
+            "url" : "https://www.isc.org/licenses/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.mindrot/jbcrypt@0.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/djmdjm/jBCrypt.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.mindrot/jbcrypt@0.4?type=jar"
+    },
+    {
+      "publisher" : "Connect2id Ltd.",
+      "group" : "com.nimbusds",
+      "name" : "oauth2-oidc-sdk",
+      "version" : "9.35",
+      "description" : "OAuth 2.0 SDK with OpenID Connection extensions for developing client and server applications.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9f2126575ebd24abe5a82bc0193da0d2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7bfdf91bc4ae265f6c49a367bc0ed0e47d0e3a97"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "95a5b7a5054fc281061b81d2354d0b7b66a862183e7d85d75a82c5ddb8867293"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "eb603c07dfc6f0cb4d0f31fd5d58e9a0af531ab9f66a68f7a01877a4ce15b8fe905e8c6d33eb663cd4b7e7ae1461e775"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4d6a751a3fac219f9a07f78b823640671ebdeba407bb9b5303fef8cef8a8e99c0eea470c63f888d7772d62bb184e698a0280a20850a486a31a2324ca479bf711"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "531d5199eaca6198b5838cc3ebb56f091d19121faa80dcad78358a017d60d0ea"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "61d3d807df1cb6f8ea7bd7d159a01611e5e76cbc124861f3ec4dd5ad6493b45ebc3039bce6f9039cbf06f3b4f0a673fa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fc8595e408d00ea1bfb0c8d15655de962cfbd16d39011286ea9b382f5b71c664bedd40984be8569c8b5f7ac35b830c1864190c5d6930bd92f762025deb9f5f03"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.nimbusds/oauth2-oidc-sdk@9.35?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://connect2id.com"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.nimbusds/oauth2-oidc-sdk@9.35?type=jar"
+    },
+    {
+      "group" : "com.github.stephenc.jcip",
+      "name" : "jcip-annotations",
+      "version" : "1.0-1",
+      "description" : "A clean room implementation of the JCIP Annotations based entirely on the specification provided by the javadocs.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d62dbfa8789378457ada685e2f614846"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ef31541dd28ae2cefdd17c7ebf352d93e9058c63"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4fccff8382aafc589962c4edb262f6aa595e34f1e11e61057d1c6a96e8fc7323"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "88b0ecfde391a3d8468349c70e1539569768dfac3233dfe0b4660904df04e6c6bf26ed9c0784b9b22c122c3448e2a6b6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "02fcd16a30d0e68b3e9e4899731181c6abb7117baa15c096ca940e01dde08bb86101cbeae552c497f8a90d923b5fa2f2b6f3850baf8dc94dbd399887924a9069"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3e79c8f58865d2d58a5311a8bb45772007f07e7f3ed2780784d1e4382dc934d0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "487b53f48b55b98a61ae60abedc43543887944867aa6bcb78d5ed46e2d0d7c19510c5fcadc362d939313feafdcfc55e1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ff32665e1b6d8176ccc7e8c836ca7343c2603dab053e42d79b4258d51a14ff63933c67d24034169ac91e11ebda21cc2c84a2a540072e656d2a8e6fcea7808421"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "http://github.com/stephenc/jcip-annotations/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/stephenc/jcip-annotations/tree/master/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar"
+    },
+    {
+      "publisher" : "Connect2id Ltd.",
+      "group" : "com.nimbusds",
+      "name" : "content-type",
+      "version" : "2.2",
+      "description" : "Java library for Content (Media) Type representation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "135aaa5ebcc12a45f4b3ff08cb6fa46a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9a894bce7646dd4086652d85b88013229f23724b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "730f1816196145e88275093c147f2e6da3c3e541207acd3503a1b06129b9bea9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c1cd98d963a191cd18cd3b7352d91e48ce5de7982a77f0cc4660b7281d309673815f41f9b2be397a816b61af87d7661a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2b3d7dbf102645b1b6c11de967a877eddb95e8d38e4418cf0c4f7112720cab72f8af8a02c1e6a290ac737186bfb57d5c6db907ac6e7580c16c626f02bd7eeae9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "10a5860f4da5c00e83300378e3e65f92d70df4b18d2bbc2c3a97c75b7f9c922b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b171815441fa1c9d8961a4e5de615f8888c23a5bc6c19380b3647ad3676e1aa1ebf7a3b63c3db9225d19249293ec5864"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bba6d712566f3e63ebcb998ee40b556004c50ac5e2cc818b01e45fd1d23929234ddb57097cc8897835810bba2d7332e0e429d5cb0fc54d5ab9d7e4715f88af17"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.nimbusds/content-type@2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://connect2id.com"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/connect2id/nimbus-content-type"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.nimbusds/content-type@2.2?type=jar"
+    },
+    {
+      "publisher" : "Chemouni Uriel",
+      "group" : "net.minidev",
+      "name" : "json-smart",
+      "version" : "2.4.8",
+      "description" : "JSON (JavaScript Object Notation) is a lightweight data-interchange format. It is easy for humans to read and write. It is easy for machines to parse and generate. It is based on a subset of the JavaScript Programming Language, Standard ECMA-262 3rd Edition - December 1999. JSON is a text format that is completely language independent but uses conventions that are familiar to programmers of the C-family of languages, including C, C++, C#, Java, JavaScript, Perl, Python, and many others. These properties make JSON an ideal data-interchange language.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "20a8427206313ed3aa85cdc47f730415"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7c62f5f72ab05eb54d40e2abf0360a2fe9ea477f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "174a9ad578b56644e62b3965d8bf94ac3a76e707c6343b8abac9d3671438b4b2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1426a97474b44c58d1f30c70afec9dd658207d89ce5067932bb4dbe2ddb31970d31d2b682631e208d4b7f435b97b14aa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "13f4609fe72df98c81f86d25616e5b0ce1426688aa5a9dd953733fa98a8deadb87b3e69a77741dc9d31dd4485265d3b9e4ec71d99346e4a7558f2500f3677714"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "60607471f4e886f0959dae77ac61ffd1b5662f9d39bd7efc552290e90e965c38"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f80d75137a6ed01e53a7a168a39d33b15c26de832268d61a80affa7f9472639f2b19165fb4fdd1b6cbcc2601cf1b413c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "84f2e3c1840bbec18ad0fade94791a759f9a2e0de4dfe3a52fc9a54d2a7cffa94e8645273c7417db7ebd9e3a35884eaa6381ca6a6d5d48eae5bb0563b741247a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.minidev/json-smart@2.4.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://urielch.github.io/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netplex/json-smart-v2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.minidev/json-smart@2.4.8?type=jar"
+    },
+    {
+      "publisher" : "Chemouni Uriel",
+      "group" : "net.minidev",
+      "name" : "accessors-smart",
+      "version" : "2.4.8",
+      "description" : "Java reflect give poor performance on getter setter an constructor calls, accessors-smart use ASM to speed up those calls.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e5761631acc11ded0255af1249937e85"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6e1bee5a530caba91893604d6ab41d0edcecca9a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7dd705aa1ac0e030f8ee2624e8e77239ae1eef6ccc2621c0b8c189866ee1c42c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9f3a75bcd9a9c00dc7437d0dfcf075d411c4bcc125ab6761f0bec3f00eec4d0e5c7d0e7f304f69d3491a12f542ee0823"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "45405c083334b05efa07572497b9d510ca771af32ce93d960be802216a9714ffff8418384ea48e197d3dfb6ebec4ec3e610155841e8a257a7fb9a4bd6a1b668f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7017996397067155374396bea86ac9871f6c672da91c91faf2ff8aa8b154624d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "764e26adb705500f3e1a81b8360ce2c9d2c23ec09e3fcc9b673378d5e10fb8846843547ec0c5383e2bed1a20c48aaa43"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a1050d7f9e728546989c62e1a9ca7b583070012d766e7e77ed0d958a2271cf21326b8ed8d2d4690277e8da5b7ac3599a617ff68418fb5be903f6b59ad21dae8b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.minidev/accessors-smart@2.4.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://urielch.github.io/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netplex/json-smart-v2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.minidev/accessors-smart@2.4.8?type=jar"
+    },
+    {
+      "publisher" : "OW2",
+      "group" : "org.ow2.asm",
+      "name" : "asm",
+      "version" : "9.1",
+      "description" : "ASM, a very small and fast Java bytecode manipulation framework",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "54b9f5d15e4877a4ea4cf9ec48e07afa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a99500cf6eea30535eeac6be73899d048f8d12a8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cda4de455fab48ff0bcb7c48b4639447d4de859a7afc30a094a986f0936beba2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9f936b2ffa1f1fccfea3c53b5206a6d94fa193aa12a0cdec2f0baf98f0cb2a0b699e99291c60be44fab6b39a1f6f2e10"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0a586544f3053ec8425d252b6f7e3e6772f010eb81d75020b4fd4759a561a4534dab4f805ffd18130594d1abbeb1ad7116b9d3a1e2e643d427e12bb866655954"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "be955c19490cbd305f4168b6ead4116659ef6fbdf96954d2c124ae8d3f4c4739"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "142b7dc3b521f681f41e8467cf292ba87ed6bfb88d57372bf6d9cc3e3042cc49fd735b367d2336ff43a3ccb64b5bc87e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fa07cc8156842f8c18e286517fd751b3e2d51be13e2e8181f1b75a6c1f98715eb3ef583cbda01ca95ca0806ffc9817d4d9ab327dca6a16152c367a319e128fed"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "url" : "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.ow2.asm/asm@9.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.ow2.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://gitlab.ow2.org/asm/asm/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail.ow2.org/wws/arc/asm/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitlab.ow2.org/asm/asm/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.ow2.asm/asm@9.1?type=jar"
+    },
+    {
+      "publisher" : "Connect2id Ltd.",
+      "group" : "com.nimbusds",
+      "name" : "lang-tag",
+      "version" : "1.6",
+      "description" : "Java implementation of \"Tags for Identifying Languages\" (RFC 5646).",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "03eaf0cb305c695a131d1494d48cec6a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ba96ae591bf885f130a772794f07209e2bdb9fb5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "409d056d9e5f566ac267f980e82027257dd864731abde7af8eba1f65213fbf4c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "026890f25031c23aed9deb69f35714722962f94193954665839fc2dd20bef7e9a602e97141553fe3318b2246443baa57"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9960e0e9fd919432d0d0b0e75d3630d4d11fed24406f8fe635f93280be4fa9038e8ace9a758f7844218ecd3eada25e2e4906d3b4b37672c9feb69d70ba056ec4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "df7061343539489a3ea3f72871885bcce00bd791780d45051497dfc5fed2a4bc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ce5cf63a3aae9367ab57ec73d56f71a5b7f49d821a52343b0d7c684631e57a865b1fcefd7a674ad0c30991ed2a3dc098"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ee28194eba420f527364ff1a215ba1c0a092f26df3715b6fdd3206794aa8047b0fc16bb219cc02d64aba539242e8f4fd049045722b2c1a86b03293fb945a64e0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.nimbusds/lang-tag@1.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://connect2id.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/connect2id/nimbus-language-tags.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.nimbusds/lang-tag@1.6?type=jar"
+    },
+    {
+      "publisher" : "Connect2id Ltd.",
+      "group" : "com.nimbusds",
+      "name" : "nimbus-jose-jwt",
+      "version" : "9.22",
+      "description" : "Java library for Javascript Object Signing and Encryption (JOSE) and JSON Web Tokens (JWT)",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "76be9e3b0a601b4b69bffec9f4966bd7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bed63628cd31d8641c5a1b29609a965179ef91ec"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f7c80eb70d5163e13452f76e85d4e4782e4ae2d8dc46fec3165d63a88f2c0799"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9390bf27e8bfac976ccf6b06c2dc7fc4affe951014171eb6a1071cc407e723765daffdcca75aed00a1c35d5ab28f1234"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "907340997bee6a293c7e518df73210548c87a822b3548fb4e02cf528f4eb3bbcda419f4ffd3535fab567f180b2aba3d480644048b221f7c61e7b2211b181b4f6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bd944f33ee64f7ff5f3e1873de424a3bfd24ca574009b197247d42c529670eb9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0558cc46dfc9a686cee1464a8e75dcb95f75051b90d218a991153976cc8ecbb7cb47dfb53364992935801239132a1d50"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3487a0534d206fba76d58b46d796eccb53cd9fc3c61f7e8326602f9add788d41ce7ebc947fe9e4f802d3f5a556e5a3489a6afc95e87a7052484d75df9e657bf3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.nimbusds/nimbus-jose-jwt@9.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://connect2id.com"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/connect2id/nimbus-jose-jwt"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.nimbusds/nimbus-jose-jwt@9.22?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-databind",
+      "version" : "2.13.2.2",
+      "description" : "General data-binding functionality for Jackson: works on core streaming API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "055c97cb488b0956801e13abcc2a0cfe"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ffeb635597d093509f33e1e94274d14be610f933"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "efb86b148712a838b94b3cfc95769785a116b3461f709b4cc510055a58b804b2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "50d2a67dd355433fb1e0643beb834dd0d507c4dc6a15f38add919ec6b78cc43b24657100e9da1da05a18ff944279244c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0e9398591d86f80f16fc2d6ff0dda3e7821033e2c59472981eaab61443be3d77198655682905b85260fb2186a2cf0f33988aff689a49bb54e56c07e02f607e8a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "72ce2fa2fbf5f1cd2083dcf79922fb4964fbcea12e2bcc8554addb60e063f930"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "72ecd5ff5f95dbcc6492cdee3dc0deec5336df4411020337cfab5c971490551a859dfd5b5bd33b340ff1654e62f771ee"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b4eb83a63cc54b6b893e75070e552b21125e5c3d8f970ffdeff992fdbe3e67ea798c82b6e70455992203afca382d7a4aa251a97cad8434a34a77290908aaa898"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-databind"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.2?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.13.2",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c56433d75479665998ccbd50678480fa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0a6a0e0620d51833feffc67bccb51937b2345763"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9bfa278ad05179fb68087851caf607652702ca25424bec8358a3716e751405c8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b0782e4b1f4486d7ff10cea5dc3e67a4bcc557af770698d41783c91fd023ad00e63ea5af6c1565dee48cfc15d2cfaf06"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c5451f5c22d09f892ff22b840e46929f4d1f5dcd4022b4170f3262d8d85d0819d87432c8eca86215fdce7b5cd10eb99ef4b2cd498af5ff5cf2b48a2701181abc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4d05dff4543b8ee7c21c6847dd715c2ca479ea3165c9a8d785204334e224d564"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1474a077534ee52eb75c53618bb504ff43d9c1c29e83c036f62edd2a85a98e425ffbc5576b607b9a4f14bde0cbfbad11"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "961b99eae0b246e505965f43f2826588bfa27a48dad3472d167054491952ee75b6981051ac7208ba4d7518687973f4d288f84da218d6ac0f2bebf1e52d082768"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.jaxrs",
+      "name" : "jackson-jaxrs-base",
+      "version" : "2.13.2",
+      "description" : "Pile of code that is shared by all Jackson-based JAX-RS providers.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "62ec818968fe8d83675af3b3cb179b38"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5fd849945a575d2f7748d2955c24963d3ce21d5a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "440363f3f8e0e28a5836099f292b0331aa87962e3facabfbdba4ee9b7cc30611"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6f9cd1528cf53d1980cc748cedeeb0ce658fb0cba44af9e9ae54ac8a58f1bc9aec47dba7ee6c38aafb816701896bbc5b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0a32fbe213e2f491593695ea556c8a508e0e2b24d605316ecd506e1e6d0fc9718777aed7ee78583b9eb7cc61396540e19ecda325be4333c479c1f8c9b373e2e3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b163835a4b586cefda32ce0fd6fb01c001e02c10d9fa9cc09bfe5a1923426b01"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b11db4f808eb6f4483424915056a45b3460e8ea1a0d54333a6c9ed760be7924e126eafeaa2c4805772355643ff65ceb3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "69c5b6ddba8b933d181252c3a773f87927d2e09bd6f3fc6fdc0aed8dd3d36b3546a833f21cabcc6be9c979d0159d2826462faf82f7e1249cad8b86ff89feda29"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-jaxrs-providers"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.2?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.jaxrs",
+      "name" : "jackson-jaxrs-json-provider",
+      "version" : "2.13.2",
+      "description" : "Functionality to handle JSON input/output for JAX-RS implementations (like Jersey and RESTeasy) using standard Jackson data binding.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bde0662b94be1f1c307dfad08afb6051"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "07bad5fd16d289d746e375c3ae9bdf88357d4aa8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5bf8978fe8b7bbff9b5e03ec63dd4b6bc66195bdc408da799dda8c0d0afe62f6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "38585958c88e009ace73e6e0c00f7127cf438c885f0f50867719950b895aa0fb6dc5777e8deebba77c59d392149e01da"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a37493a827808dbe1813f185a911746d4be3270ffba347a8b3b0c87cd17ecf4ea265521d9ec97fdea4e3f88d215529a51cb49239964f6888cf9befb647004956"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4334b2b4b4603881a62e234b0fe052cd3b8eddac6df81cf5fb8b44752ed34ffc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "44439fff503207847cab12867941d76ad41c29b70fc40c984eca8cb4741b3e79246348101cf05dee92dbc8b31b488db9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ca6f3a12f2260306be1c5b3c2f07045295d3a4bda2fbb6243abd56340ae1285ad8606f2dff29f81a5060cfe599ea17011ad7049d0214ff522e2cfbc0f15dd7a9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-jaxrs-providers"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.2?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-classic",
+      "version" : "1.2.11",
+      "description" : "logback-classic module",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e13679004cc76ad5792f275f04884fab"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4741689214e9d1e8408b206506cbe76d1c6a7d60"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4d8e899621a3006c2f66e19feab002b11e6cfc5cb1854fc41f01532c00deb2aa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d480881d1a0d58c94aba0b719d56cd492147bc6481b67370dc7426ea7a81326af5b19f32d6a95fee714f37b90a5eed76"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6df8b42396c5d3257f11fb19c280533aa28d66e647115816d4ebfd6a58c9b5adf0e098504772261b29435df75b86cb2b9a47f846ed45d770179c9d10f39941de"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "60c1dbe51066ffb3885673255a279e8894c89fe26f079180fa992478c1d9b03e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "070647c93da744f04cc13ab3f1958c61a8b1e219fe221ed0bf251e4cc97563c64be323bfb3a9e2fd4839e33ded424b21"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ce16fae69767bca975bec0d7dd0ceeb40c15cf034a4a949721c828a0f2c25cb9d619c4db3f986f6d9805d5b76d27b8926c55be5579522cd5ab3fa5e69bb68aeb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.qos.ch"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ceki/logback"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-core",
+      "version" : "1.2.11",
+      "description" : "logback-core module",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "115da115b5e66ef64e774ec35af1fb1a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a01230df5ca5c34540cdaa3ad5efb012f1f1f792"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6ce1e9397be8298a2e99029f55f955c6fa3cef255171c554d0b9c201cffd0159"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2afd896ebe6333d99e5baa553d80b7851d8ff51c06c725267e061df81bc9a878b74a65394699ae853f9738a08963aa0a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "86b12a74c2a822a12ba2e9a7b0db5013803f18784a3cb1201c95d5f7872a6aa8cf06d5861a5c35777a7decc7ea26df7b4388fab3b3b71aab7274527d9b339318"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c23af1733b972e958369a2e14372fd2b306d4f552d7ae5ff6b9dfad3c14611c6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "43d39acc5608b60d671c000bf6114f4623d3057399142abca01b0fc2381f2191479a2f0dd74f812223b66f57fa48fd9c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c7f6357d32a3b9fd82dfbd162c3a6cbe4b4909ef530e956bcd18649b2d3624eb51c5a71fee54533a9786e87cf1ccdc693f563ef6e3c6fbff7beedbd1d670f9bb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.qos.ch"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ceki/logback"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar"
+    },
+    {
+      "group" : "org.owasp",
+      "name" : "security-logging-common",
+      "version" : "1.1.7",
+      "description" : "The OWASP Security Logging project provides developers and ops personnel with APIs for logging security-related events.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9f11b84aefd2f2dcf48f8443a6213619"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4717c0c2225a2aad898b2fbdf717ec6e034d48f8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ef9c6e4fefcf8ffcee7590239a8e8c56b192fc71c183fd8a943cf177e01b07eb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f10fbb5250849634a79477a536eb7f4a07aa66d5d1234e18caf5dbd2ab9473a4e26baa4fe381af9240eb6f9471cbb937"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d30fa0cce5b75758289a255946f165418786d96c5de3dbb12084d6da6bb75e556e43e002050ea114e3adb0ca15dc16e28b6218f5b2fcf993eadcb37076fb522a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2c7bf9e688071240437f106b05955c298c9ee42f6c119cd918460af5a3a82a48"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fee72e5c1e41740264f6d0f1fcfd72731c92df25af3d529509a006ce8330430390ab1139b8798c8cd6b78bcc0656d4e4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0ff1a2d6da110ca1a1713b052bab481bf052033e9cef7362a69a30e485d4a8ae8ba78ecd02278f4f81558d9cd2f12402108f82668754eade77fde3670433740c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.owasp/security-logging-common@1.1.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javabeanz/owasp-security-logging"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.owasp/security-logging-common@1.1.7?type=jar"
+    },
+    {
+      "group" : "org.owasp",
+      "name" : "security-logging-logback",
+      "version" : "1.1.7",
+      "description" : "The OWASP Security Logging project provides developers and ops personnel with APIs for logging security-related events.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c1148e1a96d53351f39b407185a59e06"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e609fe8531b96fcd559c9e146342aa3a56d16231"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "100f5e85cbf9cf395983d85355cc17ed1d19d77176d93c58a14f339e62382168"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8502c6a84746dfd8b9960d599cd476dd3b2c0017b2e8eba169411f7adbfea4236323ada03cb7e005812456976e673a7b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9bdb7df787ae5264e509082aa3b6f865ec543801587270eb582c3cb430a15f019c24a25e5a1d4df462a2dec0e6e82ce636807b055d5e72b73d67d90805e9e5d1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5a2f21e6fe6fe4bc45c439d7dbb5a16d07cc56ecf15b10a60125ee777bac1122"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "283c28b7760973dc0195fcd2127294c4c77a2a8c95bcc597401f00ffbd8c5367788ae9c9b6874deac178526fe93c1265"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f2fa575c8838d7dcb5d11678cff9afaeb65d3bb227f501cf86541e4131c7a3cb72921d8ff8d28f91f7a6d5d3ac08d579f1fba73e8a7627c7a46371ed0a62fad9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.owasp/security-logging-logback@1.1.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javabeanz/owasp-security-logging"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.owasp/security-logging-logback@1.1.7?type=jar"
+    },
+    {
+      "publisher" : "OWASP (Open Web-Application Security Project)",
+      "group" : "org.owasp.encoder",
+      "name" : "encoder",
+      "version" : "1.2.3",
+      "description" : "The OWASP Encoders package is a collection of high-performance low-overhead contextual encoders, that when utilized correctly, is an effective tool in preventing Web Application security vulnerabilities such as Cross-Site Scripting.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "541c66032b50af0c60c1723bdb900d11"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "35ae93be1524b161525da2c9a110019616f67548"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b09e2cd5c36a7127e091df9be628278b1166b40bc08b9de8196ccddb0cccd67f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f076cc6675cd055ddb58a5356b28de7268fd96d34393767a8b33c055b7836bdf302c6828e7a9ae61ff19930fc7015fb2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ba7887259007272c533228cec1e2c5caebd639ef05b7b8925be6a0b5a7da5859e82489af4d462153e64bf2ce1234a8d6caa606fc6e42675a41cf7a067cfc5f6b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e909463a15ecf0cd8b1354a89357d5efbf3f8277d5acff4922f38b46b05c0be8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "47bf29919d6cc83b4010de59b1403e3f9d795c1487bc77da58e2f1607ae652a48c1d2e6479f63b19e28345e53340654c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "269c329b2d1c308418239281b1df9c10885e1c49ff9ad54067e2b8bcc0e18bcd8494ad82d7ac28c354053b00df8b3f6906f9c78ef32ccf313ae454f4c2463891"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.owasp.encoder/encoder@1.2.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.owasp.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/owasp/owasp-java-encoder/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.owasp.org/pipermail/owasp-java-encoder-project/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/owasp/owasp-java-encoder"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.owasp.encoder/encoder@1.2.3?type=jar"
+    },
+    {
+      "publisher" : "OWASP (Open Web-Application Security Project)",
+      "group" : "org.owasp.encoder",
+      "name" : "encoder-jsp",
+      "version" : "1.2.3",
+      "description" : "The OWASP Encoder JSP package contains JSP tag definitions and TLDs to allow easy use of the OWASP Encoder Project's core API. The TLDs contain both tag definitions and JSP EL functions.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2aa0db8eb0a3c2294ce81e5c525c5b0d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c0ff3cfc6ef21c8b43b045268203147029f23505"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cca9152d68581eacfa86c0518590b1f153d1daf505f1318f3711f66049217b3c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0207fefe84778df49ea316cec19981237f0a6e05c6463c6a0954a144acfc46d968397900891cbc4b94a1ea105633314d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "99566f092be000f84c30ea5f495995824aba91dc5d377c8b4bbc3164f1fd921d2f3c54fa956f03701dab23afdd06d35f713a46f4d0e4e47ca1a41365281254f8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "21edeb5020107f2f3558b1d6aa6e7bce7bb50d1977cd11201ee59a67a21fd5b5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c285915fa4ffd67ce5d268fb98e14be84082e656143007f3beaa169914674d25f8a22f9c67b28dd7d4adc767ef825f98"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7a4681e587ffb9f6c28d659d2f8f3d55ee4e9d51c640ba0c57e45362ddf2a44edeec7d5d7fef4ad6d31fadbbeea1ffa69c93485a04439afb542bbc6536ed30c3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.owasp.encoder/encoder-jsp@1.2.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.owasp.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/owasp/owasp-java-encoder/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.owasp.org/pipermail/owasp-java-encoder-project/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/owasp/owasp-java-encoder"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.owasp.encoder/encoder-jsp@1.2.3?type=jar"
+    },
+    {
+      "publisher" : "Oracle",
+      "group" : "com.sun.mail",
+      "name" : "jakarta.mail",
+      "version" : "1.6.7",
+      "description" : "${project.name}",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "17eb378c9dd574be23e71014ce9d5d30"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "319df0e9d536c1a01acdfe49b6e82b97d2393073"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1b258ef45fae93059b65d0a0dd109e59ab93e8cd8a735ff66b2ba85f870d5150"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "868a5f77973668eb2af92c8a32fca8b0d80860be3489249b4e93246eda5711aad64eefe0f97ec436c57e2cb0cc89f9e8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3f392a6ae3eada47c37b67d92f3cf39c609a5309fcc97eb271bcf079d0d01f5973c0d32458a875ac1186092a113bb452439f7b7b0edd58a5b3aba5f775e9a001"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1c64d48a7aadd0b7a75fd93d642da723921763ddb215bd78cdbe05d01e80541b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "83395046d0ad4d01c7ca16fb35a0591bb26367583e65dcbf4f11b9be80241c117ab61859e4e4f4c31883caf6539613af"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dc6c43c485a5b8eefc8211862b44195bfa1d830ba4f4029b7fc68eaf08dccb8909a9cb93772fd81a3b7c785cbc873c046c10d1c391040282cb58595bdd0ed3d2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.mail/jakarta.mail@1.6.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/mail/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/mail"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.mail/jakarta.mail@1.6.7?type=jar"
+    },
+    {
+      "group" : "com.google.code.findbugs",
+      "name" : "jsr305",
+      "version" : "3.0.2",
+      "description" : "JSR305 Annotations for Findbugs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd83accb899363c32b07d7a1b2e4ce40"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca0b169d3eb2d0922dc031133a021f861a043bb3e405a88728215fd6ff00fa52fdc7347842dcc2031472e3726164bdc4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bb09db62919a50fa5b55906013be6ca4fc7acb2e87455fac5eaf9ede2e41ce8bbafc0e5a385a561264ea4cd71bbbd3ef5a45e02d63277a201d06a0ae1636f804"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "223fda9a89a461afaae73b177a2dc20ed4a90f2f8757f5c65f3241b0510f00ff"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9903fd7505218999f8262efedb3d935d64bcef84aae781064ab5e1b24755466b269517cada562fa140cd1d417ede57a1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3996b5af57a5d5c6a0cd62b11773360fb051dd86a2ba968476806a2a5d32049b82d69a24a3c694e8fe4d735be6a28e41000cc500cc2a9fb577e058045855d2d6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://code.google.com/p/jsr-305/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar"
+    },
+    {
+      "group" : "com.github.ben-manes.caffeine",
+      "name" : "caffeine",
+      "version" : "3.1.0",
+      "description" : "A high performance caching library",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c58e84bbc64160f07ba37a3a46b6d3cb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9205324f069a5349a4e78a5e77b89038699e4608"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "84e30d3756e667b33679fd5b57e5c84f7ef3e57f40eb094e54fde1a9749a9547"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "67d8771ead3ff8e364cf2256c80d1746b22c1cb35dfd9f690a244dcf52cc087b6906f77255866aad95f41276fa3606bc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2c51f6055d4fb5b1719d74e095fcfe517b3d459eefaed0056776480ae2c75aea3c5405275c0356d3d05adf5a7353e86cac15db50b38d9d42b87b202a4e8bf0b1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "672955fdef234c5171955f9120b0274d6de894da3a299b9ca397f0d7717ac88c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1bc1b5e30a7fce791f1e85c1194431847732d18472d544f78c65982f8f61f8542c0e6081d4b061d0746f6ba7124a6086"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0c9938437d475538ffe102f5ec5f87cb5efcd5c7c1f0c2511c2585dc431d031554de085e729560aa4c13171bd4285676dcc092f5514ba7edfc151920a4486d72"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ben-manes/caffeine"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.0?type=jar"
+    },
+    {
+      "publisher" : "Google LLC",
+      "group" : "com.google.errorprone",
+      "name" : "error_prone_annotations",
+      "version" : "2.13.1",
+      "description" : "Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0f28a56be37d460d0bec1d95641d98a8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0c11e02ad8f1fadf72cd94bdd92cd27d156c7cc4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f5ee2aac2ee6443789e1dee0f96e3c35d9f3c78891f54ed83f3cf918a1cde6d1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "47addfa849a5ec78518df0b38922dc286629be5fa7d171bb4f731ae16407247e7549267af76ee4d69a88ecc48ef20fd9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c58299e6509cf6f58965f9b6382be54ba3fb2502805365e79051e6143a95055de8fed0ab4bacb20fa8fb5f6bab3045d560310c7b04fe8aa48ef4aa96575074e1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bcfd70878840335d66192f4173a3fbdd1b834a85b9fcb6ce9b51520979168887"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6852dccc8b6b3d152baf34d39e53c63e9e8edc9e28b0d1b81df5a5627edb170a9d3da92438a4539a5bf4401b8e1bcc19"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c7da95755d5938f125cec6e880ad96d26f1a5a8c1147b5f0780e27e3520d1d858f429d55c21ce6ceb874b6b57daa5301a8587502a2fc016b9d42f904262193b2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.google.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/error-prone"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.13.1?type=jar"
+    },
+    {
+      "group" : "us.springett",
+      "name" : "cvss-calculator",
+      "version" : "1.4.1",
+      "description" : "A Java library for calculating CVSSv2, CVSSv3, and CVSSv3.1 scores and vectors",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4e02c31221121da4920f7e419b058ee2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8db4648d457df0aa955d34270f416647cbddba36"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fa47029010c209762cad63cd3ea4dfb95cb83a6dedc6d148be579991cf7cc682"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2f49681f515b1dd5338f026f42b951ac0237d293fd824f917b077f9e58d33eef601d1de6c9cd1eb6ff0d6cdcd78ed9c7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8f6813108e648c7a5988f73c2ea7c555626f7c6f4c73e7b37e5a5138dc1436378dbf7ac4ffde453cacbae5079cfd9691cd2101d39b1359afffa759b9f523129c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c230ea81db59948d037caf9ea09b50227a3c5ffb31ee40f06d9d96a5d1259dd7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5b164d8a49c78480d7fcf74be67463d881a4604a8b69c933fc2395a1ebf497a8fd9fd8ee3a6b756f777200a5f7310f19"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "19a8092b01599aad845b0af0c48123c50f0ff0812171798b8bdeada4285117643643cb5248248d7123e4be37aec84673dd349fb4345d2e5014537543cb474bbb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/us.springett/cvss-calculator@1.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/stevespringett/cvss-calculator"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/stevespringett/cvss-calculator/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/stevespringett/cvss-calculator.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/us.springett/cvss-calculator@1.4.1?type=jar"
+    },
+    {
+      "group" : "us.springett",
+      "name" : "cpe-parser",
+      "version" : "2.0.2",
+      "description" : "A utility for validating and parsing Common Platform Enumeration (CPE) v2.2 and v2.3 as originally defined by MITRE and maintained by NIST.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f07de5ae8549a93b912a223a83c30655"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "677cff319cdc8bd9578a3d04c1fd9c366cc9ff6e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8fddc10cf23ad8d3329dd8343ea1e291e1eb39344dd6e61b676a0cde88cf6375"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "99b53a6ebfe82a6e0b7e5b6b9648d6e871a4b015b26c503a921d0713ede738930c352aae77448202ccfe74d84008c88e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2b546382f2747b2628a3f0169289ddee8639d8aeb26da119fc439db42b4518281509139126a6e6972ee5079ad34dc164c9d15e44cda1597900dc4b7429736889"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e72269d096adf457cd78b931cd2a2902a5bee446f5c79e25fc4bb30e64d1d2cd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1f4e7d87d281a484edd8cd06a27ec58b664ac3f0ea747e622a32ddacd6728ff512cbf89c2003af76e4532c73ab13f4e3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8cc7471a8af3d0eaf226cc37317f40b9303b055a338a26efad89e7586eee6cb06f149c70eead9500b982f5b1318d1e5d806e7648823da69d0031fe4463d8c58e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/us.springett/cpe-parser@2.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/stevespringett/CPE-Parser"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/stevespringett/CPE-Parser/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/stevespringett/CPE-Parser.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/us.springett/cpe-parser@2.0.2?type=jar"
+    },
+    {
+      "publisher" : "OWASP Foundation",
+      "group" : "org.cyclonedx",
+      "name" : "cyclonedx-core-java",
+      "version" : "7.1.4",
+      "description" : "The CycloneDX core module provides a model representation of the BOM along with utilities to assist in creating, parsing, and validating BOMs.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6183f51edd1d799a49d98cb10c365a59"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e0acafed3c0f41f312dda0d7927e7256b28f50da"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "311ef7d1d2802ab0f0d3babc4345117153599061716692fe61d736b659a00c48"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f017823b617ffd8fbba4332c25fe5a4c75cf80467fdc5c9b2b13fd5bfa43d5b79c3d948565bc053c5d6a57708bd89ef3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7131bd1c60c53664778a94cf646c88061e4ed3b149eef75e3d511f2dc3218e480b2504fc4131ef6b0d5a737cd937c4531b2cf79209947b3a12443dec6e981191"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0e4e350512419fd0ffe3fe7cf0688c7f4b42ffd06a821106b7f48cebaa7ecf5d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3009dbe6edc6408683bd71f91f4e703c6cb860a1e774419d61c960384dd4fd290d92c84306084deee7825804045d2463"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4bdd5884c27027f154a7235685ded29987c1c105fe429ef5fb3e12787250725ebc3c1ce7634351db2b4a2c24471f426a8f3cbdd168b35da8c9c32d417e5b6c31"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@7.1.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://owasp.org/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@7.1.4?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-codec",
+      "name" : "commons-codec",
+      "version" : "1.15",
+      "description" : "The Apache Commons Codec package contains simple encoder and decoders for various formats such as Base64 and Hexadecimal. In addition to these widely used encoders and decoders, the codec package also maintains a collection of phonetic encoding utilities.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "303baf002ce6d382198090aedd9d79a2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "49d94806b6e3dc933dacbd8acb0fdbab8ebd1e5d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b3e9f6d63a790109bf0d056611fbed1cf69055826defeb9894a71369d246ed63"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "05d0506283716472175d44c2a4766523397bf8a007c18848f9c9a61718cc8aa437f9cb4b91771037ab29a960860b62a0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "da30a716770795fce390e4dd340a8b728f220c6572383ffef55bd5839655d5611fcc06128b2144f6cdcb36f53072a12ec80b04afee787665e7ad0b6e888a6787"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "87be248f33f241121f54aad61a9a460a79eabefbf1b5b0dd22aeb95b581f727e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "12fad4ef78274b06f97b1243cea6f970088abde082d2de9377d915a34b44f7d7d67807c03e59c849b69f1544e2a9a1be"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8c992c9c569ebaa0bf956a4c5b34fbf5e1ed1c212c2dd896fa216183ee0bcd341e96698af4b9cec7e8880762faa081a3d3a27f51349aa457cb8e373e4f57c788"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-codec/commons-codec@1.15?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/CODEC"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/commons-codec"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-codec/commons-codec@1.15?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.dataformat",
+      "name" : "jackson-dataformat-xml",
+      "version" : "2.13.2",
+      "description" : "Data format extension for Jackson to offer alternative support for serializing POJOs as XML and deserializing XML as pojos.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e88d4f53cf4e3d671436ad5732e28645"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cb6a722f128ff0ce2494384d419b6ff20fad25ab"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8ea46758e5720695ab0fd9455d33ba698784a079248057a34148f2c23fe2f4b0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "422792c224b9581b69501c8e67e13860e08895b46672cca077341124cf88fad1ea4a410741bc591eed5193c8e50db8ae"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "90f560e01dc4b2f46b6cb8c0f30ca3e159ea5dcf892f5d660878703bf5c43ce942eb67ac7cc084fd82f71aa777273f1d1f4d8d0d85481cd82d06839b3ce95dc4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b0b21165b3c2255ebf4518161b35296976e7f2cfc02e7b095208fcdc3c1e81e5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dafa41415f124ca98c61689403b1d492eceed2d06991281fb00420c981a83a4fe08cbe0181dfe664badbe288fbad1f59"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cdf926890be6be22ab30414f37f026752bdf8b94dbfa4b61a867648638e46e46cd39e085da1672a1244fee93e82eced1329f611badc5e0582192d13c522575b4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-dataformat-xml"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.13.2?type=jar"
+    },
+    {
+      "group" : "com.networknt",
+      "name" : "json-schema-validator",
+      "version" : "1.0.69",
+      "description" : "A json schema validator that supports draft v4, v6, v7 and v2019-09",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ac5b1612e3a19f57502371b9bc2a679d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "689fadf1019ac28ba988031f5eeb49eab6c05b9b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "00481ccebf8edc8aeed4d9962d385687bfb29eee8dd64d2169b49c20ea5dda4b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3a93fc5f36a2725401949240076cb8fbc9bcc491cabfce8950e63f99db2f375b75946852368a89fd3fc51b7126811f02"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b4458b0904674fda7485630919929354abcc347e88cb87a5c6a6f8e2a5ce85af45542ed05df3494768669b6109a06a93a52a42c6a1fbc257eb36a0446a068f7e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "782cbb239a1124ef952ed069399c046f5061cf8178c44c68b0ddf1faa9e83950"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0b52c1a2054c8ebf3be3a7c4997a3bba8c8b1ff89f635482997ae53016d352fdd5a8c4d052d2f20e1a64e36471f16ce8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8287240261027d004e0d017e9a98dfa5d6c79a44cbf137adb76b4eeecd3991a96e362e4840f3299ca684857ea5ea3c4f765a095be4beaf377941f81318c76e0c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.networknt/json-schema-validator@1.0.69?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/networknt/json-schema-validator/issues"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.networknt/json-schema-validator@1.0.69?type=jar"
+    },
+    {
+      "group" : "com.ethlo.time",
+      "name" : "itu",
+      "version" : "1.5.1",
+      "description" : "Extremely fast date/time parser and formatter - RFC 3339 (ISO 8601 profile) and W3C format",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "324a8ca9b01f44dc2a376b81d6f8e329"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a30f897caa066b37d574af237eebdac7638e0fb2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2fa82963daf8a91678f7ed3859c756e95d24a571ac4ba57a1a6b78bb68567156"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0078f848c16ccc16f85699f6b282af47c3250f1889b636eda9328a00dadc2ac79b45b9929e86114c49d91b3556212aa9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "15038003f36f85638fd7c165bae374b08952b610682feba2c2aaadc7d50a793bb66055685b5288751fa9fefc9abc10f3ed022b41f5a5dce78094bd676454cc4c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d954aaf4ce13a9810a0e1e5f2066e67582cc92e735813c953699e4a131c06bff"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7081323f8764f3c1ed9e1ab027d58fc8767ee5c65e49e87bf416eb5c668df73051848614207ef581db152102bc00f937"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "eb1f9dae8c963113b1c5f60f7bd396ef064b3d13fdefd8725c16a3d700278baea9d9dc54c083a7916bbf4ae43e1eb384ed9794b68530357e0c0209a9c9039746"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.ethlo.time/itu@1.5.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ethlo.time/itu@1.5.1?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jaxb",
+      "name" : "jaxb-runtime",
+      "version" : "2.3.6",
+      "description" : "JAXB (JSR 222) Reference Implementation",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "29acad12b7cdd22b2a5ab66cd7439d48"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1e6cd0e5d9f9919c8c8824fb4d310b09a978a60e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cd87d4b98a8bec1d237aed61472ef4adb6a8bb0515cbde1fd62fdd9781c16770"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6c3cfac49412ee125c0183e39ef751b8a7db04f02133ca6e039259708d2bd36df88bca3163672c8ab809cca9824e8d7e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8e8042f4a2a45f3520ce6376d826c0445a54509a728f9f61b274c2e2d92d242bfabfba112994d0df56f59f58c48e4069fb2dabf0fcc67208e651597de5eeaa98"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "00c4b10fb5581894c010618d4af73b821fbc262d883e5e1089438efa72243668"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3a0e2fbe2231fb39ae58afc52ad6dabf3cb932d4b56116f5ed3697b57bd0970c915e1f2b14df48576277c50ebb055a3b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f5657b09370ecd381e76148b52fd8aa8e904f09424f2c7df5307b11ac0403db885d8a82e50002047c5be4c532c8f5778bd11833beebef3ddfe02fbf2fd35b464"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Eclipse Distribution License - v 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://accounts.eclipse.org/mailing-list/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri.git"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.xml.bind",
+      "name" : "jakarta.xml.bind-api",
+      "version" : "2.3.3",
+      "description" : "Jakarta XML Binding API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "61286918ca0192e9f87d1358aef718dd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "48e3b9cfc10752fba3521d6511f4165bea951801"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c04539f472e9a6dd0c7685ea82d677282269ab8e7baca2e14500e381e0c6cec5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bad8b9f52bf7a7e1d3974cb305a69c093fb32d2131539c18d34e471e3ec32bdd9dd136bb4b38bb14d84e99c562f208c7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "adf6436a7a9dc6f64b97127861d7a89b78e82bea67f72bda800ef285163adcd84dbf006f679108a2a8c2eed013e0b771da2354087e0845479ff2b6318b881442"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a9e4179a6bfa8b363b9fd4f32f8892c4a7954ed1695d3f33ccef73ceffcaa1d4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8131aaf65f996cfa2c3f7d406caab3acf3e6650bcbbcd5595f8a457a211810ff110c1923876e068831a07388ddc26f33"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9ecbc0f4aa9cff28d519cbf74c8234b5180ae6ff0d6de4efe2de126b3251d466a5ddb878e70b9968095a843c82721c93a4dec53bfe09e3700f4cfe2e38bcac0a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Eclipse Distribution License - v 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api.git"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jaxb",
+      "name" : "txw2",
+      "version" : "2.3.6",
+      "description" : "TXW is a library that allows you to write XML documents.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd02e61e4662e6461f0c21b08e721021"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "45db7b69a8f1ec2c21eb7d4fc0ee729f53c1addc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f8bc249d22ad950257c373aea80c2f16f18f5eb4d557bdb2660bf5e1f1e84776"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "02c99a070c038081922bdae47cd9e739045342b223c55204716bba9f81eca971ed1313eab8bb103dc596bfd7b84a6b72"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "468cd89821480364a49f73f1774383fd483fd8273d373601a4867b37267f125c3fdf3ffd8a73a114408699137c469c02e47f94b80c7d21df236b4a187d12680d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "585be97a69d2a94b6647330ac36b3d5b2389eadfb92138f2b80a3e8c3bcc4b63"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e63ebe6d86a51506c45b430c8a71d80ac0fa95f99692a30697468b242ccd5c818f5d4aaf967e049797fee704a92307db"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2e7ed6f7267f7e4eb0c0b0e89f845fcd253eec4ab1fa66fd915b7a4bd738e881c9e8f801af17dbbbfbc4311409f0fad9737780693a1018582e307a3293d27405"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Eclipse Distribution License - v 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://accounts.eclipse.org/mailing-list/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri.git"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.istack",
+      "name" : "istack-commons-runtime",
+      "version" : "3.0.12",
+      "description" : "istack common utility code",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1952bd76321f8580cfaa57e332a68287"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cbbe1a62b0cc6c85972e99d52aaee350153dc530"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ad8ba1f6538e087915b1e7fbf4a7a60b006ebecc4ab52986c10dfe88ae11ae7eb6e1f302bee06f70b16ec316f001375b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "af36b11cc0d82b7f62c64941f4e7d441d25cb9f3c4b3e08753d038c388e5a09364b5dac9127f29a9b8df6d96034133caadab6d74371077478d2f301605913460"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50a425e524a6ee81110ecd86190d039a84d46aa3c45855310fe4f95abba3c21e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2207c7e1570860d6300ef3157905498efaf26ba85566b053495f583b20c755cc07d6855b2d79136ab4d6544635e39f4d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "286997280ee0885c456686cf91c601e600106138f39eb81fc27381868f7ede0d1521cdf22c420331b1a961ed2f1ba1887a9ae05073f4364e3ffc297f40f0de53"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Eclipse Distribution License - v 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-istack-commons/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-istack-commons"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.activation",
+      "name" : "jakarta.activation",
+      "version" : "1.2.2",
+      "description" : "${project.name}",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0b8bee3bf29b9a015f8b992035581a7c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "74548703f9851017ce2f556066659438019e7eb5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1cb0aff8b73ba52a9931b2cf13c75a1ce6665fb826bf97ede66db75c532136aa189fb53a1925e62b6eef572309ef3b9a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8bd94a4370b827e3904f31253b022e5c1851896d3b616ca7daebfef259238cedc56d4ced32c74f24a13c3e2295b0ea012af5d04656b7f713cc53a2f18d5e2cf7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5363211b59dfaff6e1973e93548e5e4062189c6d0f43d7802627ebeb7b7ff37d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "83801332576d931f4091ba65ea240d49c23e3b93dae939ce2eed63de943f80f251a4347638b99900de5b831796b12590"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0c7b62a3432b19ffad02eafffc7e598391cd32b1313d075f94cda09913402770b4ba2314716625571f266431067229c93cec36e17c3ea598623542988634ca0a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "EDL 1.0",
+            "url" : "http://www.eclipse.org/org/documents/edl-v10.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaf/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaf"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+    },
+    {
+      "publisher" : "Oracle",
+      "group" : "javax.activation",
+      "name" : "javax.activation-api",
+      "version" : "1.2.0",
+      "description" : "${project.name}",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5e50e56bcf4a3ef3bc758f69f7643c3b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "85262acf3ca9816f9537ca47d5adeabaead7cb16"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "43fdef0b5b6ceb31b0424b208b930c74ab58fac2ceeb7b3f6fd3aeb8b5ca4393"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d38a6af7ed00f13de8b46d49b9592af9b67adf3df47ddae5e4672f989f3f39101d446a77d1c11319acf8ff0a5b4feedf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8ee0db43ae402f0079a836ef2bff5d15160e3ff9d585c3283f4cf474be4edd2fcc8714d8f032efd72cae77ec5f6d304fc24fa094d9cdba5cf72966cc964af6c9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "aff48d0f28d8a99690c5a84c3fffdb3775452d5387e5698f4c9028c92a3b4888"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cfee76de5976d5994758a06113368092f09b0729d753b99969d6a5ec32919428bd7c270c98cbbc682ff8ebcf2b93fd8d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0507ece74b3147de60a830071bd434569c82e03f414a2b7f0d8a225dda36720d2e2194799cdc04def1909fdec21059b67c518bb9162f7f605764d542194e721d"
+        }
+      ],
+      "licenses" : [ ],
+      "purl" : "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/javaee/activation/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javaee/activation"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.java.net/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar"
+    },
+    {
+      "group" : "org.json",
+      "name" : "json",
+      "version" : "20220320",
+      "description" : "JSON is a light-weight, language independent, data interchange format. See http://www.JSON.org/ The files in this package implement JSON encoders/decoders in Java. It also includes the capability to convert between JSON and XML, HTTP headers, Cookies, and CDL. This is a reference implementation. There is a large number of JSON packages in Java. Perhaps someday the Java community will standardize on one. Until then, choose carefully. The license includes this restriction: \"The software shall be used for good, not evil.\" If your conscience cannot live with that, then choose a different package.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "86978058a0b60d816e8c48da84c547e4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "06df2c050972619466f6dcef7654ef9bcc01dfd0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1edf7fcea79a16b8dfdd3bc988ddec7f8908b1f7762fdf00d39acb037542747a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "61ef4fbf6068e477d5b5d6d9494f52e6cd65159d37e94aaae4da6f7067062f96d17b61e2b63422fdda604dbf69a08a72"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8d14b62fa0ba6434709a33fee009071c5510826f1ef7545f8c32604d07899259f3bf9c8596d62a38db2a34716983ece8d33125253d5cb4e2ab93c456cba52197"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "007bed5bc6500fc1e92de7e460d4281b4216480603ff04330f242e61b1958153"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b56b2a58d509072e644962eea41a9a8ba1e22b67e49ec00e3fdecd7928d84bd2b96b19401f48fec0a2082c1c715752db"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c640ea1daa14b4ccab5e4b62c5049b6941a2091ff3baca71bb38320a88a7401f8edbce6f1303ab29e40d75adc1f02fc02c77a8c5b8fcf56abb7b4a0378022556"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "JSON"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.json/json@20220320?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/douglascrockford/JSON-java.git"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.json/json@20220320?type=jar"
+    },
+    {
+      "group" : "com.github.package-url",
+      "name" : "packageurl-java",
+      "version" : "1.4.1",
+      "description" : "The official Java implementation of the PackageURL specification. PackageURL (purl) is a minimal specification for describing a package via a \"mostly universal\" URL.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f8b3a23e6402d317b612251c83d292e7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0a0d1009191c1cf6b04f40d26e4717596f3a90e0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8e23280221afd1e6561d433dfb133252cd287167acb0eca5a991667118ff10a2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "791d86830598ccce6ea59faaa7ece317b84ce1b245194e39cf576f65250b32c8a62c0660478a4d4038040b8650e520b3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ea5ed91a395e3c8ef18d575d363dc30302986dc5cc8423e97950708cd48dd87e97176619a246d72e8f5b4ff1a7fbb2afb5e9b3c7a11aa7340b540655ba4d4e9b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "29888a1b55158593ef90003638a7ea204b0cff1d255f48780caa37e1c52bcfe3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c2354f6e79b3feefa44b289a53b9ee05a4db20d75a6a367a4880a2028ec8306fd45c5495962381709b15134136bd3ed6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3bb0b2ef76d2dc0cff23f70541091bd30744d1fb0e240aca4c930f01f70314f1f7cf80552d0116b77333a2c3a3025b217fc3aceca2755469f6871983d5e9740a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.package-url/packageurl-java@1.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.com/package-url/packageurl-java"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/package-url/packageurl-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/package-url/packageurl-java.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.package-url/packageurl-java@1.4.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.lucene",
+      "name" : "lucene-core",
+      "version" : "8.11.1",
+      "description" : "Apache Lucene Java Core",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "95d8c2ad39e2fd98c1f1865751e4d69e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "75dcf930ece95581af3f31af5692e4963fc7ad8e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "78a61d0b843c1cf1fe5be380a4d3a4c1602d3fbba4ca1185da8797c9bb115483"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "32d1f3f19295c75bcc06331fb5da4b91b36f956f9051bc84592369de6602e395d45a2ba0e24b0f298e12630055a285b7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0a8a7c126e090c773bb0156f46bc5607097445d08d38e8119b061826d04963fbe680dc9894698a7942fa545ef8f4e176b416b90e485ae72a479ebb2731a4af26"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9b8429ca810c1516eb85c2418b56c45e3a7728e2991a079f61ad7507db642724"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ce011f601ca9846b62b805b7dbfbcce7a7ba1ec29a8794438e9bc9b88e540d31939ed1534a07372c7fdb147eb5da392e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "367f0283088f90c2696cc82c96f5d9fb9facb33fa8c2fa32379e4fa53233b10a5119cc696c1ca0799ee98daf36336ab19b0e68f674ce4eb4066e070b96e10541"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.lucene/lucene-core@8.11.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/computer/lucene/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LUCENE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/lucene-general/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.lucene/lucene-core@8.11.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.lucene",
+      "name" : "lucene-analyzers-common",
+      "version" : "8.11.1",
+      "description" : "Additional Analyzers",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "56657c7678492a87cbf7b844e91a1f6e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e50af506f271a3f7246da054a2569b42ff73abb2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1cdcc5a2d9cf4ffaf12fbf24bc2a18f2469cd295b60470ae8b97d1aa85dbad6f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "233c10e0e62334d75eca9c96495d2c50d428abbd9a45924db8f7aba1d0fc3512c76f8b7ec81de64e0ef0bc95a5d067dc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cdce02fe59469e722e73fd75d87bb6a9587c4f3303096ec005aa35b695410e195258229cac74d2e686413dc25647d15ff88e697557b4eba2e88637760fd95eb9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8a470de4e8164fef98b3dcf5c7be09ae65e82501936853815e4a091a899f9f10"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9024f2d68a130b840ff2e4e0bcba7c8396262287cad262e7fceb8d9e085b7958eb219d0e1b6259917e5a07113f4f1b73"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "847c75f5033ea748d8afb9fb67bad20a5b610aadd4e39124f6f55c2c9e932f730b58351087df84fcd49b3696fdecf715d963a41915f72b6b85450cdf893c0c10"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.lucene/lucene-analyzers-common@8.11.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/computer/lucene/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LUCENE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/lucene-general/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.lucene/lucene-analyzers-common@8.11.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.lucene",
+      "name" : "lucene-queryparser",
+      "version" : "8.11.1",
+      "description" : "Lucene QueryParsers module",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4c4685761f00464ea36159a64e7c71c7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5a44df2cb26fa1e0e64be53fe474c7f1d5a3e634"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "23abf022a19e609fe3ca421ab6b6868a3250974d31c5b92f9879d97c127a77b8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "12256acd869520cd064ac779453975dfc1226528637cf416b8b86fbb003f97f7b80a9cc775c14a4d8c51b3a6e820566b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b3facdf82dc045d70f136e867af8fba1cf9cc0437f688e35917db80f6143df5111edf1974f36b274f48aa8dbe02ff14d30a8296afeca2916ca739de8a62b5d5e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5afa17ed9d58e96045be55e7c8383f68de4b087f279054fedb06a8193a19279b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "80c9947d727b7289f5645521a90b7a37dadac641b5d5bbaf5bdd84e6e735c5a776021fdaf30bf1645bba3d47042965f2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "64b22ba8e7c3ad4db6929fc6ffbc20a08f90cc09857ae6698587fe0d1dac72829d9dbceb61428122c78d359cd633cc3426a0d57bec4a16ce2a2a05c370a8de29"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.lucene/lucene-queryparser@8.11.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/computer/lucene/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LUCENE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/lucene-general/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.lucene/lucene-queryparser@8.11.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.lucene",
+      "name" : "lucene-queries",
+      "version" : "8.11.1",
+      "description" : "Lucene Queries Module",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b4c5f9687dcd70d15c9f527af580de0c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "02a0abca16b31453cbd832ba27c96fce1208db5e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "11fb2e90da5b4e6a6c26120bb80a2937a20a585d32236ed7c277048ba65f07ca"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "999e241ba6ddcd7998d9c6aa51f832cd0f7fa3f335081627ebc20caafe9114771d1926d3d86db4d30fc8697e131243d6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "602bd488cbb3a33052a0e6e90d4caf49614667d33ba06b9dc916270568a27ea55d53fbaa7e605a2cfd71844ac5c3131ff0c21048ef1ece53fac4e6723559917f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fea7a1e631cb4ecdd5b8155cf887bd1b02cbcbffaf0eff7c4b2e4ec7699acebd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3d35b2f51969dd440be0e81fa87d9ebbbfb8bbd28b264b48c07c0912d49d45e2e32069dfb73be5561ec347c85f023e84"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7f2bddcb2580ae555dc0ce260da5c4ba2e0e7c93c2665f3b588605239d04d48abf8e4a685b0d5c805ef07369b9094a205faed2aa6759ffb511a14982eadcc3d1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.lucene/lucene-queries@8.11.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/computer/lucene/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LUCENE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/lucene-general/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.lucene/lucene-queries@8.11.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.lucene",
+      "name" : "lucene-sandbox",
+      "version" : "8.11.1",
+      "description" : "Lucene Sandbox",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "402424583b372b452444b5391abc8ab0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bd4392f44a5f7ed798baca88896c0ff6a428ab90"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "28bee2711947cf3a9957f3f77132ce37457894c1fb468b0a20e9a95788b11c87"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9b7da92493589ec4d2f2b7e088bad198288241346eb3399efbfd6577e4aa40e7a1e9051a388cd88690524a5143d1bafc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "019438b584fd8d03d96e3a6466c0d0f652b48310bf9b44ad55e8491c62342f25e6e85344b41d8ab4d3bfd3d03f9a2f54ce9bf9eed9f119f4c58048c5c8aa0670"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d4b9bfb56124f34c7884e41b20719dcacbb11be0f4a602f1fe26779fb627c882"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f1a431b8be815e7ff76396ca1488027fe0a48b0b4f87468f01a709fce14ca0883ea86cc1af2a7b95a7faefa87b381a3e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3a3ffde7a5530f743a9eaf3d86d1d729bccb304f372bc8ca4700c6122692e923eb68d0b9f2ceed625a23fc4bf7bb3f309cc7c897aabaa917090c81999e36110a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.lucene/lucene-sandbox@8.11.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/computer/lucene/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LUCENE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/lucene-general/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.lucene/lucene-sandbox@8.11.1?type=jar"
+    },
+    {
+      "group" : "io.pebbletemplates",
+      "name" : "pebble",
+      "version" : "3.1.5",
+      "description" : "Templating engine for Java.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d01954316286253ddc360585affef6f9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0bc7d795cef5281a4f75d00df2607d78de0ae4bc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d253a6dde59e138698aaaaee546461d2f1f6c8bd2aa38ecdd347df17cf90d6f0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "79d78f005a5cf7051f4a93a7123bc799e0d96837230aa4ddef235cecb945b7fe0d27329e2fe0fa61538a614462acdf27"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9b7733df0439aadd0fcf383663864e966130d79cad7d5d9e72046bd9d691e6bd4ecef7e4bf9476ffc89f5d6faec799cd45da715ec7c39a599432f26f56616b66"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a56939c5339952cec602feb6835103bc2874146afb0f86b4211314c0531ec914"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f300bb42282fdcea346420476e81a4b06fd5b7cf7e464d735f581dbd1f067c1f7368fe5eee0b939f22f8a41333e19a18"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cad84d10b15e33f99a54a8077a1171ee205359676bc80cf2903c007bdd11416bdd130d8efb7e963e54fee4bc17566a256ba76dc162ed66f0a1414f4995d062b1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.pebbletemplates/pebble@3.1.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/PebbleTemplates/pebble.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.pebbletemplates/pebble@3.1.5?type=jar"
+    },
+    {
+      "publisher" : "The UNBESCAPE team",
+      "group" : "org.unbescape",
+      "name" : "unbescape",
+      "version" : "1.1.6.RELEASE",
+      "description" : "Advanced yet easy-to-use escape/unescape library for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d95ed94e1624e307a1958ee105ccbf39"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7b90360afb2b860e09e8347112800d12c12b2a13"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "597cf87d5b1a4f385b9d1cec974b7b483abb3ee85fc5b3f8b62af8e4bec95c2c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1b808b67c784b69afea64364ba4c0d433c7f042c512f5c18f07d5388fe7ac4741913f696424bd8fbde147383cfb3d8f9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6918e9579b06721942fdcd91e401f5b996fb4eac13056dbafdf594661f355a34874eb5266784bc2c4f82df9fdd9e219d71a96f52945a354f01665f85f8166bb3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a190c9bedccff959d08db12fe7080437fb4e98f05516b39d6540be718e151cc6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6525bd20a12ff43a0089c0d59369574ae6c01e2b4b1aacf466847d4433ae403db08404a9b59be397c3034f972bcd6b06"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5d7b5edc0c2a0d47c9625936c14b4122330b96cdf54260fe2a6468289c2f4cbc4ee19770c1144acfa702f2f058a81544b4aea9258fe0e15166a1a331736d7b77"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.unbescape.org"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar"
+    },
+    {
+      "group" : "us.springett",
+      "name" : "vulndb-data-mirror",
+      "version" : "1.0.1",
+      "description" : "VulnDB Data Mirror is a Java command-line utility that mirrors the entire contents of the VulnDB service. The intended purpose of vulndb-data-mirror is to be able to replicate the VulnDB vulnerabiity data inside a company firewall so that local (faster) access to data can be achieved and reused by the Dependency-Check and Dependency-Track ecosystem.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "eb9ee5b2bf1d4a49df87f5e753bf84b4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a9c60b680f508f70a763815ef2558db2a0edecfc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "33f7e8af3b859b6881fd0eb1b99f7ad707321dcc632deb48b924a7c627090721"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0e0547665131899d0c51b3c17e08898cb78c7a39ed1562492a9499c55abf7ee070eff02a930228befe231ee3cbb2fb8d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "aef0872ad9875d54013d60bdd32daa98070aa6fe2dc042153899a002eadefaddef87450a73cc5de6d66358beca6906e76a12d24a92cec49b161d779d1ed6c232"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f360f3ec2f9c324e321cfbd789b930f17e078dc2640e34cdd3acb7a409495d4e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "83220f391c12952afa45c5c913c1387439cbc08300c6e75265322724adfed2a706f918a85b984a547f7d4c7203d68e8b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "94e24bf96cc1d51d984834b44577df80cee79409f550187d941429c9eb3b060514bfb76f2a39a5594fd467f63b6295815daba4df4d93a87449e9d797c6ba7959"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/us.springett/vulndb-data-mirror@1.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/stevespringett/vulndb-data-mirror"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/stevespringett/vulndb-data-mirror/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/stevespringett/vulndb-data-mirror.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/us.springett/vulndb-data-mirror@1.0.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-cli",
+      "name" : "commons-cli",
+      "version" : "1.5.0",
+      "description" : "Apache Commons CLI provides a simple API for presenting, processing and validating a Command Line Interface.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6c3b2052160144196118b1f019504388"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "dc98be5d5390230684a092589d70ea76a147925c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bc8bb01fc0fad250385706e20f927ddcff6173f6339b387dc879237752567ac6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a7a2daa807c4007c506b5100f0a9b526c0052c4e1f6b699904ef9d2aba8195b6003dc4d47ca133b15e2f3e830bdbe6c4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b78ac2b418e9e9e7d0bc866664577199d320408a6f03151b3789bac365c986dd526df853599e633d7e50fe136cbf3eb9ce50c9cfa0ad38c3cc8d8ee416f61c40"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a0a47001d3a293f129ffc21f17f575a9d23ce5b88b440e651e4cd01edd0cc421"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "44ca97514a2e34b5bf3de9b5d45c8e871f6eee517db7f3c4b4476eb3e8dfe9a9d8760f3181114708288c373727b42475"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "483dae23d6827a105d17847c8c813527f19042b65c4d09635dfc4bfd25990fe3ba2a997540460fd5b1d72ca3add9a38ca8b32004680764db972a9bb62f7f68d8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/CLI"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-cli.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar"
+    },
+    {
+      "group" : "oauth.signpost",
+      "name" : "signpost-core",
+      "version" : "2.1.1",
+      "description" : "A simple, light-weight, and modular OAuth client library for the Java platform.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ef778c731f9b6cbb8311a780b1f4094f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e307e72ff918b775f797f364b1fd442f23b5408a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2628d8c1928e512cea34001c1108bfe251049b1ef747ba284aa7c781c24b2e79"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c4051510406394dd52cbb6170f20869e5cef2b026e88c672908bb2ceaeeb43cd88df2811dd75fbe6ad37f2c523f562cd"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9c3a0934458de2d79c00d53422b838e17369cece5e325b11709af1c74e368c58de1c175eed689a247f6ab622f2a67c2ccd06283864e64d95abdbc26629d0226d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "190333f0f7c94e3db5f4d49392d454f43c710e43266fbb6049b58f8e22dc1548"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1a09cf0e64cd9366f19197b6a66b3a94bb4851efa596f94538890d01e3261a611a7ceb6768512e5e3c2fd8fc5d3d01c4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9f0c3184b752c9ed73ab4f34805e62cafde30dc4b94f2dc55aa9645c15921ebaeba3f2bf3202ed98e60f3bb66e47945b1449e07fd559e0654afbe92f2a6a94c5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/oauth.signpost/signpost-core@2.1.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/mttkay/signpost/pulls"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/mttkay/signpost"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/oauth.signpost/signpost-core@2.1.1?type=jar"
+    },
+    {
+      "group" : "com.konghq",
+      "name" : "unirest-java",
+      "version" : "3.13.8",
+      "description" : "Simplified, lightweight HTTP client library.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ae84562a90efc2d35b747b8078588def"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "abb273cbae38280b2f72bd0d9ee0330a90846cc7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ef9f627222e789aa7b15ddad0e0670d60834d7611f30ea967d3148fdbf21939b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e5f07d1568385be6c9002eb773234d96813da0928997871725e3956c81f1d8fa1e6acffc172c90f688ba7e95496d0c56"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "68d514bd728891342399d1eb0dcdf613d20ccb7d54085a0a9dd0938dabdcd0b206d95f184e785d8cf4f13c29ba2762e1d0c2d43731ef0fd79a35b295eec24c53"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7e0f1dc6e944680d2103add736e6b395baf27a3dd4f33cb735badc2f16aa1e47"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "42b2265eb0f49e9f65a8bae1534fbbdc083201af7b55f4b733aa8fc1aad297af9808d47d75eadd1a308e9c63b578da96"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2c14d77004e34317165e6aef2ef1335d815cbba4942e45eb5525387ec9535c73c5229199fc58ee5d07e5b6391bb63779112e9f60facb5aaceb7ec30a879471a7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.konghq/unirest-java@3.13.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/Kong/unirest-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.konghq/unirest-java@3.13.8?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpclient",
+      "version" : "4.5.13",
+      "description" : "Apache HttpComponents Client",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "40d6b9075fbd28fa10292a45a0db9457"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e5f6cae5ca7ecaac1ec2827a9e2d65ae2869cada"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "093ac3e2dde58e34aa70309c7305eb3c9b5be2509a9293f1672494da55479a86bd112e83326746dc7a32855472952b99"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3567739186e551f84cad3e4b6b270c5b8b19aba297675a96bcdff3663ff7d20d188611d21f675fe5ff1bfd7d8ca31362070910d7b92ab1b699872a120aa6f089"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "710b1d8d7dae0b8e4270756694ca9c83d64965f42d3b4170c609b14d47c2762c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cd6882e7868624164e460f2f3ea01466f863c0dcb902b031c656b57356f563be83b29530df41d88d634ed3d01fc9964d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "276fa6a6599dc89382d658115695cf4da6b0d39b34e9c349c17a5dbd64122eaee553bb9ed75c0378ec4a83be157c8aa39370662de3c9b8fd55ebc1dd608383e6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.apache.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPCLIENT"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpcore",
+      "version" : "4.4.13",
+      "description" : "Apache HttpComponents Core (blocking I/O)",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e07a248f61c52776a2366c075dcd4963"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "853b96d3afbb7bf8cc303fe27ee96836a10c1834"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b776d57492478c162d428bdd3139be0fa6c3cf4503355c3a04710ca7bc3ee74d66627f49eb42814fd8f8364dbd17aa91"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "23430cde8b9bed33c91474ba49f1143284135df1b25fdcbc37bc3bb7e9549e77b3918eb40250093db652ae200367e87316129b23b4f6987e94939d60f467498d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "721a9fc1bb353ddf3e438bed4306a3fa5b55ffafb474be5dc8715bd23d7a5afa"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f6f9e70b76717b705d040f0b33857f0dde89736f2e6d55ea56585235eb1b6d0ce4d5aa18c82050391ac968dcb5ec29e2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c78f9d464e4b840e28266658512b1cab0ece1470bef2764deb2dc20ba69b73d526d92a19494ccb87b4408f9235c4294417f2e10ba709469f4bd62d017b9e3cbe"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.apache.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPCORE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-logging",
+      "name" : "commons-logging",
+      "version" : "1.2",
+      "description" : "Apache Commons Logging is a thin adapter allowing configurable bridging to other, well known logging systems.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "040b4b4d8eac886f6b4a2a3bd2f31b00"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4bfc12adfe4842bf07b657f0369c4cb522955686"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ac20720d7156131478205f1b454395abf84cfc8da2f163301af32f63bd3c4764bd26cb54ed53800f33193ae591f3ce9c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ed00dbfabd9ae00efa26dd400983601d076fe36408b7d6520084b447e5d1fa527ce65bd6afdcb58506c3a808323d28e88f26cb99c6f5db9ff64f6525ecdfa557"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9aab62deccf156ee6e324c925dfc30ecb53e8465802863a551901a461424e807"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "628eb4407e95dca84da1a06b08a6d9b832a49de8472b1b217e8607f08efeeed18b996232d64dd07f03e78e0e3bb4b078"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3fd76857f6d20c03799537cc961c1c4ddf1c375c6c192fb982363e3b9397ba138b77f24ef38b4202f44e37586789c0320e4de18fdadd2772304fd14a9b26d552"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-logging/commons-logging@1.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/LOGGING"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.apache.org/repos/asf/commons/proper/logging/trunk"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://continuum-ci.apache.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-logging/commons-logging@1.2?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpmime",
+      "version" : "4.5.13",
+      "description" : "Apache HttpComponents HttpClient - MIME coded entities",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3f0c1ef2c9dc47b62b780192f54b0c18"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "efc110bad4a0d45cda7858e6beee1d8a8313da5a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "06e754d99245b98dcc2860dcb43d20e737d650da2bf2077a105f68accbd5c5cc"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bfb59447493ea1dd69a0b5a49de8adfc9813d45aae7e005cfe8e6fe282d6caadf7aea520ec6df3f1bdeb99f129701827"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e1b0ee84bce78576074dc1b6836a69d8f5518eade38562e6890e3ddaa72b7f54bf735c8e2286142c58cddf45f745da31261e5d73b7d8092eb6ecfb20946eb36c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8bbe5a758db8c840cc2d72dc4070c2e264d01fb0d3ed3dd92489e0eb25d030c7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0c728ad29e80bb4d262d4adf901880518627ab78ef39e194bfce87f91555fc62bf9423f3c15ab7f5c1b6b895865a263c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "76c5f955afbbb00ff00ea39ad2179727c2d7be2a75bd3f654db01e06bb611803bd1258b7527ac30c9d81987b32d1347fbcb23ce967638188672d5ed0151cc791"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.apache.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPCLIENT"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpcore-nio",
+      "version" : "4.4.13",
+      "description" : "Apache HttpComponents Core (non-blocking I/O)",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "acf9cdf59217b169c3f68582ed0be0a8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3f897ace4d7f10f0ea6a58f524a3b105dd483653"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "71fcfbe869002c48563cc5979fc734571c8d0d167ccce42970c932f337981f19"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "63c8517be7bee321af4876f4bc4bf6ddd2493b0044d51279171f0c8caaa2e55d16a62f672676a029f0027a7506d8c264"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ac0f7c8691c9797fd72a26c003c594e7ade382d9454d5e6151ff38c99fa5a37cd5305f15d7643cb75054e1e67d672444e358c2fe1f625818aed2ebbbd5157590"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7e4266a4c17e87d98c425993f6efcff1f9ae12fad15bbf549d980665ceff690f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "655ab06d67536754f62b490503a6a358df59c493019de8008809a6d2a6b647fbc4015c603495ce2d6f764e310685e7f3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d50bd619d9af2f8aecbe361fa2234d3b9e3ad2dec4762881b9f07255df99a18a0971f036b3e2646680a6d798b0e19b718cf16aca0992c9fb701c2b0b6cdd06c2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpcore-nio@4.4.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.apache.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPCORE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpcore-nio@4.4.13?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpasyncclient",
+      "version" : "4.1.5",
+      "description" : "Apache HttpComponents AsyncClient",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5346c547bfd0da64eb3dc54be9380d65"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cd18227f1eb8e9a263286c1d7362ceb24f6f9b32"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0c1877489a9d1ba4fa50f6cfcab11d1123618858cb31d56afaab5afdd5064d99"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9c4cf09ffeb61bccc3b67375f401c8a96c46bdee7c77f84e3227271a635e109a550526185407869e93ede8f081786977"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1e33c7fdfa63f377ec4844b7744d2f8ec30dc7867136905ff5a5a6e5f94efa5b8159ba20e81f0048f48430cf63ada7411a3974a418aefa497d2b4fab3501f5ba"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ddb21eeb3e1c3f00ebcf397b58d8d972cc7ab7b140e8939654bf24b8b89382a7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "25bcc09200af70f5624baf5ddb95ac6bf46daaffb938d141f72f63ef76df8b740ba3b50104da997cfe67c34bd520fa5e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f753a8b9607f42417912c3bddeda3f189ab9f469416dafdbcd29b1df7a358aa57deba8a79a5663fdd1a4acbe35b39a48fd24f889a50e05a4726132db85699ebd"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpasyncclient@4.1.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.apache.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPASYNC"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://svn.apache.org/repos/asf/httpcomponents/httpasyncclient/branches/4.1.x"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpasyncclient@4.1.5?type=jar"
+    },
+    {
+      "group" : "com.google.code.gson",
+      "name" : "gson",
+      "version" : "2.9.0",
+      "description" : "Gson JSON library",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "53fa3e6753e90d931d62cb89580fde2f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8a1167e089096758b49f9b34066ef98b2f4b37aa"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fde5b61066a8cdd711874ed42f20cb914e4193f1477456c431fb0ca32d86324414e92b0b2c5696f56d0b9d69521d8dee"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "13ff22a60ee6a72ba0c4e8fe3702b8f3f6be6b67ed4279079a9843f57ad0ca125d4ecc1564ac4e736eab10fb6254d2c011b2c08c514d708be7f8091332ed2c2c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5e550f5f719c5f5c4ad04fbe6cd0d7868d6bf0e4184f386e4896e72c4839de3e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "314156bb766c2f792317763322a819ef968e5ecc7f1a236ab0bb383426d1bf396e18099edb16f85e572b42c85a6c89ba"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a3db5a0129c42598b5ded96cdf75d69c75d4a6b317746c9b7fbf238b2ca78cfb48fb0023ae1a4178bc8da3727ceb0bad6930f8f24624e0be6dbbde00adbb0624"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.code.gson/gson@2.9.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/gson/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/gson/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.code.gson/gson@2.9.0?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.woodstox",
+      "name" : "woodstox-core",
+      "version" : "6.2.8",
+      "description" : "Woodstox is a high-performance XML processor that implements Stax (JSR-173), SAX2 and Stax2 APIs",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a06f113f68a07546494ee9cb1d5fb0c6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "670748292899c53b1963730d9eb7f8ab71314e90"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3801762d429c5edf3aef9d734118987bb7bf09c786eecb7b7613e9b658d031cc"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4cc74445f45201145689a4b3662f12cc671d581f72e78c301f11be08f9905eb60377e4fd882d4e09bd0f6a75ce2ad2e0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "99e486c76143cb4807ea0c22c17a4b90303024213a1dfcc0404d0becec4037845a273d5adf029feb5ea7c7644de15738f858f3b7212362be2f59025888b9b043"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ca1482e9a34da10afa842bbece347e56f3d7c9193079a7c566afa7637ad5175e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e6d59c6e16c9f980b1b87010282fbec4cb7a712441d61daa06faf521fa7f0cf6edf3de07075d8a119da3097161c2f450"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7de871791222469d7508d051afcd15b3438a8de370a734e8f54d163e89fdad390f440ef8d3b8ae1e624b37efa1f173e21509fe6a17037e4e5cc4f4a4a651c1b2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.2.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/woodstox/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/woodstox"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.2.8?type=jar"
+    },
+    {
+      "publisher" : "fasterxml.com",
+      "group" : "org.codehaus.woodstox",
+      "name" : "stax2-api",
+      "version" : "4.2.1",
+      "description" : "tax2 API is an extension to basic Stax 1.0 API that adds significant new functionality, such as full-featured bi-direction validation interface and high-performance Typed Access API.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "af8377bc7882332e22456616a9f164f6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a3f7325c52240418c2ba257b103c3c550e140c83"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "678567e48b51a42c65c699f266539ad3d676d4b1a5b0ad7d89ece8b9d5772579"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "97a6a9f0cc666776e4a4f08729c303d2a602ce5c25ee633cd6c54c72f12d11e9d43634ca6ca4ef7da5973a52030384da"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "00efc5d4d17540fb180c5b20d456630a8b3262dff46676689ae916ba16f0fbd9b1a71c7badfb254faad6597f94fed1edb96f77c15f40178eaf4d8cd35cea5e8d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5e8e54209fb6b580e928e703ef11645aff1a21dfd47cca2dc0e53d0befaef09c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "683a1f110ab84333e7517dabe175b91d7ea2fbead2f9d02acf798c588a7508bc67580642afa8d57441bc56ce610d5b0f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d79338a481605c94e144c967cb7adbc6cfd06ee6a1182b5ebc8cd8ad3deedd707931e404aa197bc94d3b5a5d82a2e6dd6a2f6cc9dafc42ce3ad5061076b05199"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "The BSD License",
+            "url" : "http://www.opensource.org/licenses/bsd-license.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/stax2-api"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.maven",
+      "name" : "maven-artifact",
+      "version" : "3.8.5",
+      "description" : "Maven is a software build management and comprehension tool. Based on the concept of a project object model: builds, dependency management, documentation creation, site publication, and distribution publication are all controlled from the declarative file. Maven can be extended by plugins to utilise a number of other development tools for reporting or the build process.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ce473b0d9fbfd10fe147f03fe8707d67"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4433f50c07debefaed0553bd0068f4f48d449313"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "91172bc294d6eab02fc9f45f4ea01fd0e418962d128cf489abea7b6957d988ee"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "98a75c0c91181a848474a4195d4905a16060028e1e2301196cfc5bd310d08aa12521189d95d7b4c25af985e3027e3aa7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9f7936f9039e22ddcb21c75bba295a54fb40cf25184bc42ca4afcab03848894d74978da86b076b11bfa4e9388abc0201af8ad5f3e26c34a4c216fcd6182eba32"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "371873aa8f6dc5354cc71229fa8dcb9d34ad609d76daba8d3312b03140b92ae8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "db8e0f81f4750f0a161b89094a78f1343164397c6c2c117869eb3bc7ba3eec43d10083792a4d6f3350704395fff4a341"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f0df15116b75ab3c7331c4a9b538d94e84a1bfd91abfe1292fcd6b864cf1d87da7af3366285edbe6e792a3aad908b4df69f3924e3ca81573e85cf449c0d3ff27"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.maven/maven-artifact@3.8.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/job/maven-box/job/maven/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.apache.org/download.html"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/MNG"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?users@maven.apache.org"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.maven/maven-artifact@3.8.5?type=jar"
+    },
+    {
+      "publisher" : "Codehaus Plexus",
+      "group" : "org.codehaus.plexus",
+      "name" : "plexus-utils",
+      "version" : "3.3.0",
+      "description" : "A collection of various utility classes to ease working with strings, files, command lines, XML and more.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3ae76ff0195ada460d495efe1fb50d17"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cf43b5391de623b36fe066a21127baef82c64022"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "76d174792540e2775af94d03d10fb2d3c776e2cd0ac0ebf427d3e570072bb9ce"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "27742e2c82c13ffe947c6ce8750b1989491e8a5d7554cc3fa240a952c9d3a22fe006516041c66650e71972275c06565e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a93038005cd9793476c913beaea7c8c170d1853dddf39bf6794ad6446165eaf538c2c3c2314baa9d919d6b0bda78e5ea3cd987d5dbacf8e3b98e315bcfa7db64"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "364bfb131dab58736c995ac4484d9eab53b1e62129a99ed55e9c12ed39079dc6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "16af5ee2b4f8710fa14bbd977ef3630466c51c4ed6bf9886ac0ea9c74bd23dedbbce60beae5217fab686777108c2e54d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4687c5ca8bb73d6880132d7d886733d0a5ce7a873c7b5b68d9d46066ee7e1f6c11f0510a70f313ca2563550bfcf6e81cf37a0c4ceef247bab55d6aadc49fae59"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "http://github.com/codehaus-plexus/plexus-utils/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/codehaus-plexus/plexus-utils"
+        },
+        {
+          "type" : "website",
+          "url" : "http://codehaus-plexus.github.io/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://archive.plexus.codehaus.org/user"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar"
+    },
+    {
+      "publisher" : "Microsoft Corporation",
+      "group" : "com.microsoft.sqlserver",
+      "name" : "mssql-jdbc",
+      "version" : "11.1.1.jre11-preview",
+      "description" : "Microsoft JDBC Driver for SQL Server.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "30628f89729f0262151264311d67221d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "83d1b0cc9248747528a329e30b620b65f7f9a474"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0daa106346f4c2106d27e0065b3f20b08e9877d35363e4016e187db13ddec7c7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5b463d2947e917821e3efc2e4138df4929b2a64b7124ed9add95e216c1584ebf6b309bba7b5e08b9c8d26329efaeac18"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bab1a593e3649ede6581bda79c821eedba1f9ad2e1d8646fde66a5da7b23e8de973e9ea141da2c6f6fd8393e3cf2ded5bc090ed86fa919c0cc20fe120afe6115"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "40a20f48acf9410e79bee46ae314cd4af17d17ed19f8223808f5f987880f4a3e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d23108eb949cd174de8a67f1d8342b51b6eedfcc3ecf342aad30ff734b4c793ee486401b7bcfe9ed8ccaff28298b2352"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "63668e7fdca0a7d92f9019a00193913390db6dd352df9645cb01ba4b69c5abfbd066e53115081a8a0a3d90bfc0b06b4d14b95a2b3d671e05c655d1d63041a854"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.microsoft.sqlserver/mssql-jdbc@11.1.1.jre11-preview?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/Microsoft/mssql-jdbc"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.microsoft.sqlserver/mssql-jdbc@11.1.1.jre11-preview?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "mysql",
+      "name" : "mysql-connector-java",
+      "version" : "8.0.29",
+      "description" : "JDBC Type 4 driver for MySQL",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d2c24e4b4ae8957cd7edff37ae833d37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "016bfffda393ac4fe56f0985f1f035b37d3fc48f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d4e32d2a6026b5acc00300b73a86c28fb92681ae9629b21048ee67014c911db6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a6c435df9739869acbccf55d306ccd1eea4d5ccb6a62df68dd254262a6e0fb722d7d57a5965709bf6462f7002f54ad7a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3eabd70f9a947918f434a44923a8e3ff4c3fbc93e6c90f4992c94d804860ef3d09f09fb4fbf905d53a39b51aab965ecfd65f2ff2aa105387b3c8f49c18d7713c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "67023a34ea604f023be0470f805bf3ba9a0875e206691d1aba846ffe472370b6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9a4a7139b2489f8ba8111dd839f908f2ed4f1fe0215b433fd6d5aad3bc2c4ebe51e27b9415c66d1283daca1a1c97e887"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9db6e98bb35abcbb80abe4e64b9e9831c5535b23bb68c488c5ca5339e9de2f0debbe832b5d4d4f5c77d5a77c6d6d6026ba9c78a3f9493d849f1e35ced343b4f4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "The GNU General Public License, v2 with FOSS exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/mysql/mysql-connector-java@8.0.29?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.oracle.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/mysql/mysql-connector-j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/mysql/mysql-connector-java@8.0.29?type=jar"
+    },
+    {
+      "group" : "com.google.protobuf",
+      "name" : "protobuf-java",
+      "version" : "3.19.4",
+      "description" : "Core Protocol Buffers library. Protocol Buffers are a way of encoding structured data in an efficient yet extensible format.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1697b144988cbe6529fd3c4ad56fe882"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "748e4e0b9e4fa6b9b1fe65690aa04a9db56cfc4d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e8f524c2ad5965aae31b0527bf9d4e3bc19b0dfba8c05aef114fccc7f057c94d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "59eb6c13e0d917af760b01024c798ced893e88800ce01fc780c974cc91318e30ceb6a8cd5a4c25bd340b40e425f73f9a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6be2ff0ec2aa2a9d81d0a7e6c9ad9a54d806a85b06114a0b8c41d7182f118c9306e766bd8bd3f156e53c404142981d82ecc09d91c278fda1793dbf72408aadc3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "856303ef72d921692dbc27b1338716578c1b7357285195ede7805dd061a61262"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "925c3a9fe26ea33950ec845938a2ed1f37c90b4ccce0ce592e71219d920b27961c272c9a97005613e534d2543402e23c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "245712cea9e0233f7608013384b282a87decafc3a7a0589a021fcb0751894a1bcdca051c9b138a6f662364fd5ee8b7c7b29a13da086d955da61bfb5c6df67372"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "url" : "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.protobuf/protobuf-java@3.19.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/protocolbuffers/protobuf"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.protobuf/protobuf-java@3.19.4?type=jar"
+    },
+    {
+      "publisher" : "PostgreSQL Global Development Group",
+      "group" : "org.postgresql",
+      "name" : "postgresql",
+      "version" : "42.3.5",
+      "description" : "PostgreSQL JDBC Driver Postgresql",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ee4505741af3b80de56e7f75c86e7602"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "438e339890a7660c88c98dc0e43cd980604d3562"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "424c9675000020e228ab13f70e99d5d63ff18d2bd0106f0ddb3e2607fcc33af4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4d95ac2881634230a97bf51ec6272fe73eec0a78b71c164d46d0cc4abde479a4a891cf18503cb76685bad60ac298f635"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "074d5e9d848243d65fb84a4a7d1b7b25d58f4b18b7a085c0c7ba568f1cb1b6ceb8ff1552da737b3300f58abbfa252375d2d2e3c46f843bd22f4f2f975c63f837"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f7d40f441f8909dc7cfaaaa8ba3cc9ad35ebac3fec8073283761f1423f96d5e0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1771f4bb08476f54b462ce66b672b13abd49e00d3005ee697b3f951bc726c6338fe1dcebbeba853db65ba5e61dd6c049"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "203b6de991a584a0f42654a0c0a059f4277996a9981b73b2fcb3095b230b9d2ff162d62698f3407cb5054dc5e737306be6d2f999c62280abf2d186187d1b19ca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "url" : "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.postgresql/postgresql@42.3.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jdbc.postgresql.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/pgjdbc/pgjdbc/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://www.postgresql.org/list/pgsql-jdbc/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/pgjdbc/pgjdbc"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.postgresql/postgresql@42.3.5?type=jar"
+    },
+    {
+      "group" : "org.checkerframework",
+      "name" : "checker-qual",
+      "version" : "3.5.0",
+      "description" : "Checker Qual is the set of annotations (qualifiers) and supporting classes used by the Checker Framework to type check Java source code. Please see artifact: org.checkerframework:checker",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4464def1ed5c10f248ebfe1bccbedf1a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2f50520c8abea66fbd8d26e481d3aef5c673b510"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "729990b3f18a95606fc2573836b6958bcdb44cb52bfbd1b7aa9c339cff35a5a4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "01fb1d7a7440f807b2bdb697c709dfa5897edc0755152c0fef465cf77dd820623fccb410ad033e3d52d4b0bc57409ecf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "407d0ac59b02cbef7d93f25c8b287cd587232aa5ddfee6d2c7ba34d712565b0a5adfe52b5daa20d3e6c3ab1e7a5f8b08698078d9179185a1b35ada1eb92213bf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4fbe95b196e75e549f66831e9b1f8f46cfe1793f4fda350857f5f24349d74af1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "626beff2173578c3a2ad732c81c48a9b091c9ffdea7d50f4b812fd14cd8299ab7a726b052808490b1022faca69aa6e91"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2c84365b1fcd16a765e49c5d8f30f28c3fe7cfe868ac32be726d8b9351c9053ffea23cfa1db9fb5c59c9928d22ad01c3c894d798e115bc446447228c7c4b24c6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/typetools/checker-framework.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar"
+    },
+    {
+      "group" : "xerces",
+      "name" : "xercesImpl",
+      "version" : "2.12.2",
+      "description" : "Xerces2 provides high performance, fully compliant XML parsers in the Apache Xerces family. This new version of Xerces continues to build upon the Xerces Native Interface (XNI), a complete framework for building parser components and configurations that is extremely modular and easy to program. The Apache Xerces2 parser is the reference implementation of XNI but other parser components, configurations, and parsers can be written using the Xerces Native Interface. For complete design and implementation documents, refer to the XNI Manual. Xerces2 provides fully conforming XML Schema 1.0 and 1.1 processors. An experimental implementation of the \"XML Schema Definition Language (XSD): Component Designators (SCD) Candidate Recommendation (January 2010)\" is also provided for evaluation. For more information, refer to the XML Schema page. Xerces2 also provides a complete implementation of the Document Object Model Level 3 Core and Load/Save W3C Recommendations and provides a complete implementation of the XML Inclusions (XInclude) W3C Recommendation. It also provides support for OASIS XML Catalogs v1.1. Xerces2 is able to parse documents written according to the XML 1.1 Recommendation, except that it does not yet provide an option to enable normalization checking as described in section 2.13 of this specification. It also handles namespaces according to the XML Namespaces 1.1 Recommendation, and will correctly serialize XML 1.1 documents if the DOM level 3 load/save APIs are in use.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "40e4f2d5aacfbf51a9a1572d77a0e5e9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f051f988aa2c9b4d25d05f95742ab0cc3ed789e2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6fc991829af1708d15aea50c66f0beadcd2cfeb6968e0b2f55c1b0909883fe16"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0a35ae0744f05973997b0710cc8d1d774867bc1c1b63ef5bf5f554d1b4c4ab42033f7819430e05ac623e7c8630aa7c52"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bfd21f2350bf0bb546a68d3303f28c6a15cee1e630138c169344c3f65fe39a15e61c6ff4e5239f38f2f1f9e488eff4d5565a4a0774263064ab6a30aa9fcaaed3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "875856aafff433840ee9933c01018cd18c0a13b46bd4472853698ef1dff83168"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b016ed02d907b21c90b4a2560aa4c778e8aad1b5ecb0ba62777f668166c6e7b8a0c0deef7d1e63b7a9b1092c64c8a4a6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1587332fb01515a72b7856b1f566070dcd26fef33c5070039c28684215466a9b9d3a4625cf7181443e3c3a67a313a938cf0775f39b96daf43f5edd4772143c23"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/xerces/xercesImpl@2.12.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://svn.apache.org/repos/asf/xerces/java/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/xerces/xercesImpl@2.12.2?type=jar"
+    },
+    {
+      "group" : "xml-apis",
+      "name" : "xml-apis",
+      "version" : "1.4.01",
+      "description" : "xml-commons provides an Apache-hosted set of DOM, SAX, and JAXP interfaces for use in other xml-based projects. Our hope is that we can standardize on both a common version and packaging scheme for these critical XML standards interfaces to make the lives of both our developers and users easier. The External Components portion of xml-commons contains interfaces that are defined by external standards organizations. For DOM, that's the W3C; for SAX it's David Megginson and sax.sourceforge.net; for JAXP it's Sun.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7eaad6fea5925cca6c36ee8b3e02ac9d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3789d9fada2d3d458c4ba2de349d48780f381ee3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a840968176645684bb01aed376e067ab39614885f9eee44abe35a5f20ebe7fad"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bce0ec0f0f692213a1110197c4a11c333673ae0630481255d12b441a8cba70aecfaf104c3d8d9b500ed2a0a19a2bfcce"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8db0283b6840cd6407957d296b802e3edf90653e2722f8e29f86c1c0b60996c4b43e9e065e6864dab89b2138ddb0174d9b4fdda4a93f94eeb884783db82f3268"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "09eb76497eac5012ce1000c52f4e597c4941a44b9d960b1ac58a19beb2dd63fc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c1d8154ef6eee57dfe6ae9a1c1a2525e9ec2aab3631911a53c064ea6480c0b3b1ce8dd079db7b3693d7ef81daba28ace"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1e4eb902e50b3388da4d161ee49f4d47b61dddd2ad10e6ef6cbb67c4ebc9043e0b65ae59a4a0c8eb03dd28814ce4aedd7e0d4962a0aedc3bdcf7de37cde38f66"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "SAX-PD",
+            "url" : "http://www.saxproject.org/copying.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "The W3C License",
+            "url" : "http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/java-binding.zip"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/bugzilla/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/xml-commons-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://svn.apache.org/viewvc/xml/commons/tags/xml-commons-external-1_4_01/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-compress",
+      "version" : "1.21",
+      "description" : "Apache Commons Compress software defines an API for working with compression and archive formats. These include: bzip2, gzip, pack200, lzma, xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4, Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a713d10331bc4e13459a3dc0463f16f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4ec95b60d4e86b5c95a0e919cb172a0af98011ef"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6aecfd5459728a595601cfa07258d131972ffc39b492eb48bdd596577a2f244a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "da56f95d420cd7278cee646f4cd0e7a5ee12b6a2894efaec12f0ff7b56c3d43e5db736fe1ed66ff91118b16f2d64ebef"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c92d9a12547aab475e057955ad815fdfe92ff44c78383fa5af54b089f1bff5525126ef6aef93334f3bfc22e2fef4ad0d969f69384e978a83a55f011a53e7e471"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "37d4a014b50393793d35c70431bd8a1842c197d854c6f174dfa946b9edc2b841"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6d3dc0198dd523a49fa94e054841aece853577b5c3ea1029fc288ad9ff580ab1b65ea99ddbe58c42125054e8c43be461"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "61609f60746406a7cb1ef3f979488beca6674fde208c9025d3fdee115de4767e8a4a1ee38f5bf79ac0104505ddb3558f1feeba5e318d6545647120ac60db6b89"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-compress@1.21?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/COMPRESS"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-compress.git"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-compress@1.21?type=jar"
+    },
+    {
+      "publisher" : "GlassFish Community",
+      "group" : "javax.servlet",
+      "name" : "javax.servlet-api",
+      "version" : "4.0.1",
+      "description" : "Java.net - The Source for Java Technology Collaboration",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b80414033bf3397de334b95e892a2f44"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a27082684a2ff0bf397666c3943496c44541d1ca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "83a03dd877d3674576f0da7b90755c8524af099ccf0607fc61aa971535ad7c60"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9f4522458bdb1c7cbc0e88271d1e4326193c8e4d422ef8b75c3dcadf0bf86a91389890ab2d25a8cc6cf276f625475cd3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "763dec9801f647b1a45e492eb2a67f6a60fc608bef4738eb7b1a92d93f1f6db02b32f4c6553d4557c320dfc25c0ea0b9854c59e793262b6ca453c71caf05ef38"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f94dd8bf0908ca77e5213d166035a427e658ff4a59d35daa7e281c5fb2fc390a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "be8a209d1912492e86e611fc42e59512a89c464aa78cea3c5badd3290a6564d8bde55933a7c5d8113d9acc848a382751"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3abbd3cad570557be24b69f700c217c7c8e1736d4db74f3ac28dd96b80822ac1c7631b3a9a15b9738754a3d68e4e7f13b732820eb8b8e8e329690ec2a23c621c"
+        }
+      ],
+      "licenses" : [ ],
+      "purl" : "pkg:maven/javax.servlet/javax.servlet-api@4.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://javaee.github.io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://maven.java.net/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/javaee/servlet-spec/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/javaee/servlet-spec"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/javax.servlet/javax.servlet-api@4.0.1?type=jar"
+    },
+    {
+      "group" : "com.google.guava",
+      "name" : "guava",
+      "version" : "31.1-jre",
+      "description" : "Guava is a suite of core and expanded libraries that include utility classes, Google's collections, I/O classes, and much more.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e37782d974104aa3b0a7bee9927c8042"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "60458f877d055d0c9114d9e1a2efb737b4bc282c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a42edc9cab792e39fe39bb94f3fca655ed157ff87a8af78e1d6ba5b07c4a00ab"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "829ba1c473782158d43a0e56c932b45139f121a504613b27eacf6b0774354e52c5eccaab5c2da3753b5686b93f0169b4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "532664e3dd33699bdfb296e355bc58fde77edc019c10f464ae49fe2494a68fd25d1623a9c86bc72830ca9f1354226366ac6f3c09d77be952641e971386a4ebbb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dd534fb7df6b380d8701290b0b0c4e388cf42f8179a436c509c0899afde91e5c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55f70ee4afad92540faa9d260109c00190e6d1bbacf10b22e52f599103284c1a8b2a2043d8fafbe1309245290b5fe614"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "617288cc45858588e0626edd21382d38b87cd0e6c78221e3a1626f579d5b4acd4adff37b72e3e51c73e91132f43951d12369624dd515f87bcc0c54213db43ede"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/guava@31.1-jre?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/google/guava/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/guava@31.1-jre?type=jar"
+    },
+    {
+      "group" : "com.google.guava",
+      "name" : "failureaccess",
+      "version" : "1.0.1",
+      "description" : "Contains com.google.common.util.concurrent.internal.InternalFutureFailureAccess and InternalFutures. Most users will never need to use this artifact. Its classes is conceptually a part of Guava, but they're in this separate artifact so that Android libraries can use them without pulling in all of Guava (just as they can use ListenableFuture by depending on the listenablefuture artifact).",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "091883993ef5bfa91da01dcc8fc52236"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "67659dbd9647ec303d7f15128dc9dba19b98fd8d74758ee3b602451e32c855e236ccaafe08edf4bbfa245f981268440f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f8d59b808d6ba617252305b66d5590937da9b2b843d492d06b8d0b1b1f397e39f360d5817707797b979a5bf20bf21987b35333e7a15c44ed7401fea2d2119cae"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ea86406e75fcd93eafe3cde1b3135ba485f1bb9b75fed98894a0bf1f0aee04f0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1460875f0331c5fa3791772a6a322a7db180261bc2adacf7271df1fbf3b088a587a755a604c039982cb593c5cfc1f101"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "52ac0f487ab5dd27c9f2e54fd1d84c7a620cae9d49be4072aa2b11501787bf4391ddaa13d02eccdf19e8eea46aecbea5f6064b26777c1b836108a280652e04ac"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/google/guava"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar"
+    },
+    {
+      "group" : "com.google.guava",
+      "name" : "listenablefuture",
+      "version" : "9999.0-empty-to-avoid-conflict-with-guava",
+      "description" : "An empty artifact that Guava depends on to signal that it is providing ListenableFuture -- but is also available in a second \"version\" that contains com.google.common.util.concurrent.ListenableFuture class, without any other Guava classes. The idea is: - If users want only ListenableFuture, they depend on listenablefuture-1.0. - If users want all of Guava, they depend on guava, which, as of Guava 27.0, depends on listenablefuture-9999.0-empty-to-avoid-conflict-with-guava. The 9999.0-... version number is enough for some build systems (notably, Gradle) to select that empty artifact over the \"real\" listenablefuture-1.0 -- avoiding a conflict with the copy of ListenableFuture in guava itself. If users are using an older version of Guava or a build system other than Gradle, they may see class conflicts. If so, they can solve them by manually excluding the listenablefuture artifact or manually forcing their build systems to use 9999.0-....",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d094c22570d65e132c19cea5d352e381"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b421526c5f297295adef1c886e5246c39d4ac629"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "caff9b74079f95832ca7f6029346b34b606051cc8c5a4389fac263511d277ada0c55f28b0d43011055b268c6eb7184d5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c5987a979174cbacae2e78b319f080420cc71bcdbcf7893745731eeb93c23ed13bff8d4599441f373f3a246023d33df03e882de3015ee932a74a774afdd0782f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1f0a8b1177773b3a8ace839df5eed63cbf56b24a38714898a6e4ed065c42559f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e939f08df0545847ea0d3e4b04a114b08499ad069ba8ec9461d1779f87a56e0c37273630a0f4c14e78c348d3ac7eb97f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6b495ecc2a18b17365cb08d124a0da47f04bcdde81927b5245edf3edd8e498c3c3fb92ce6a4127f660bac851bb1d3e4510e5c20d03be47ce99dc296d360db285"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/google/guava"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar"
+    },
+    {
+      "group" : "com.google.j2objc",
+      "name" : "j2objc-annotations",
+      "version" : "1.3",
+      "description" : "A set of annotations that provide additional information to the J2ObjC translator to modify the result of translation.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5fa4ec4ec0c5aa70af8a7d4922df1931"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ba035118bc8bac37d7eff77700720999acd9986d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d2a54e4bb17793a98f85fb8f91138cd3b3d311385b7fb2c09d05c3112d42218a6da29154ba184f00031919548022aa71"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "51ea975179f809cb260751d11a513881b643bf016d15949bcb63b57d3c8868a2197e0620ccbaa5739e032797ec6faa3aa6d64606e999fce32930314780ca4115"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e97bbe4e1ac9f9785ad0b81fd29fc9c6b0d9e37acc6da6d0b31ce9e6da072664"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8ba512ee47d36d5712335849e8f0fae21498c983c48fc2b4749ac7dfb4eeddf75dd51d21366667f90d6414db032a7b5b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "864bc6181c8ad8372e0a05ec3b0bdebc876571692331d3519e19df54a21ef333e992fe5c4e84759f010cf0657f9ea1c435bea8f103735ec3dc9dd31493e7d4a6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war",
+      "dependsOn" : [
+        "pkg:maven/us.springett/alpine-common@2.0.0?type=jar",
+        "pkg:maven/us.springett/alpine-model@2.0.0?type=jar",
+        "pkg:maven/us.springett/alpine-infra@2.0.0?type=jar",
+        "pkg:maven/us.springett/alpine-server@2.0.0?type=jar",
+        "pkg:maven/us.springett/cvss-calculator@1.4.1?type=jar",
+        "pkg:maven/us.springett/cpe-parser@2.0.2?type=jar",
+        "pkg:maven/org.cyclonedx/cyclonedx-core-java@7.1.4?type=jar",
+        "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar",
+        "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar",
+        "pkg:maven/org.json/json@20220320?type=jar",
+        "pkg:maven/com.github.package-url/packageurl-java@1.4.1?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-core@8.11.1?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-analyzers-common@8.11.1?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-queryparser@8.11.1?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-queries@8.11.1?type=jar",
+        "pkg:maven/org.apache.lucene/lucene-sandbox@8.11.1?type=jar",
+        "pkg:maven/io.pebbletemplates/pebble@3.1.5?type=jar",
+        "pkg:maven/us.springett/vulndb-data-mirror@1.0.1?type=jar",
+        "pkg:maven/com.konghq/unirest-java@3.13.8?type=jar",
+        "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.2.8?type=jar",
+        "pkg:maven/org.apache.maven/maven-artifact@3.8.5?type=jar",
+        "pkg:maven/com.microsoft.sqlserver/mssql-jdbc@11.1.1.jre11-preview?type=jar",
+        "pkg:maven/mysql/mysql-connector-java@8.0.29?type=jar",
+        "pkg:maven/org.postgresql/postgresql@42.3.5?type=jar",
+        "pkg:maven/xerces/xercesImpl@2.12.2?type=jar",
+        "pkg:maven/org.apache.commons/commons-compress@1.21?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/us.springett/alpine-common@2.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/us.springett/alpine-model@2.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.datanucleus/datanucleus-api-jdo@5.2.7?type=jar",
+        "pkg:maven/org.datanucleus/datanucleus-core@5.2.7?type=jar",
+        "pkg:maven/org.datanucleus/javax.jdo@3.2.0-release?type=jar",
+        "pkg:maven/org.glassfish.jersey.ext/jersey-bean-validation@2.35?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.datanucleus/datanucleus-api-jdo@5.2.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.datanucleus/datanucleus-core@5.2.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.datanucleus/javax.jdo@3.2.0-release?type=jar",
+      "dependsOn" : [
+        "pkg:maven/javax.transaction/javax.transaction-api@1.3?type=jar",
+        "pkg:maven/org.glassfish.corba/glassfish-corba-omgapi@4.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/javax.transaction/javax.transaction-api@1.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.corba/glassfish-corba-omgapi@4.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.ext/jersey-bean-validation@2.35?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.glassfish.hk2.external/jakarta.inject@2.6.1?type=jar",
+        "pkg:maven/org.glassfish.jersey.core/jersey-common@2.35?type=jar",
+        "pkg:maven/org.glassfish.jersey.core/jersey-server@2.35?type=jar",
+        "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+        "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.0.Final?type=jar",
+        "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+        "pkg:maven/org.glassfish/jakarta.el@3.0.4?type=jar",
+        "pkg:maven/jakarta.ws.rs/jakarta.ws.rs-api@2.1.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.hk2.external/jakarta.inject@2.6.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.core/jersey-common@2.35?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.glassfish.hk2/osgi-resource-locator@1.0.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.hk2/osgi-resource-locator@1.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.core/jersey-server@2.35?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish/jakarta.el@3.0.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.ws.rs/jakarta.ws.rs-api@2.1.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/us.springett/alpine-infra@2.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+        "pkg:maven/org.datanucleus/datanucleus-rdbms@5.2.7?type=jar",
+        "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+        "pkg:maven/org.javassist/javassist@3.28.0-GA?type=jar",
+        "pkg:maven/io.jsonwebtoken/jjwt@0.9.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.datanucleus/datanucleus-rdbms@5.2.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.javassist/javassist@3.28.0-GA?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.jsonwebtoken/jjwt@0.9.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/us.springett/alpine-server@2.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+        "pkg:maven/org.glassfish.jersey.core/jersey-client@2.35?type=jar",
+        "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet@2.35?type=jar",
+        "pkg:maven/org.glassfish.jersey.media/jersey-media-json-jackson@2.35?type=jar",
+        "pkg:maven/org.glassfish.jersey.media/jersey-media-multipart@2.35?type=jar",
+        "pkg:maven/org.glassfish.jersey.inject/jersey-hk2@2.35?type=jar",
+        "pkg:maven/javax.xml.bind/jaxb-api@2.3.1?type=jar",
+        "pkg:maven/com.sun.xml.bind/jaxb-core@2.3.0.1?type=jar",
+        "pkg:maven/com.sun.xml.bind/jaxb-impl@2.3.6?type=jar",
+        "pkg:maven/javax.json/javax.json-api@1.1.4?type=jar",
+        "pkg:maven/org.glassfish/javax.json@1.1.4?type=jar",
+        "pkg:maven/io.swagger/swagger-jersey2-jaxrs@1.6.6?type=jar",
+        "pkg:maven/com.h2database/h2@1.4.200?type=jar",
+        "pkg:maven/org.mindrot/jbcrypt@0.4?type=jar",
+        "pkg:maven/com.nimbusds/oauth2-oidc-sdk@9.35?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.2?type=jar",
+        "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+        "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+        "pkg:maven/org.owasp/security-logging-common@1.1.7?type=jar",
+        "pkg:maven/org.owasp/security-logging-logback@1.1.7?type=jar",
+        "pkg:maven/org.owasp.encoder/encoder@1.2.3?type=jar",
+        "pkg:maven/org.owasp.encoder/encoder-jsp@1.2.3?type=jar",
+        "pkg:maven/com.sun.mail/jakarta.mail@1.6.7?type=jar",
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+        "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.core/jersey-client@2.35?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet@2.35?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet-core@2.35?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.containers/jersey-container-servlet-core@2.35?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.media/jersey-media-json-jackson@2.35?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.glassfish.jersey.ext/jersey-entity-filtering@2.35?type=jar",
+        "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.ext/jersey-entity-filtering@2.35?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-jaxb-annotations@2.12.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.media/jersey-media-multipart@2.35?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jvnet.mimepull/mimepull@1.9.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jvnet.mimepull/mimepull@1.9.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jersey.inject/jersey-hk2@2.35?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.glassfish.hk2/hk2-locator@2.6.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.hk2/hk2-locator@2.6.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.glassfish.hk2.external/aopalliance-repackaged@2.6.1?type=jar",
+        "pkg:maven/org.glassfish.hk2/hk2-api@2.6.1?type=jar",
+        "pkg:maven/org.glassfish.hk2/hk2-utils@2.6.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.hk2.external/aopalliance-repackaged@2.6.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.hk2/hk2-api@2.6.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.hk2/hk2-utils@2.6.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/javax.xml.bind/jaxb-api@2.3.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.xml.bind/jaxb-core@2.3.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.xml.bind/jaxb-impl@2.3.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/javax.json/javax.json-api@1.1.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish/javax.json@1.1.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger/swagger-jersey2-jaxrs@1.6.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.swagger/swagger-jaxrs@1.6.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger/swagger-jaxrs@1.6.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.swagger/swagger-core@1.6.6?type=jar",
+        "pkg:maven/org.reflections/reflections@0.9.11?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger/swagger-core@1.6.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.13.2?type=jar",
+        "pkg:maven/io.swagger/swagger-models@1.6.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.13.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.yaml/snakeyaml@1.30?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger/swagger-models@1.6.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.swagger/swagger-annotations@1.6.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger/swagger-annotations@1.6.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.reflections/reflections@0.9.11?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.h2database/h2@1.4.200?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.mindrot/jbcrypt@0.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.nimbusds/oauth2-oidc-sdk@9.35?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar",
+        "pkg:maven/com.nimbusds/content-type@2.2?type=jar",
+        "pkg:maven/net.minidev/json-smart@2.4.8?type=jar",
+        "pkg:maven/com.nimbusds/lang-tag@1.6?type=jar",
+        "pkg:maven/com.nimbusds/nimbus-jose-jwt@9.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.stephenc.jcip/jcip-annotations@1.0-1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.nimbusds/content-type@2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.minidev/json-smart@2.4.8?type=jar",
+      "dependsOn" : [
+        "pkg:maven/net.minidev/accessors-smart@2.4.8?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/net.minidev/accessors-smart@2.4.8?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.ow2.asm/asm@9.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.ow2.asm/asm@9.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.nimbusds/lang-tag@1.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.nimbusds/nimbus-jose-jwt@9.22?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base@2.13.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider@2.13.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.owasp/security-logging-common@1.1.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.owasp/security-logging-logback@1.1.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.owasp.encoder/encoder@1.2.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.owasp.encoder/encoder-jsp@1.2.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.mail/jakarta.mail@1.6.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.ben-manes.caffeine/caffeine@3.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.13.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.13.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/us.springett/cvss-calculator@1.4.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/us.springett/cpe-parser@2.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@7.1.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-codec/commons-codec@1.15?type=jar",
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.13.2?type=jar",
+        "pkg:maven/com.networknt/json-schema-validator@1.0.69?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-codec/commons-codec@1.15?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.13.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.networknt/json-schema-validator@1.0.69?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ethlo.time/itu@1.5.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ethlo.time/itu@1.5.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+        "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+        "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+        "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/javax.activation/javax.activation-api@1.2.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.json/json@20220320?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.package-url/packageurl-java@1.4.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.lucene/lucene-core@8.11.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.lucene/lucene-analyzers-common@8.11.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.lucene/lucene-queryparser@8.11.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.lucene/lucene-queries@8.11.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.lucene/lucene-sandbox@8.11.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.pebbletemplates/pebble@3.1.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/us.springett/vulndb-data-mirror@1.0.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
+        "pkg:maven/oauth.signpost/signpost-core@2.1.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/oauth.signpost/signpost-core@2.1.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.konghq/unirest-java@3.13.8?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpcore-nio@4.4.13?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpasyncclient@4.1.5?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.9.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar",
+        "pkg:maven/commons-logging/commons-logging@1.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/commons-logging/commons-logging@1.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpcore-nio@4.4.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpasyncclient@4.1.5?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.code.gson/gson@2.9.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.2.8?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.maven/maven-artifact@3.8.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.microsoft.sqlserver/mssql-jdbc@11.1.1.jre11-preview?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/mysql/mysql-connector-java@8.0.29?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.protobuf/protobuf-java@3.19.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.protobuf/protobuf-java@3.19.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.postgresql/postgresql@42.3.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/xerces/xercesImpl@2.12.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-compress@1.21?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,10 @@
                 <goal>verify</goal>
               </goals>
               <configuration>
+                <includes>
+                  <include>**/*IT.java</include>
+                  <include>**/*E2ET.java</include>
+                </includes>
                 <systemPropertyVariables>
                   <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                   <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <lib.conscrypt.version>2.5.2</lib.conscrypt.version>
     <lib.cvss-calculator.version>1.4.1</lib.cvss-calculator.version>
     <lib.cyclonedx-java.version>7.3.2</lib.cyclonedx-java.version>
+    <lib.greenmail.version>1.6.14</lib.greenmail.version>
     <lib.json-unit.version>2.36.1</lib.json-unit.version>
     <lib.maven-artifact.version>4.0.0-alpha-4</lib.maven-artifact.version>
     <lib.mockserver-netty.version>5.15.0</lib.mockserver-netty.version>
@@ -163,6 +164,11 @@
         <groupId>net.javacrumbs.json-unit</groupId>
         <artifactId>json-unit-assertj</artifactId>
         <version>${lib.json-unit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.icegreen</groupId>
+        <artifactId>greenmail-junit5</artifactId>
+        <version>${lib.greenmail.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <sonar.projectKey>dependency-track_hyades</sonar.projectKey>
     <sonar.moduleKey>${artifactId}</sonar.moduleKey>
     <sonar.coverage.jacoco.xmlReportPaths>**/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.exclusions>e2e/**/*</sonar.exclusions>
 
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0</surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <module>repository-meta-analyzer</module>
     <module>proto</module>
     <module>vulnerability-analyzer</module>
+    <module>e2e</module>
   </modules>
 
   <properties>

--- a/scripts/create-topics.sh
+++ b/scripts/create-topics.sh
@@ -57,3 +57,4 @@ create_topic "${API_TOPIC_PREFIX:-}dtrack.vulnerability.mirror.osv" "${VULN_MIRR
 create_topic "${API_TOPIC_PREFIX:-}dtrack.vulnerability.mirror.nvd" "${VULN_MIRROR_TOPICS_PARTITIONS:-1}" "retention.ms=${VULN_MIRROR_TOPICS_RETENTION_MS:-43200000}"
 create_topic "${API_TOPIC_PREFIX:-}dtrack.vulnerability" "${VULN_MIRROR_TOPICS_PARTITIONS:-3}" "cleanup.policy=compact"
 
+echo "All topics created successfully"


### PR DESCRIPTION
This PRs lays the groundwork for end-to-end tests, incorporating all services and infrastructure components of the system.

Some cornerstones of the current implementation:

* [testcontainers](https://www.testcontainers.org/) is used to setup and tear down containers for every test case
* [WireMock](https://wiremock.org/) is used to verify Webhook alerts
* [GreenMail](https://greenmail-mail-test.github.io/greenmail/) is used to verify email alerts
* No Quarkus / CDI context is spun up to keep the tests simple and as lightweight as possible
* End-to-end tests live in the `e2e` module, and *must* be suffixed with `E2ET` to distinguish them from integration tests (`*IT`)
* End-to-end tests are skipped per default, enabling them requires usage of the `e2e-all` Maven profile
* End-to-end tests will be executed in CI **after** the *Publish Jar* workflow completes
  * This happens only for pushes to `main`

Closes #391