### PR TITLE
Fix NPE on mirror service

### DIFF
--- a/mirror-service/src/main/java/org/hyades/MirrorServiceTopology.java
+++ b/mirror-service/src/main/java/org/hyades/MirrorServiceTopology.java
@@ -78,6 +78,7 @@ public class MirrorServiceTopology {
 
     List<KeyValue<String, Bom>> mirrorOsv(String ecosystem) throws IOException {
         return osvMirrorHandler.performMirror(ecosystem).stream()
+                .filter(bom -> (bom.getVulnerabilities() != null  && bom.getVulnerabilities().get(0) != null))
                 .map(bom -> KeyValue.pair(Vulnerability.Source.OSV.name() + "/" + bom.getVulnerabilities().get(0).getId(), bom))
                 .toList();
     }

--- a/mirror-service/src/main/java/org/hyades/dto/OsvDto.java
+++ b/mirror-service/src/main/java/org/hyades/dto/OsvDto.java
@@ -156,6 +156,7 @@ public class OsvDto implements Serializable {
         this.aliases = aliases;
     }
 
+    @RegisterForReflection
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Credit {
         private String name;
@@ -179,6 +180,7 @@ public class OsvDto implements Serializable {
         private List<String> contact;
     }
 
+    @RegisterForReflection
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Reference {
         private String type;


### PR DESCRIPTION
Mirror service was failing with NPE when BOM did not had vulnerabilities
In native mode, since inner classes were. not registered for reflection, it could not deserialise