### PR TITLE
Bump Kafka client libraries to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <lib.cyclonedx-java.version>7.3.2</lib.cyclonedx-java.version>
     <lib.greenmail.version>1.6.14</lib.greenmail.version>
     <lib.json-unit.version>2.37.0</lib.json-unit.version>
+    <lib.kafka.version>3.4.0</lib.kafka.version>
     <lib.maven-artifact.version>4.0.0-alpha-5</lib.maven-artifact.version>
     <lib.mockserver-netty.version>5.15.0</lib.mockserver-netty.version>
     <lib.org-json.version>20230227</lib.org-json.version>
@@ -112,6 +113,24 @@
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
         <version>${lib.org-json.version}</version>
+      </dependency>
+             
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${lib.kafka.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-streams</artifactId>
+        <version>${lib.kafka.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-streams-test-utils</artifactId>
+        <version>${lib.kafka.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fixes the annoying `NullPointerException` whenever Kafka Streams applications start up:

```
Error while loading kafka-streams-version.properties: java.lang.NullPointerException: inStream parameter is null
```

Quarkus will only ship these updates in their v3 release.