### PR TITLE
Fix `XPathFactoryConfigurationException` in `MavenMetaAnalyzer` when running JVM-based container image

### DIFF
--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -19,6 +19,17 @@
     <dependency>
       <groupId>org.hyades</groupId>
       <artifactId>commons</artifactId>
+      <exclusions>
+        <exclusion>
+          <!--
+            Causes XPathFactoryConfigurationException in MavenMetaAnalyzer
+            when running in JVM-based container image. It's likely conflicting
+            with other JAXP providers.
+          -->
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hyades</groupId>


### PR DESCRIPTION
Seems like Quarkus' custom classloader in combination with multiple JAXP implementations on the classpath is the culprit. Excluding the xerces dependency inherited from the `commons` module resolves the issue.

For reference, this is the error as identified in #422:

```
2023-03-21 15:21:48,070 INFO  [repo-meta-analyzer] (docker-java-stream-1096884721) STDOUT: 2023-03-21 14:21:48,067 ERROR [org.hya.pro.MetaAnalyzerProcessor] (hyades-repository-meta-analyzer-4574539f-8ab0-4c6c-b2cd-30a9e77b9653-StreamThread-2) Failed to analyze pkg:maven/com.google.errorprone/error_prone_annotations@2.13.1?type=jar using MavenMetaAnalyzer with repository central: java.lang.RuntimeException: XPathFactory#newInstance() failed to create an XPathFactory for the default object model: http://java.sun.com/jaxp/xpath/dom with the XPathFactoryConfigurationException: javax.xml.xpath.XPathFactoryConfigurationException: No XPathFctory implementation found for the object model: http://java.sun.com/jaxp/xpath/dom
2023-03-21 15:21:48,071 INFO  [repo-meta-analyzer] (docker-java-stream-1096884721) STDOUT:      at javax.xml.xpath.XPathFactory.newInstance(Unknown Source)
2023-03-21 15:21:48,072 INFO  [repo-meta-analyzer] (docker-java-stream-1096884721) STDOUT:      at org.hyades.repositories.MavenMetaAnalyzer.analyze(MavenMetaAnalyzer.java:88)
2023-03-21 15:21:48,073 INFO  [repo-meta-analyzer] (docker-java-stream-1096884721) STDOUT:      at org.hyades.processor.MetaAnalyzerProcessor.analyze(MetaAnalyzerProcessor.java:128)
2023-03-21 15:21:48,074 INFO  [repo-meta-analyzer] (docker-java-stream-1096884721) STDOUT:      at org.hyades.processor.MetaAnalyzerProcessor.process(MetaAnalyzerProcessor.java:95)
```