### PR TITLE
Add tests for reworked mirror service

### DIFF
--- a/mirror-service-x/pom.xml
+++ b/mirror-service-x/pom.xml
@@ -48,6 +48,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-streams</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.github.jeremylong</groupId>

--- a/mirror-service-x/pom.xml
+++ b/mirror-service-x/pom.xml
@@ -62,6 +62,22 @@
             <groupId>dev.failsafe</groupId>
             <artifactId>failsafe</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-kafka-companion</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mirror-service-x/pom.xml
+++ b/mirror-service-x/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>wiremock-jre8-standalone</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jacoco</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mirror-service-x/pom.xml
+++ b/mirror-service-x/pom.xml
@@ -69,6 +69,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -76,6 +81,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-kafka-companion</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/mirror-service-x/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientBuilder.java
+++ b/mirror-service-x/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientBuilder.java
@@ -1,0 +1,139 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.ghsa;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Used to build an GitHub SecurityAdvisory GraphQL API client. As the GitHubSecurityAdvisoryClient client is
+ * autoclosable the builder should be used in a try with resources:
+ *
+ * <pre>
+ * try (GitHubSecurityAdvisoryClient api = GitHubSecurityAdvisoryClientBuilder.aGitHubSecurityAdvisoryClient()
+ *         .withApiKey(githubToken).build()) {
+ *     while (api.hasNext()) {
+ *         Collection&lt;SecurityAdvisory&gt; items = api.next();
+ *     }
+ * }
+ * </pre>
+ */
+public final class GitHubSecurityAdvisoryClientBuilder {
+
+    /**
+     * Reference to the logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(GitHubSecurityAdvisoryClientBuilder.class);
+    /**
+     * The GitHub SecurityAdvisory GraphQL API key.
+     */
+    private String apiKey;
+    /**
+     * The endpoint for the GitHub GraphQL API.
+     */
+    private String endpoint;
+    /**
+     * The updatedSince filter.
+     */
+    private ZonedDateTime updatedSince;
+    /**
+     * The publishedSince filter.
+     */
+    private ZonedDateTime publishedSince;
+
+    /**
+     * Private constructor for a builder.
+     */
+    private GitHubSecurityAdvisoryClientBuilder() {
+    }
+
+    /**
+     * Begin building the GitHub GraphQL for SecurityAdvisories Object.
+     *
+     * @return the builder
+     */
+    public static GitHubSecurityAdvisoryClientBuilder aGitHubSecurityAdvisoryClient() {
+        return new GitHubSecurityAdvisoryClientBuilder();
+    }
+
+    /**
+     * Use an GitHub SecurityAdvisory GraphQL API key.
+     *
+     * @param apiKey the GitHub API key.
+     * @return the builder
+     */
+    public GitHubSecurityAdvisoryClientBuilder withApiKey(String apiKey) {
+        this.apiKey = apiKey;
+        return this;
+    }
+
+    /**
+     * Use an alternative endpoint for the GitHub SecurityAdvisory GraphQL API.
+     *
+     * @param endpoint the endpoint for the GitHub SecurityAdvisory GraphQL API
+     * @return the builder
+     */
+    public GitHubSecurityAdvisoryClientBuilder withEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+        return this;
+    }
+
+    /**
+     * Filter for Security Advisories that have been updated since a specific date/time.
+     *
+     * @param utcUpdatedSince the UTC date time
+     * @return the builder
+     */
+    public GitHubSecurityAdvisoryClientBuilder withUpdatedSinceFilter(ZonedDateTime utcUpdatedSince) {
+        updatedSince = utcUpdatedSince;
+        return this;
+    }
+
+    /**
+     * Filter the results with a range of published since date/time.
+     *
+     * @param utcStartDate the UTC date time for the range start
+     * @return the builder
+     */
+    public GitHubSecurityAdvisoryClientBuilder withPublishedSinceFilter(ZonedDateTime utcStartDate) {
+        publishedSince = utcStartDate;
+        return this;
+    }
+
+    /**
+     * Build the GitHub SecurityAdvisory GraphQL API client.
+     *
+     * @return the GitHub SecurityAdvisory GraphQL API client
+     */
+    public GitHubSecurityAdvisoryClient build() {
+        GitHubSecurityAdvisoryClient client;
+        if (endpoint == null) {
+            client = new GitHubSecurityAdvisoryClient(apiKey);
+        }  else {
+            client = new GitHubSecurityAdvisoryClient(apiKey, endpoint);
+        }
+        if (publishedSince != null) {
+            client.setPublishedSinceFilter(publishedSince);
+        }
+        if (updatedSince != null) {
+            client.setUpdatedSinceFilter(updatedSince);
+        }
+        return client;
+    }
+}

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
@@ -31,7 +31,7 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
     private Logger logger;
 
     /**
-     * Non-private no-args constructor required by Quarkus.
+     * Non-private, no-args constructor required by Quarkus.
      * <p>
      * DO NOT USE, use {@link #AbstractDatasourceMirror(Datasource, MirrorStateStore, VulnerabilityDigestStore, Producer, Class)} instead.
      *
@@ -41,6 +41,13 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
     protected AbstractDatasourceMirror() {
     }
 
+    /**
+     * @param datasource       The {@link Datasource} supported by this mirror
+     * @param mirrorStateStore The state store to use for persisting state
+     * @param vulnDigestStore  The state store to use for querying vulnerability digests
+     * @param kafkaProducer    The Kafka {@link Producer} to use for publishing events
+     * @param stateClass       Class of the state object
+     */
     protected AbstractDatasourceMirror(final Datasource datasource,
                                        final MirrorStateStore mirrorStateStore,
                                        final VulnerabilityDigestStore vulnDigestStore,
@@ -54,6 +61,9 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
         this.logger = LoggerFactory.getLogger(getClass());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean supportsDatasource(final Datasource datasource) {
         return this.datasource == datasource;

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
@@ -102,13 +102,11 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
         final byte[] bovDigest = DigestUtils.getSha256Digest().digest(serializedBov);
 
         if (!Arrays.equals(vulnDigestStore.get(Datasource.NVD, vulnId), bovDigest)) {
-            // TODO: Change back to debug; info is used for demonstration purposes only.
-            logger.info("{} has changed", recordKey);
+            logger.debug("{} has changed", recordKey);
             kafkaProducer.send(new ProducerRecord<>(
                     KafkaTopic.NEW_VULNERABILITY.getName(), recordKey, serializedBov)).get();
         } else {
-            // TODO: Change back to debug; info is used for demonstration purposes only.
-            logger.info("{} did not change", recordKey);
+            logger.debug("{} did not change", recordKey);
         }
     }
 

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
@@ -1,16 +1,22 @@
 package org.hyades.vulnmirror.datasource;
 
+import com.google.protobuf.Timestamp;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.cyclonedx.proto.v1_4.Bom;
 import org.hyades.common.KafkaTopic;
+import org.hyades.proto.notification.v1.Group;
+import org.hyades.proto.notification.v1.Level;
+import org.hyades.proto.notification.v1.Notification;
+import org.hyades.proto.notification.v1.Scope;
 import org.hyades.vulnmirror.state.MirrorStateStore;
 import org.hyades.vulnmirror.state.VulnerabilityDigestStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -20,7 +26,7 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
     private Datasource datasource;
     public MirrorStateStore mirrorStateStore;
     private VulnerabilityDigestStore vulnDigestStore;
-    private Producer<String, byte[]> bovProducer;
+    private Producer<String, byte[]> kafkaProducer;
     private Class<T> stateClass;
     private Logger logger;
 
@@ -38,12 +44,12 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
     protected AbstractDatasourceMirror(final Datasource datasource,
                                        final MirrorStateStore mirrorStateStore,
                                        final VulnerabilityDigestStore vulnDigestStore,
-                                       final Producer<String, byte[]> bovProducer,
+                                       final Producer<String, byte[]> kafkaProducer,
                                        final Class<T> stateClass) {
         this.datasource = datasource;
         this.mirrorStateStore = mirrorStateStore;
         this.vulnDigestStore = vulnDigestStore;
-        this.bovProducer = bovProducer;
+        this.kafkaProducer = kafkaProducer;
         this.stateClass = stateClass;
         this.logger = LoggerFactory.getLogger(getClass());
     }
@@ -88,12 +94,34 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
         if (!Arrays.equals(vulnDigestStore.get(Datasource.NVD, vulnId), bovDigest)) {
             // TODO: Change back to debug; info is used for demonstration purposes only.
             logger.info("{} has changed", recordKey);
-            bovProducer.send(new ProducerRecord<>(
+            kafkaProducer.send(new ProducerRecord<>(
                     KafkaTopic.NEW_VULNERABILITY.getName(), recordKey, serializedBov)).get();
         } else {
             // TODO: Change back to debug; info is used for demonstration purposes only.
             logger.info("{} did not change", recordKey);
         }
+    }
+
+    /**
+     * Publish a {@link Notification} of group {@link Group#GROUP_DATASOURCE_MIRRORING} to Kafka.
+     *
+     * @param level   The {@link Level} of the {@link Notification}
+     * @param title   The title of the {@link Notification}
+     * @param content The content of the {@link Notification}
+     */
+    protected void dispatchNotification(final Level level, final String title, final String content) {
+        kafkaProducer.send(new ProducerRecord<>(
+                KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), null,
+                Notification.newBuilder()
+                        .setScope(Scope.SCOPE_SYSTEM)
+                        .setGroup(Group.GROUP_DATASOURCE_MIRRORING)
+                        .setLevel(level)
+                        .setTitle(title)
+                        .setContent(content)
+                        .setTimestamp(Timestamp.newBuilder()
+                                .setSeconds(Instant.now().getEpochSecond()))
+                        .build()
+                        .toByteArray()));
     }
 
 }

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/DatasourceMirror.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/DatasourceMirror.java
@@ -1,9 +1,22 @@
 package org.hyades.vulnmirror.datasource;
 
+import java.util.concurrent.Future;
+
 public interface DatasourceMirror {
 
+    /**
+     * Determine whether a given {@link Datasource} is supported by this mirror.
+     *
+     * @param datasource The {@link Datasource} to check
+     * @return {@code true} when supported, otherwise {@code false}
+     */
     boolean supportsDatasource(final Datasource datasource);
 
-    void doMirror();
+    /**
+     * <em>Asynchronously</em> execute a mirroring operating.
+     *
+     * @return A {@link Future} for tracking completion of the operation
+     */
+    Future<?> doMirror();
 
 }

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubApiClientFactory.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubApiClientFactory.java
@@ -22,6 +22,7 @@ class GitHubApiClientFactory {
     GitHubSecurityAdvisoryClient create(final long lastUpdatedEpochSeconds) {
         final GitHubSecurityAdvisoryClientBuilder builder = aGitHubSecurityAdvisoryClient();
 
+        config.baseUrl().ifPresent(builder::withEndpoint);
         config.apiKey().ifPresent(builder::withApiKey);
 
         if (lastUpdatedEpochSeconds > 0) {

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubConfig.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubConfig.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 @ConfigMapping(prefix = "mirror.datasource.github")
 public interface GitHubConfig {
 
+    Optional<String> baseUrl();
+
     Optional<String> apiKey();
 
 }

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorConfiguration.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorConfiguration.java
@@ -1,5 +1,7 @@
 package org.hyades.vulnmirror.datasource.github;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -22,6 +24,15 @@ class GitHubMirrorConfiguration {
 
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
                 new LinkedBlockingQueue<>(1), threadFactory);
+    }
+
+    @Produces
+    @ApplicationScoped
+    @Named("githubDurationTimer")
+    Timer durationTimer(final MeterRegistry meterRegistry) {
+        return Timer.builder("mirror.github.duration")
+                .description("Duration of GitHub mirroring operations")
+                .register(meterRegistry);
     }
 
 }

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorConfiguration.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorConfiguration.java
@@ -1,8 +1,6 @@
 package org.hyades.vulnmirror.datasource.github;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
@@ -20,10 +18,6 @@ class GitHubMirrorConfiguration {
     ExecutorService executorService() {
         final var threadFactory = new BasicThreadFactory.Builder()
                 .namingPattern("hyades-mirror-github-%d")
-                .uncaughtExceptionHandler((thread, exception) -> {
-                    final Logger logger = LoggerFactory.getLogger(GitHubMirror.class);
-                    logger.error("An uncaught exception was thrown while mirroring GitHub Advisories", exception);
-                })
                 .build();
 
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdApiClientFactory.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdApiClientFactory.java
@@ -20,6 +20,7 @@ class NvdApiClientFactory {
     NvdCveApi createApiClient(final long lastModifiedEpochSeconds) {
         final NvdCveApiBuilder builder = NvdCveApiBuilder.aNvdCveApi();
 
+        config.baseUrl().ifPresent(builder::withEndpoint);
         config.apiKey().ifPresent(apiKey -> {
             builder.withApiKey(apiKey);
             builder.withThreadCount(config.numThreads());

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdConfig.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdConfig.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 @ConfigMapping(prefix = "mirror.datasource.nvd")
 public interface NvdConfig {
 
+    Optional<String> baseUrl();
+
     Optional<String> apiKey();
 
     int numThreads();

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorConfiguration.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorConfiguration.java
@@ -1,5 +1,7 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -22,6 +24,15 @@ class NvdMirrorConfiguration {
 
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
                 new LinkedBlockingQueue<>(1), threadFactory);
+    }
+
+    @Produces
+    @ApplicationScoped
+    @Named("nvdDurationTimer")
+    Timer durationTimer(final MeterRegistry meterRegistry) {
+        return Timer.builder("mirror.nvd.duration")
+                .description("Duration of NVD mirroring operations")
+                .register(meterRegistry);
     }
 
 }

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorConfiguration.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorConfiguration.java
@@ -1,8 +1,6 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
@@ -20,10 +18,6 @@ class NvdMirrorConfiguration {
     ExecutorService executorService() {
         final var threadFactory = new BasicThreadFactory.Builder()
                 .namingPattern("hyades-mirror-nvd-%d")
-                .uncaughtExceptionHandler((thread, exception) -> {
-                    final Logger logger = LoggerFactory.getLogger(NvdMirror.class);
-                    logger.error("An uncaught exception was thrown while mirroring NVD", exception);
-                })
                 .build();
 
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/MirrorStateStore.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/MirrorStateStore.java
@@ -68,8 +68,7 @@ public class MirrorStateStore {
         Failsafe
                 .with(RetryPolicy.builder()
                         .handleResultIf(result -> {
-                            // TODO: Change back to debug; info is used for demonstration purposes only.
-                            LOGGER.info("Waiting for state to become consistent (want: {}; got: {})", state, result);
+                            LOGGER.debug("Waiting for state to become consistent (want: {}; got: {})", state, result);
                             return !Objects.equals(state, result);
                         })
                         .withDelay(Duration.ofMillis(100))

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/MirrorStateStore.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/MirrorStateStore.java
@@ -18,6 +18,22 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * A key-value store for {@link Datasource} mirrors to store their internal state.
+ * <p>
+ * The store is backed by a Kafka Streams global {@link ReadOnlyKeyValueStore},
+ * that is populated by the application's Kafka Streams topology.
+ * <p>
+ * Writing to the store via {@link #put(Datasource, Object)} involves publishing of change events
+ * to the backing {@link ReadOnlyKeyValueStore}'s changelog topic. This makes changes to the store
+ * eventually consistent, as there is no guarantee how soon changes will be visible.
+ * <p>
+ * If consistent reads are required, {@link #putAndWait(Datasource, Object)} should be used instead.
+ * <p>
+ * The design is heavily influenced by the Strimzi topic operator.
+ *
+ * @see <a href="https://github.com/strimzi/strimzi-kafka-operator/blob/0.34.0/topic-operator/design/topic-store.md">Strimzi Topic Operator</a>
+ */
 @ApplicationScoped
 public class MirrorStateStore {
 

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/StateStoreUpdater.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/StateStoreUpdater.java
@@ -1,10 +1,25 @@
 package org.hyades.vulnmirror.state;
 
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
 
+/**
+ * A {@link ContextualProcessor} for updating global state stores.
+ * <p>
+ * Note that this processor must not perform any transformations on the records,
+ * it must simply insert or delete records from the store.
+ * <p>
+ * Refer to {@link StreamsBuilder#addGlobalStore(StoreBuilder, String, Consumed, ProcessorSupplier)} for details.
+ *
+ * @param <K> Type of the record key
+ * @param <V> Type of the record value
+ */
 public class StateStoreUpdater<K, V> extends ContextualProcessor<K, V, Void, Void> {
 
     private final String storeName;

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/StateStores.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/StateStores.java
@@ -15,6 +15,9 @@ import java.time.Duration;
 
 import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
 
+/**
+ * @see <a href="https://kafka.apache.org/34/documentation/streams/developer-guide/interactive-queries.html">Interactive Queries</a>
+ */
 public final class StateStores {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StateStores.class);
@@ -36,8 +39,8 @@ public final class StateStores {
         return Failsafe
                 .with(RetryPolicy.builder()
                         .handle(InvalidStateStoreException.class)
-                        .onRetry(event -> LOGGER.debug("State store {} is not ready yet; Retrying", name))
-                        .onRetriesExceeded(event -> LOGGER.debug("Retries exceeded for state store {}", name))
+                        .onRetry(event -> LOGGER.debug("State store {} is not ready yet; Retrying", name, event.getLastException()))
+                        .onRetriesExceeded(event -> LOGGER.warn("Max retries exceeded while waiting for state store {} to become ready", name, event.getException()))
                         .onSuccess(event -> LOGGER.debug("State store {} is ready", name))
                         .withDelay(Duration.ofMillis(50))
                         .withMaxRetries(100)

--- a/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/StateStores.java
+++ b/mirror-service-x/src/main/java/org/hyades/vulnmirror/state/StateStores.java
@@ -16,6 +16,8 @@ import java.time.Duration;
 import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
 
 /**
+ * Utilities for accessing Kafka Streams state stores for interactive queries.
+ *
  * @see <a href="https://kafka.apache.org/34/documentation/streams/developer-guide/interactive-queries.html">Interactive Queries</a>
  */
 public final class StateStores {
@@ -28,6 +30,19 @@ public final class StateStores {
     private StateStores() {
     }
 
+    /**
+     * Get a {@link ReadOnlyKeyValueStore} with a given name.
+     * <p>
+     * Will wait up to 5 seconds for the state store to become accessible,
+     * in case it is not ready yet, for example during a re-balance.
+     *
+     * @param name Name of the key-value store to get
+     * @param <K>  Type of the key
+     * @param <V>  Type of the value
+     * @return The key-value state store
+     * @throws IllegalStateException      When no {@link KafkaStreams} instance could be discovered via CDI
+     * @throws InvalidStateStoreException When the state store could not be accessed
+     */
     static <K, V> ReadOnlyKeyValueStore<K, V> keyValueStore(final String name) {
         final Instance<KafkaStreams> kafkaStreamsInstance = CDI.current().select(KafkaStreams.class);
         if (!kafkaStreamsInstance.isResolvable()) {

--- a/mirror-service-x/src/main/resources/application.properties
+++ b/mirror-service-x/src/main/resources/application.properties
@@ -10,13 +10,13 @@ quarkus.arc.exclude-types=org.hyades.persistence.*
 
 ## Kafka
 #
-kafka.bootstrap.servers=localhost:9092
+%dev.kafka.bootstrap.servers=localhost:9092
 quarkus.kafka.snappy.enabled=true
 kafka.compression.type=snappy
 
 ## Kafka Streams
 #
-quarkus.kafka-streams.bootstrap-servers=localhost:9092
+%dev.quarkus.kafka-streams.bootstrap-servers=localhost:9092
 quarkus.kafka-streams.application-server=localhost:8093
 quarkus.kafka-streams.topics=\
   dtrack.vulnerability,\
@@ -27,6 +27,14 @@ quarkus.kafka-streams.topics=\
 quarkus.log.category."org.apache.kafka".level=WARN
 kafka-streams.num.stream.threads=3
 kafka-streams.commit.interval.ms=1000
+
+## Dev Services for Kafka
+#
+quarkus.kafka.devservices.image-name=docker.redpanda.com/vectorized/redpanda:v23.1.2
+quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability.mirror.command"=1
+quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability.mirror.state"=1
+quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability.digest"=1
+quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability"=1
 
 mirror.datasource.nvd.api-key=
 mirror.datasource.nvd.num-threads=4

--- a/mirror-service-x/src/main/resources/application.properties
+++ b/mirror-service-x/src/main/resources/application.properties
@@ -13,6 +13,12 @@ quarkus.arc.exclude-types=org.hyades.persistence.*
 %dev.kafka.bootstrap.servers=localhost:9092
 quarkus.kafka.snappy.enabled=true
 kafka.compression.type=snappy
+# Quarkus' ClassLoader black magic doesn't play well with
+# native libraries like the one required by Snappy.
+# It's causing failures when multiple tests with different
+# TestProfile are executed in the same test run.
+%test.quarkus.kafka.snappy.enabled=false
+%test.kafka.compression.type=none
 
 ## Kafka Streams
 #
@@ -35,6 +41,7 @@ quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability.mirror.command"
 quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability.mirror.state"=1
 quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability.digest"=1
 quarkus.kafka.devservices.topic-partitions."dtrack.vulnerability"=1
+quarkus.kafka.devservices.topic-partitions."dtrack.notification.datasource-mirroring"=1
 
 mirror.datasource.nvd.api-key=
 mirror.datasource.nvd.num-threads=4

--- a/mirror-service-x/src/test/java/org/hyades/util/WireMockTestResource.java
+++ b/mirror-service-x/src/test/java/org/hyades/util/WireMockTestResource.java
@@ -1,6 +1,7 @@
 package org.hyades.util;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 import java.lang.annotation.ElementType;
@@ -36,7 +37,7 @@ public class WireMockTestResource implements QuarkusTestResourceLifecycleManager
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer = new WireMockServer(options().dynamicPort().notifier(new ConsoleNotifier(true)));
         wireMockServer.start();
 
         if (serverUrlProperty == null) {

--- a/mirror-service-x/src/test/java/org/hyades/util/WireMockTestResource.java
+++ b/mirror-service-x/src/test/java/org/hyades/util/WireMockTestResource.java
@@ -1,7 +1,6 @@
 package org.hyades.util;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 import java.lang.annotation.ElementType;
@@ -37,7 +36,7 @@ public class WireMockTestResource implements QuarkusTestResourceLifecycleManager
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(options().dynamicPort().notifier(new ConsoleNotifier(true)));
+        wireMockServer = new WireMockServer(options().dynamicPort());
         wireMockServer.start();
 
         if (serverUrlProperty == null) {

--- a/mirror-service-x/src/test/java/org/hyades/util/WireMockTestResource.java
+++ b/mirror-service-x/src/test/java/org/hyades/util/WireMockTestResource.java
@@ -1,0 +1,63 @@
+package org.hyades.util;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+/**
+ * A Quarkus test resource that provisions a WireMock server on a random open port.
+ * <p>
+ * Note that the same {@link WireMockServer} instance will be used for all tests in the
+ * annotated test class. Stubs will need to manually be reset after each test using {@link WireMockServer#resetAll()}.
+ *
+ * @see <a href="https://quarkus.io/guides/getting-started-testing#altering-the-test-class">Quarkus Documentation</a>
+ */
+public class WireMockTestResource implements QuarkusTestResourceLifecycleManager {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface InjectWireMock {
+    }
+
+    private WireMockServer wireMockServer;
+    private String serverUrlProperty;
+
+    @Override
+    public void init(final Map<String, String> initArgs) {
+        serverUrlProperty = initArgs.get("serverUrlProperty");
+    }
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+
+        if (serverUrlProperty == null) {
+            return null;
+        }
+
+        return Map.of(serverUrlProperty, wireMockServer.baseUrl());
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+            wireMockServer = null;
+        }
+    }
+
+    @Override
+    public void inject(final TestInjector testInjector) {
+        testInjector.injectIntoFields(wireMockServer,
+                new TestInjector.AnnotatedAndMatchesType(InjectWireMock.class, WireMockServer.class));
+    }
+
+}

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
@@ -94,6 +94,8 @@ class KafkaStreamsTopologyIT {
             // Wait for all expected vulnerability records; There should be one for each CVE.
             final List<ConsumerRecord<String, Bom>> results = kafkaCompanion
                     .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                    .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                    .withAutoCommit()
                     .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 3, Duration.ofSeconds(15))
                     .awaitCompletion()
                     .getRecords();
@@ -132,6 +134,8 @@ class KafkaStreamsTopologyIT {
             // Wait for the notification that reports the successful mirroring operation.
             final List<ConsumerRecord<String, Notification>> notifications = kafkaCompanion
                     .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                    .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                    .withAutoCommit()
                     .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
                     .awaitCompletion()
                     .getRecords();
@@ -194,6 +198,8 @@ class KafkaStreamsTopologyIT {
             // Wait for all expected vulnerability records; There should be one for each advisory.
             final List<ConsumerRecord<String, Bom>> results = kafkaCompanion
                     .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                    .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                    .withAutoCommit()
                     .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 3, Duration.ofSeconds(15))
                     .awaitCompletion()
                     .getRecords();
@@ -236,6 +242,8 @@ class KafkaStreamsTopologyIT {
             // Wait for the notification that reports the successful mirroring operation.
             final List<ConsumerRecord<String, Notification>> notifications = kafkaCompanion
                     .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                    .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                    .withAutoCommit()
                     .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
                     .awaitCompletion()
                     .getRecords();

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
@@ -4,6 +4,8 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
@@ -15,6 +17,7 @@ import org.cyclonedx.proto.v1_4.Bom;
 import org.cyclonedx.proto.v1_4.Vulnerability;
 import org.hyades.common.KafkaTopic;
 import org.hyades.proto.KafkaProtobufSerde;
+import org.hyades.proto.notification.v1.Notification;
 import org.hyades.util.WireMockTestResource;
 import org.hyades.util.WireMockTestResource.InjectWireMock;
 import org.junit.jupiter.api.Test;
@@ -24,10 +27,14 @@ import org.junit.platform.suite.api.Suite;
 import javax.ws.rs.core.MediaType;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.http.Body.fromJsonBytes;
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
@@ -55,6 +62,7 @@ class KafkaStreamsTopologyIT {
 
         @Test
         void test() throws Exception {
+            // Simulate the first page of CVEs, containing 2 CVEs.
             wireMock.stubFor(get(urlPathEqualTo("/"))
                     .withQueryParam("startIndex", equalTo("0"))
                     .willReturn(aResponse()
@@ -62,22 +70,28 @@ class KafkaStreamsTopologyIT {
                             .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                             .withResponseBody(fromJsonBytes(resourceToByteArray("/datasource/nvd/cves-page-01.json")))));
 
+            // Simulate the second page of CVEs, containing only one item.
+            // NOTE: The nvd-lib library will request pages of 2000 items each,
+            // that's why we're expecting a startIndex=2000 parameter here.
             wireMock.stubFor(get(urlPathEqualTo("/"))
                     .withQueryParam("startIndex", equalTo("2000"))
                     .willReturn(aResponse()
                             .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                             .withResponseBody(fromJsonBytes(resourceToByteArray("/datasource/nvd/cves-page-02.json")))));
 
+            // Trigger a NVD mirroring operation.
             kafkaCompanion
                     .produce(Serdes.String(), Serdes.String())
                     .fromRecords(new ProducerRecord<>(KafkaTopic.VULNERABILITY_MIRROR_COMMAND.getName(), "NVD", null));
 
+            // Wait for all expected vulnerability records; There should be one for each CVE.
             final List<ConsumerRecord<String, Bom>> results = kafkaCompanion
                     .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
                     .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 3, Duration.ofSeconds(15))
                     .awaitCompletion()
                     .getRecords();
 
+            // Ensure the vulnerability details are correct.
             assertThat(results).satisfiesExactlyInAnyOrder(
                     record -> {
                         assertThat(record.key()).isEqualTo("NVD/CVE-2022-40489");
@@ -107,16 +121,32 @@ class KafkaStreamsTopologyIT {
                         assertThat(vuln.getSource().getName()).isEqualTo("NVD");
                     }
             );
+
+            // Wait for the notification that reports the successful mirroring operation.
+            final List<ConsumerRecord<String, Notification>> notifications = kafkaCompanion
+                    .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                    .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
+                    .awaitCompletion()
+                    .getRecords();
+            assertThat(notifications).hasSize(1);
         }
 
     }
 
     @QuarkusIntegrationTest
+    @TestProfile(GitHubMirrorIT.TestProfile.class)
     @QuarkusTestResource(KafkaCompanionResource.class)
     @QuarkusTestResource(value = WireMockTestResource.class, initArgs = {
             @ResourceArg(name = "serverUrlProperty", value = "mirror.datasource.github.base-url")
     })
-    public static class GitHubMirrorIT {
+    static class GitHubMirrorIT {
+
+        public static class TestProfile implements QuarkusTestProfile {
+            @Override
+            public Map<String, String> getConfigOverrides() {
+                return Map.of("mirror.datasource.github.api-key", "foobar");
+            }
+        }
 
         @InjectKafkaCompanion
         KafkaCompanion kafkaCompanion;
@@ -125,8 +155,78 @@ class KafkaStreamsTopologyIT {
         WireMockServer wireMock;
 
         @Test
-        void test() {
+        void test() throws Exception {
+            wireMock.stubFor(any(anyUrl())
+                    .willReturn(aResponse()
+                            .withStatus(418)));
 
+            // Simulate the first page of CVEs, containing 2 CVEs.
+            wireMock.stubFor(post(anyUrl())
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                            .withResponseBody(fromJsonBytes(resourceToByteArray("/datasource/github/advisories-page-01.json")))));
+
+            // Simulate the second page of CVEs, containing only one item.
+            // NOTE: The nvd-lib library will request pages of 2000 items each,
+            // that's why we're expecting a startIndex=2000 parameter here.
+            wireMock.stubFor(post(anyUrl())
+                    .inScenario("advisories-paging")
+                    .whenScenarioStateIs("first-page-fetched")
+                    .willReturn(aResponse()
+                            .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                            .withResponseBody(fromJsonBytes(resourceToByteArray("/datasource/github/advisories-page-02.json")))));
+
+            // Trigger a NVD mirroring operation.
+            kafkaCompanion
+                    .produce(Serdes.String(), Serdes.String())
+                    .fromRecords(new ProducerRecord<>(KafkaTopic.VULNERABILITY_MIRROR_COMMAND.getName(), "GITHUB", null));
+
+            // Wait for all expected vulnerability records; There should be one for each CVE.
+            final List<ConsumerRecord<String, Bom>> results = kafkaCompanion
+                    .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                    .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 3, Duration.ofSeconds(15))
+                    .awaitCompletion()
+                    .getRecords();
+
+            // Ensure the vulnerability details are correct.
+            assertThat(results).satisfiesExactlyInAnyOrder(
+                    record -> {
+                        assertThat(record.key()).isEqualTo("NVD/CVE-2022-40489");
+                        assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                        final Vulnerability vuln = record.value().getVulnerabilities(0);
+                        assertThat(vuln.getId()).isEqualTo("CVE-2022-40489");
+                        assertThat(vuln.hasSource()).isTrue();
+                        assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                    },
+                    record -> {
+                        assertThat(record.key()).isEqualTo("NVD/CVE-2022-40849");
+                        assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                        final Vulnerability vuln = record.value().getVulnerabilities(0);
+                        assertThat(vuln.getId()).isEqualTo("CVE-2022-40849");
+                        assertThat(vuln.hasSource()).isTrue();
+                        assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                    },
+                    record -> {
+                        assertThat(record.key()).isEqualTo("NVD/CVE-2022-44262");
+                        assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                        final Vulnerability vuln = record.value().getVulnerabilities(0);
+                        assertThat(vuln.getId()).isEqualTo("CVE-2022-44262");
+                        assertThat(vuln.hasSource()).isTrue();
+                        assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                    }
+            );
+
+            // Wait for the notification that reports the successful mirroring operation.
+            final List<ConsumerRecord<String, Notification>> notifications = kafkaCompanion
+                    .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                    .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
+                    .awaitCompletion()
+                    .getRecords();
+            assertThat(notifications).hasSize(1);
         }
 
     }

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
@@ -1,0 +1,134 @@
+package org.hyades.vulnmirror;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import org.apache.http.HttpHeaders;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.cyclonedx.proto.v1_4.Bom;
+import org.cyclonedx.proto.v1_4.Vulnerability;
+import org.hyades.common.KafkaTopic;
+import org.hyades.proto.KafkaProtobufSerde;
+import org.hyades.util.WireMockTestResource;
+import org.hyades.util.WireMockTestResource.InjectWireMock;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+import javax.ws.rs.core.MediaType;
+import java.time.Duration;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.http.Body.fromJsonBytes;
+import static org.apache.commons.io.IOUtils.resourceToByteArray;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Suite
+@SelectClasses(value = {
+        KafkaStreamsTopologyIT.NvdMirrorIT.class,
+        KafkaStreamsTopologyIT.GitHubMirrorIT.class
+})
+class KafkaStreamsTopologyIT {
+
+    @QuarkusIntegrationTest
+    @QuarkusTestResource(KafkaCompanionResource.class)
+    @QuarkusTestResource(value = WireMockTestResource.class, initArgs = {
+            @ResourceArg(name = "serverUrlProperty", value = "mirror.datasource.nvd.base-url")
+    })
+    static class NvdMirrorIT {
+
+        @InjectKafkaCompanion
+        KafkaCompanion kafkaCompanion;
+
+        @InjectWireMock
+        WireMockServer wireMock;
+
+        @Test
+        void test() throws Exception {
+            wireMock.stubFor(get(urlPathEqualTo("/"))
+                    .withQueryParam("startIndex", equalTo("0"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                            .withResponseBody(fromJsonBytes(resourceToByteArray("/datasource/nvd/cves-page-01.json")))));
+
+            wireMock.stubFor(get(urlPathEqualTo("/"))
+                    .withQueryParam("startIndex", equalTo("2000"))
+                    .willReturn(aResponse()
+                            .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                            .withResponseBody(fromJsonBytes(resourceToByteArray("/datasource/nvd/cves-page-02.json")))));
+
+            kafkaCompanion
+                    .produce(Serdes.String(), Serdes.String())
+                    .fromRecords(new ProducerRecord<>(KafkaTopic.VULNERABILITY_MIRROR_COMMAND.getName(), "NVD", null));
+
+            final List<ConsumerRecord<String, Bom>> results = kafkaCompanion
+                    .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                    .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 3, Duration.ofSeconds(15))
+                    .awaitCompletion()
+                    .getRecords();
+
+            assertThat(results).satisfiesExactlyInAnyOrder(
+                    record -> {
+                        assertThat(record.key()).isEqualTo("NVD/CVE-2022-40489");
+                        assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                        final Vulnerability vuln = record.value().getVulnerabilities(0);
+                        assertThat(vuln.getId()).isEqualTo("CVE-2022-40489");
+                        assertThat(vuln.hasSource()).isTrue();
+                        assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                    },
+                    record -> {
+                        assertThat(record.key()).isEqualTo("NVD/CVE-2022-40849");
+                        assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                        final Vulnerability vuln = record.value().getVulnerabilities(0);
+                        assertThat(vuln.getId()).isEqualTo("CVE-2022-40849");
+                        assertThat(vuln.hasSource()).isTrue();
+                        assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                    },
+                    record -> {
+                        assertThat(record.key()).isEqualTo("NVD/CVE-2022-44262");
+                        assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                        final Vulnerability vuln = record.value().getVulnerabilities(0);
+                        assertThat(vuln.getId()).isEqualTo("CVE-2022-44262");
+                        assertThat(vuln.hasSource()).isTrue();
+                        assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                    }
+            );
+        }
+
+    }
+
+    @QuarkusIntegrationTest
+    @QuarkusTestResource(KafkaCompanionResource.class)
+    @QuarkusTestResource(value = WireMockTestResource.class, initArgs = {
+            @ResourceArg(name = "serverUrlProperty", value = "mirror.datasource.github.base-url")
+    })
+    public static class GitHubMirrorIT {
+
+        @InjectKafkaCompanion
+        KafkaCompanion kafkaCompanion;
+
+        @InjectWireMock
+        WireMockServer wireMock;
+
+        @Test
+        void test() {
+
+        }
+
+    }
+
+}

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/TestConstants.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/TestConstants.java
@@ -1,0 +1,10 @@
+package org.hyades.vulnmirror;
+
+public final class TestConstants {
+
+    public static final String CONSUMER_GROUP_ID = "test-consumer-group";
+
+    private TestConstants() {
+    }
+
+}

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
@@ -16,6 +16,7 @@ import org.cyclonedx.proto.v1_4.Vulnerability;
 import org.hyades.common.KafkaTopic;
 import org.hyades.proto.KafkaProtobufSerde;
 import org.hyades.proto.notification.v1.Notification;
+import org.hyades.vulnmirror.TestConstants;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -67,6 +68,8 @@ class GitHubMirrorTest {
 
         final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
                 .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
                 .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
                 .awaitCompletion()
                 .getRecords();
@@ -98,6 +101,8 @@ class GitHubMirrorTest {
 
         final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
                 .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
                 .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
                 .awaitCompletion()
                 .getRecords();
@@ -135,6 +140,8 @@ class GitHubMirrorTest {
 
         final List<ConsumerRecord<String, Bom>> vulnRecords = kafkaCompanion
                 .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
                 .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 1, Duration.ofSeconds(5))
                 .awaitCompletion()
                 .getRecords();

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
@@ -1,0 +1,160 @@
+package org.hyades.vulnmirror.datasource.github;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jeremylong.ghsa.GitHubSecurityAdvisoryClient;
+import io.github.jeremylong.ghsa.SecurityAdvisory;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.cyclonedx.proto.v1_4.Bom;
+import org.cyclonedx.proto.v1_4.Vulnerability;
+import org.hyades.common.KafkaTopic;
+import org.hyades.proto.KafkaProtobufSerde;
+import org.hyades.proto.notification.v1.Notification;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.apache.commons.io.IOUtils.resourceToByteArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.hyades.proto.notification.v1.Group.GROUP_DATASOURCE_MIRRORING;
+import static org.hyades.proto.notification.v1.Level.LEVEL_ERROR;
+import static org.hyades.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
+import static org.hyades.proto.notification.v1.Scope.SCOPE_SYSTEM;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
+class GitHubMirrorTest {
+
+    @Inject
+    GitHubMirror githubMirror;
+
+    @InjectMock
+    GitHubApiClientFactory apiClientFactoryMock;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @InjectKafkaCompanion
+    KafkaCompanion kafkaCompanion;
+
+    @Test
+    void testDoMirrorSuccessNotification() {
+        final var apiClientMock = mock(GitHubSecurityAdvisoryClient.class);
+        when(apiClientMock.hasNext())
+                .thenReturn(false);
+
+        when(apiClientFactoryMock.create(anyLong()))
+                .thenReturn(apiClientMock);
+
+        assertThatNoException().isThrownBy(() -> githubMirror.doMirror().get());
+
+        final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(notificationRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isNull();
+                    assertThat(record.value().getScope()).isEqualTo(SCOPE_SYSTEM);
+                    assertThat(record.value().getGroup()).isEqualTo(GROUP_DATASOURCE_MIRRORING);
+                    assertThat(record.value().getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                    assertThat(record.value().getTitle()).isEqualTo("GitHub Advisory Mirroring");
+                    assertThat(record.value().getContent()).isEqualTo("Mirroring of GitHub Advisories completed successfully.");
+                }
+        );
+    }
+
+    @Test
+    void testDoMirrorFailureNotification() {
+        final var apiClientMock = mock(GitHubSecurityAdvisoryClient.class);
+        when(apiClientMock.hasNext())
+                .thenReturn(true);
+        when(apiClientMock.next())
+                .thenThrow(new IllegalStateException());
+
+        when(apiClientFactoryMock.create(anyLong()))
+                .thenReturn(apiClientMock);
+
+        assertThatNoException().isThrownBy(() -> githubMirror.doMirror().get());
+
+        final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(notificationRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isNull();
+                    assertThat(record.value().getScope()).isEqualTo(SCOPE_SYSTEM);
+                    assertThat(record.value().getGroup()).isEqualTo(GROUP_DATASOURCE_MIRRORING);
+                    assertThat(record.value().getLevel()).isEqualTo(LEVEL_ERROR);
+                    assertThat(record.value().getTitle()).isEqualTo("GitHub Advisory Mirroring");
+                    assertThat(record.value().getContent()).isEqualTo("An error occurred mirroring the contents of GitHub Advisories. Check log for details.");
+                }
+        );
+    }
+
+    @Test
+    void testMirrorInternal() throws Exception {
+        final var advisory = objectMapper.readValue(resourceToByteArray("/datasource/github/advisory.json"), SecurityAdvisory.class);
+
+        final var apiClientMock = mock(GitHubSecurityAdvisoryClient.class);
+        when(apiClientMock.hasNext())
+                .thenReturn(true)
+                .thenReturn(false);
+        when(apiClientMock.next())
+                .thenReturn(List.of(advisory));
+        when(apiClientMock.getLastUpdated())
+                .thenReturn(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1679922240L), ZoneOffset.UTC));
+
+        when(apiClientFactoryMock.create(anyLong()))
+                .thenReturn(apiClientMock);
+
+        assertThatNoException().isThrownBy(() -> githubMirror.mirrorInternal());
+        verify(apiClientFactoryMock).create(eq(0L));
+
+        final List<ConsumerRecord<String, Bom>> vulnRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(vulnRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isEqualTo("GITHUB/GHSA-fxwm-579q-49qq");
+                    assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                    final Vulnerability vuln = record.value().getVulnerabilities(0);
+                    assertThat(vuln.getId()).isEqualTo("GHSA-fxwm-579q-49qq");
+                    assertThat(vuln.hasSource()).isTrue();
+                    assertThat(vuln.getSource().getName()).isEqualTo("GITHUB");
+                }
+        );
+
+        // Trigger a mirror operation one more time.
+        // Verify that this time the previously stored "last updated" timestamp is used.
+        assertThatNoException().isThrownBy(() -> githubMirror.mirrorInternal());
+        verify(apiClientFactoryMock).create(eq(1679922240L));
+    }
+
+}

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
@@ -1,0 +1,158 @@
+package org.hyades.vulnmirror.datasource.nvd;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jeremylong.nvdlib.NvdCveApi;
+import io.github.jeremylong.nvdlib.nvd.DefCveItem;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.cyclonedx.proto.v1_4.Bom;
+import org.cyclonedx.proto.v1_4.Vulnerability;
+import org.hyades.common.KafkaTopic;
+import org.hyades.proto.KafkaProtobufSerde;
+import org.hyades.proto.notification.v1.Notification;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.time.Duration;
+import java.util.List;
+
+import static org.apache.commons.io.IOUtils.resourceToByteArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.hyades.proto.notification.v1.Group.GROUP_DATASOURCE_MIRRORING;
+import static org.hyades.proto.notification.v1.Level.LEVEL_ERROR;
+import static org.hyades.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
+import static org.hyades.proto.notification.v1.Scope.SCOPE_SYSTEM;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
+class NvdMirrorTest {
+
+    @Inject
+    NvdMirror nvdMirror;
+
+    @InjectMock
+    NvdApiClientFactory apiClientFactoryMock;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @InjectKafkaCompanion
+    KafkaCompanion kafkaCompanion;
+
+    @Test
+    void testDoMirrorSuccessNotification() {
+        final var apiClientMock = mock(NvdCveApi.class);
+        when(apiClientMock.hasNext())
+                .thenReturn(false);
+
+        when(apiClientFactoryMock.createApiClient(anyLong()))
+                .thenReturn(apiClientMock);
+
+        assertThatNoException().isThrownBy(() -> nvdMirror.doMirror().get());
+
+        final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(notificationRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isNull();
+                    assertThat(record.value().getScope()).isEqualTo(SCOPE_SYSTEM);
+                    assertThat(record.value().getGroup()).isEqualTo(GROUP_DATASOURCE_MIRRORING);
+                    assertThat(record.value().getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                    assertThat(record.value().getTitle()).isEqualTo("NVD Mirroring");
+                    assertThat(record.value().getContent()).isEqualTo("Mirroring of the National Vulnerability Database completed successfully.");
+                }
+        );
+    }
+
+    @Test
+    void testDoMirrorFailureNotification() {
+        final var apiClientMock = mock(NvdCveApi.class);
+        when(apiClientMock.hasNext())
+                .thenReturn(true);
+        when(apiClientMock.next())
+                .thenThrow(new IllegalStateException());
+
+        when(apiClientFactoryMock.createApiClient(anyLong()))
+                .thenReturn(apiClientMock);
+
+        assertThatNoException().isThrownBy(() -> nvdMirror.doMirror().get());
+
+        final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(notificationRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isNull();
+                    assertThat(record.value().getScope()).isEqualTo(SCOPE_SYSTEM);
+                    assertThat(record.value().getGroup()).isEqualTo(GROUP_DATASOURCE_MIRRORING);
+                    assertThat(record.value().getLevel()).isEqualTo(LEVEL_ERROR);
+                    assertThat(record.value().getTitle()).isEqualTo("NVD Mirroring");
+                    assertThat(record.value().getContent()).isEqualTo("An error occurred mirroring the contents of the National Vulnerability Database. Check log for details.");
+                }
+        );
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void testMirrorInternal() throws Exception {
+        final var item = objectMapper.readValue(resourceToByteArray("/datasource/nvd/cve.json"), DefCveItem.class);
+
+        final var apiClientMock = mock(NvdCveApi.class);
+        when(apiClientMock.hasNext())
+                .thenReturn(true)
+                .thenReturn(false);
+        when(apiClientMock.next())
+                .thenReturn(List.of(item));
+        when(apiClientMock.getLastModifiedRequest())
+                .thenReturn(1679922240L);
+
+        when(apiClientFactoryMock.createApiClient(anyLong()))
+                .thenReturn(apiClientMock);
+
+        assertThatNoException().isThrownBy(() -> nvdMirror.mirrorInternal());
+        verify(apiClientFactoryMock).createApiClient(eq(0L));
+
+        final List<ConsumerRecord<String, Bom>> vulnRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(vulnRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isEqualTo("NVD/CVE-2022-40489");
+                    assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                    final Vulnerability vuln = record.value().getVulnerabilities(0);
+                    assertThat(vuln.getId()).isEqualTo("CVE-2022-40489");
+                    assertThat(vuln.hasSource()).isTrue();
+                    assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                }
+        );
+
+        // Trigger a mirror operation one more time.
+        // Verify that this time the previously stored "last updated" timestamp is used.
+        assertThatNoException().isThrownBy(() -> nvdMirror.mirrorInternal());
+        verify(apiClientFactoryMock).createApiClient(eq(1679922240L));
+    }
+
+}

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
@@ -16,6 +16,7 @@ import org.cyclonedx.proto.v1_4.Vulnerability;
 import org.hyades.common.KafkaTopic;
 import org.hyades.proto.KafkaProtobufSerde;
 import org.hyades.proto.notification.v1.Notification;
+import org.hyades.vulnmirror.TestConstants;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -64,6 +65,8 @@ class NvdMirrorTest {
 
         final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
                 .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
                 .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
                 .awaitCompletion()
                 .getRecords();
@@ -95,6 +98,8 @@ class NvdMirrorTest {
 
         final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
                 .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
                 .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
                 .awaitCompletion()
                 .getRecords();
@@ -133,6 +138,8 @@ class NvdMirrorTest {
 
         final List<ConsumerRecord<String, Bom>> vulnRecords = kafkaCompanion
                 .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
                 .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 1, Duration.ofSeconds(5))
                 .awaitCompletion()
                 .getRecords();

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/state/MirrorStateStoreTest.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/state/MirrorStateStoreTest.java
@@ -26,7 +26,7 @@ class MirrorStateStoreTest {
     }
 
     @Test
-    void test() {
+    void testPutAndWait() {
         final ObjectNode nvdState = JsonNodeFactory.instance.objectNode();
         nvdState.put("foo", "bar");
         nvdState.put("baz", 12345);

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/state/MirrorStateStoreTest.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/state/MirrorStateStoreTest.java
@@ -1,0 +1,66 @@
+package org.hyades.vulnmirror.state;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.kafka.common.errors.SerializationException;
+import org.hyades.vulnmirror.datasource.Datasource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@QuarkusTest
+class MirrorStateStoreTest {
+
+    @Inject
+    MirrorStateStore stateStore;
+
+    @AfterEach
+    void afterEach() {
+        stateStore.clear();
+    }
+
+    @Test
+    void test() {
+        final ObjectNode nvdState = JsonNodeFactory.instance.objectNode();
+        nvdState.put("foo", "bar");
+        nvdState.put("baz", 12345);
+
+        final String githubState = "foobarbaz";
+
+        stateStore.putAndWait(Datasource.NVD, nvdState);
+        stateStore.putAndWait(Datasource.GITHUB, githubState);
+
+        final ObjectNode savedNvdState = stateStore.get(Datasource.NVD, ObjectNode.class);
+        assertThat(savedNvdState).isNotNull();
+        assertThat(savedNvdState.get("foo").asText()).isEqualTo("bar");
+        assertThat(savedNvdState.get("baz").asInt()).isEqualTo(12345);
+
+        final String savedGithubState = stateStore.get(Datasource.GITHUB, String.class);
+        assertThat(savedGithubState).isEqualTo("foobarbaz");
+    }
+
+    @Test
+    void testGet() {
+        final ObjectNode savedState = stateStore.get(Datasource.NVD, ObjectNode.class);
+        assertThat(savedState).isNull();
+    }
+
+    @Test
+    void testGetWithDeserializationError() {
+        final ObjectNode state = JsonNodeFactory.instance.objectNode();
+        state.put("foo", "bar");
+        state.put("baz", 12345);
+
+        stateStore.putAndWait(Datasource.NVD, state);
+
+        assertThatExceptionOfType(SerializationException.class)
+                .isThrownBy(() -> stateStore.get(Datasource.NVD, ArrayNode.class));
+    }
+
+}

--- a/mirror-service-x/src/test/java/org/hyades/vulnmirror/state/VulnerabilityDigestStoreTest.java
+++ b/mirror-service-x/src/test/java/org/hyades/vulnmirror/state/VulnerabilityDigestStoreTest.java
@@ -1,0 +1,64 @@
+package org.hyades.vulnmirror.state;
+
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.cyclonedx.proto.v1_4.Bom;
+import org.cyclonedx.proto.v1_4.Source;
+import org.cyclonedx.proto.v1_4.Vulnerability;
+import org.hyades.common.KafkaTopic;
+import org.hyades.proto.KafkaProtobufSerde;
+import org.hyades.vulnmirror.datasource.Datasource;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
+class VulnerabilityDigestStoreTest {
+
+    @Inject
+    VulnerabilityDigestStore digestStore;
+
+    @InjectKafkaCompanion
+    KafkaCompanion kafkaCompanion;
+
+    @Test
+    void testGet() {
+        final Bom bov = Bom.newBuilder()
+                .addVulnerabilities(Vulnerability.newBuilder()
+                        .setId("CVE-1234")
+                        .setSource(Source.newBuilder().setName("NVD")))
+                .build();
+
+        kafkaCompanion
+                .produce(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                .fromRecords(new ProducerRecord<>(KafkaTopic.NEW_VULNERABILITY.getName(), "NVD/CVE-1234", bov));
+
+        final byte[] vulnDigest = Failsafe
+                .with(RetryPolicy.builder()
+                        .handleResultIf(Objects::isNull)
+                        .withDelay(Duration.ofMillis(50))
+                        .withMaxRetries(100)
+                        .build())
+                .get(() -> digestStore.get(Datasource.NVD, "CVE-1234"));
+        assertThat(vulnDigest).asHexString().isEqualTo("79A14B6943F4B6579AB948A51A8F63E39D0599B7FBFAB8A8D2112EB39AA1900F");
+    }
+
+    @Test
+    void testGetWhenNoDigestExists() {
+        assertThat(digestStore.get(Datasource.NVD, "foobar")).isNull();
+    }
+
+}

--- a/mirror-service-x/src/test/resources/datasource/github/advisories-page-01.json
+++ b/mirror-service-x/src/test/resources/datasource/github/advisories-page-01.json
@@ -207,7 +207,7 @@
           "withdrawnAt": null
         }
       ],
-      "totalCount": 4,
+      "totalCount": 3,
       "pageInfo": {
         "hasNextPage": true,
         "endCursor": "Y3Vyc29yOnYyOpK5MjAyMS0xMi0wM1QxNTo1NDo0MyswMTowMM0E_A=="

--- a/mirror-service-x/src/test/resources/datasource/github/advisories-page-01.json
+++ b/mirror-service-x/src/test/resources/datasource/github/advisories-page-01.json
@@ -1,0 +1,217 @@
+{
+  "data": {
+    "rateLimit": {
+      "limit": 5000,
+      "cost": 1,
+      "remaining": 4997,
+      "resetAt": "2023-03-28T11:22:27Z"
+    },
+    "securityAdvisories": {
+      "nodes": [
+        {
+          "databaseId": 1275,
+          "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/",
+          "ghsaId": "GHSA-fxwm-579q-49qq",
+          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLWZ4d20tNTc5cS00OXFx",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-fxwm-579q-49qq"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2019-8331"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq",
+          "publishedAt": "2019-02-22T20:54:40Z",
+          "references": [
+            {
+              "url": "https://github.com/advisories/GHSA-fxwm-579q-49qq"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Moderate severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass",
+          "updatedAt": "2021-12-03T14:54:43Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2019-02-22T20:53:04Z",
+                  "firstPatchedVersion": {
+                    "identifier": "4.3.1"
+                  },
+                  "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
+                  "package": {
+                    "ecosystem": "NUGET",
+                    "name": "bootstrap"
+                  }
+                }
+              },
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2019-02-22T20:53:04Z",
+                  "firstPatchedVersion": {
+                    "identifier": "4.3.1"
+                  },
+                  "vulnerableVersionRange": "< 4.3.1",
+                  "package": {
+                    "ecosystem": "NUGET",
+                    "name": "bootstrap.sass"
+                  }
+                }
+              },
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2019-02-22T20:53:04Z",
+                  "firstPatchedVersion": {
+                    "identifier": "3.4.1"
+                  },
+                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
+                  "package": {
+                    "ecosystem": "NUGET",
+                    "name": "bootstrap"
+                  }
+                }
+              },
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2019-02-22T20:53:04Z",
+                  "firstPatchedVersion": {
+                    "identifier": "3.4.1"
+                  },
+                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
+                  "package": {
+                    "ecosystem": "NUGET",
+                    "name": "Bootstrap.Less"
+                  }
+                }
+              }
+            ],
+            "totalCount": 4,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQyMTo1MzowNCswMTowMM0H6w=="
+            }
+          },
+          "cvss": {
+            "score": 0.0,
+            "vectorString": null
+          },
+          "cwes": {
+            "edges": [],
+            "totalCount": 0,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 1276,
+          "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/",
+          "ghsaId": "GHSA-wh77-3x4m-4q9g",
+          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXdoNzctM3g0bS00cTln",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-wh77-3x4m-4q9g"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2019-8331"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-wh77-3x4m-4q9g/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-wh77-3x4m-4q9g",
+          "publishedAt": "2019-02-22T20:54:27Z",
+          "references": [
+            {
+              "url": "https://github.com/advisories/GHSA-wh77-3x4m-4q9g"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Moderate severity vulnerability that affects bootstrap and bootstrap-sass",
+          "updatedAt": "2021-12-03T14:54:43Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2019-02-22T20:53:13Z",
+                  "firstPatchedVersion": {
+                    "identifier": "4.3.1"
+                  },
+                  "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
+                  "package": {
+                    "ecosystem": "NPM",
+                    "name": "bootstrap"
+                  }
+                }
+              },
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2019-02-22T20:53:13Z",
+                  "firstPatchedVersion": {
+                    "identifier": "3.4.1"
+                  },
+                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
+                  "package": {
+                    "ecosystem": "NPM",
+                    "name": "bootstrap"
+                  }
+                }
+              },
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2019-02-22T20:53:13Z",
+                  "firstPatchedVersion": {
+                    "identifier": "3.4.1"
+                  },
+                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
+                  "package": {
+                    "ecosystem": "NPM",
+                    "name": "bootstrap-sass"
+                  }
+                }
+              }
+            ],
+            "totalCount": 3,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQyMTo1MzoxMyswMTowMM0H7g=="
+            }
+          },
+          "cvss": {
+            "score": 0.0,
+            "vectorString": null
+          },
+          "cwes": {
+            "edges": [],
+            "totalCount": 0,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
+          },
+          "withdrawnAt": null
+        }
+      ],
+      "totalCount": 4,
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "Y3Vyc29yOnYyOpK5MjAyMS0xMi0wM1QxNTo1NDo0MyswMTowMM0E_A=="
+      }
+    }
+  }
+}

--- a/mirror-service-x/src/test/resources/datasource/github/advisories-page-02.json
+++ b/mirror-service-x/src/test/resources/datasource/github/advisories-page-02.json
@@ -106,78 +106,9 @@
             }
           },
           "withdrawnAt": null
-        },
-        {
-          "databaseId": 2315,
-          "description": "### Impact\nServer JWT signing secret was included in static assets and served to clients.\n\nThis ALLOWS Flood's builtin authentication to be bypassed. Given Flood is granted access to rTorrent's SCGI interface (which is unprotected and ALLOWS arbitrary code execution) and usually wide-ranging privileges to files, along with Flood's lack of security controls against authenticated users, the severity of this vulnerability is **CRITICAL**. \n\n### Background\nCommit 8d11640b imported `config.js` to client (frontend) components to get `disableUsersAndAuth` configuration variable. Subsequently contents of `config.js` are compiled into static assets and served to users. Unfortunately `config.js` also includes `secret`.\n\nIntruders can use `secret` to sign authentication tokens themselves to bypass builtin access control of Flood.\n\n### Patches\nCommit 042cb4ce removed imports of `config.js` from client (frontend) components. Additionally an eslint rule was added to prevent config.js from being imported to client (frontend) components.\n\nCommit 103f53c8 provided a general mitigation to this kind of problem by searching static assets to ensure `secret` is not included before starting server (backend). \n\n### Workarounds\nUsers shall upgrade if they use Flood's builtin authentication system.\n\nWhile maintainers will do their best to support it, Flood cannot guarantee its in-house access control system can stand against determined attackers in high-stake environments. \n\n> Use `HTTP Basic Auth` or other battle-hardened authentication methods instead of Flood's in-house one. You can use `disableUsersAndAuth` to avoid duplicate authentication.\n\nUsers are advised to check out the [wiki](https://github.com/jesec/flood/wiki) for more information on security precautions.\n\n### References\n[Wiki - Security precautions](https://github.com/jesec/flood/wiki/Security-precautions)\n\n[Introduction to JSON Web Tokens](https://jwt.io/introduction/)\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Open an issue in [issue tracker](https://github.com/jesec/flood/issues)\n* Email us at [jc@linux.com](mailto:jc@linux.com)",
-          "ghsaId": "GHSA-r587-7jh2-4qr3",
-          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXI1ODctN2poMi00cXIz",
-          "identifiers": [
-            {
-              "type": "GHSA",
-              "value": "GHSA-r587-7jh2-4qr3"
-            }
-          ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-r587-7jh2-4qr3/dependabot",
-          "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-r587-7jh2-4qr3",
-          "publishedAt": "2020-08-26T19:32:50Z",
-          "references": [
-            {
-              "url": "https://github.com/jesec/flood/security/advisories/GHSA-r587-7jh2-4qr3"
-            },
-            {
-              "url": "https://github.com/jesec/flood/commit/103f53c8d2963584e41bcf46ccc6fe0fabf179ca"
-            },
-            {
-              "url": "https://github.com/jesec/flood/commit/d137107ac908526d43966607149fbaf00cfcedf0"
-            },
-            {
-              "url": "https://github.com/advisories/GHSA-r587-7jh2-4qr3"
-            }
-          ],
-          "severity": "CRITICAL",
-          "summary": "Server secret was included in static assets and served to clients",
-          "updatedAt": "2023-01-06T05:01:57Z",
-          "vulnerabilities": {
-            "edges": [
-              {
-                "node": {
-                  "severity": "CRITICAL",
-                  "updatedAt": "2022-09-09T20:56:50Z",
-                  "firstPatchedVersion": {
-                    "identifier": "3.0.0"
-                  },
-                  "vulnerableVersionRange": ">= 2.0.0, < 3.0.0",
-                  "package": {
-                    "ecosystem": "NPM",
-                    "name": "flood"
-                  }
-                }
-              }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQyMjo1Njo1MCswMjowMM2Cyg=="
-            }
-          },
-          "cvss": {
-            "score": 0.0,
-            "vectorString": null
-          },
-          "cwes": {
-            "edges": [],
-            "totalCount": 0,
-            "pageInfo": {
-              "hasNextPage": false,
-              "endCursor": null
-            }
-          },
-          "withdrawnAt": null
         }
       ],
-      "totalCount": 4,
+      "totalCount": 3,
       "pageInfo": {
         "hasNextPage": false,
         "endCursor": "Y3Vyc29yOnYyOpK5MjAyMy0wMS0wNlQwNjowMTo1NyswMTowMM0JCw=="

--- a/mirror-service-x/src/test/resources/datasource/github/advisories-page-02.json
+++ b/mirror-service-x/src/test/resources/datasource/github/advisories-page-02.json
@@ -1,0 +1,187 @@
+{
+  "data": {
+    "rateLimit": {
+      "limit": 5000,
+      "cost": 1,
+      "remaining": 4996,
+      "resetAt": "2023-03-28T11:22:27Z"
+    },
+    "securityAdvisories": {
+      "nodes": [
+        {
+          "databaseId": 2660,
+          "description": "Versions of `dojo` prior to 1.2.0 are vulnerable to Cross-Site Scripting (XSS). The package fails to sanitize HTML code in user-controlled input, allowing attackers to execute arbitrary JavaScript in the victim's browser.\n\n\n## Recommendation\n\nUpgrade to version 1.2.0 or later.",
+          "ghsaId": "GHSA-p82g-2xpp-m5r3",
+          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXA4MmctMnhwcC1tNXIz",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-p82g-2xpp-m5r3"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2015-5654"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-p82g-2xpp-m5r3/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-p82g-2xpp-m5r3",
+          "publishedAt": "2020-09-11T21:18:05Z",
+          "references": [
+            {
+              "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5654"
+            },
+            {
+              "url": "https://snyk.io/vuln/SNYK-JS-DOJO-174933"
+            },
+            {
+              "url": "https://www.npmjs.com/advisories/973"
+            },
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5654"
+            },
+            {
+              "url": "http://jvn.jp/en/jp/JVN13456571/index.html"
+            },
+            {
+              "url": "http://jvndb.jvn.jp/jvndb/JVNDB-2015-000153"
+            },
+            {
+              "url": "http://www-01.ibm.com/support/docview.wss?uid=swg21975256"
+            },
+            {
+              "url": "http://www.securityfocus.com/bid/77026"
+            },
+            {
+              "url": "http://www.securitytracker.com/id/1034848"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-p82g-2xpp-m5r3"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Cross-Site Scripting in dojo",
+          "updatedAt": "2023-01-06T05:01:55Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "node": {
+                  "severity": "MODERATE",
+                  "updatedAt": "2022-09-09T19:34:40Z",
+                  "firstPatchedVersion": {
+                    "identifier": "1.9.1"
+                  },
+                  "vulnerableVersionRange": "< 1.2.0",
+                  "package": {
+                    "ecosystem": "NPM",
+                    "name": "dojo"
+                  }
+                }
+              }
+            ],
+            "totalCount": 1,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQyMTozNDo0MCswMjowMM0R1Q=="
+            }
+          },
+          "cvss": {
+            "score": 5.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+          },
+          "cwes": {
+            "edges": [
+              {
+                "node": {
+                  "cweId": "CWE-79",
+                  "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                  "description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+                }
+              }
+            ],
+            "totalCount": 1,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "Y3Vyc29yOnYyOpFA"
+            }
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 2315,
+          "description": "### Impact\nServer JWT signing secret was included in static assets and served to clients.\n\nThis ALLOWS Flood's builtin authentication to be bypassed. Given Flood is granted access to rTorrent's SCGI interface (which is unprotected and ALLOWS arbitrary code execution) and usually wide-ranging privileges to files, along with Flood's lack of security controls against authenticated users, the severity of this vulnerability is **CRITICAL**. \n\n### Background\nCommit 8d11640b imported `config.js` to client (frontend) components to get `disableUsersAndAuth` configuration variable. Subsequently contents of `config.js` are compiled into static assets and served to users. Unfortunately `config.js` also includes `secret`.\n\nIntruders can use `secret` to sign authentication tokens themselves to bypass builtin access control of Flood.\n\n### Patches\nCommit 042cb4ce removed imports of `config.js` from client (frontend) components. Additionally an eslint rule was added to prevent config.js from being imported to client (frontend) components.\n\nCommit 103f53c8 provided a general mitigation to this kind of problem by searching static assets to ensure `secret` is not included before starting server (backend). \n\n### Workarounds\nUsers shall upgrade if they use Flood's builtin authentication system.\n\nWhile maintainers will do their best to support it, Flood cannot guarantee its in-house access control system can stand against determined attackers in high-stake environments. \n\n> Use `HTTP Basic Auth` or other battle-hardened authentication methods instead of Flood's in-house one. You can use `disableUsersAndAuth` to avoid duplicate authentication.\n\nUsers are advised to check out the [wiki](https://github.com/jesec/flood/wiki) for more information on security precautions.\n\n### References\n[Wiki - Security precautions](https://github.com/jesec/flood/wiki/Security-precautions)\n\n[Introduction to JSON Web Tokens](https://jwt.io/introduction/)\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Open an issue in [issue tracker](https://github.com/jesec/flood/issues)\n* Email us at [jc@linux.com](mailto:jc@linux.com)",
+          "ghsaId": "GHSA-r587-7jh2-4qr3",
+          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXI1ODctN2poMi00cXIz",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-r587-7jh2-4qr3"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-r587-7jh2-4qr3/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-r587-7jh2-4qr3",
+          "publishedAt": "2020-08-26T19:32:50Z",
+          "references": [
+            {
+              "url": "https://github.com/jesec/flood/security/advisories/GHSA-r587-7jh2-4qr3"
+            },
+            {
+              "url": "https://github.com/jesec/flood/commit/103f53c8d2963584e41bcf46ccc6fe0fabf179ca"
+            },
+            {
+              "url": "https://github.com/jesec/flood/commit/d137107ac908526d43966607149fbaf00cfcedf0"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-r587-7jh2-4qr3"
+            }
+          ],
+          "severity": "CRITICAL",
+          "summary": "Server secret was included in static assets and served to clients",
+          "updatedAt": "2023-01-06T05:01:57Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "node": {
+                  "severity": "CRITICAL",
+                  "updatedAt": "2022-09-09T20:56:50Z",
+                  "firstPatchedVersion": {
+                    "identifier": "3.0.0"
+                  },
+                  "vulnerableVersionRange": ">= 2.0.0, < 3.0.0",
+                  "package": {
+                    "ecosystem": "NPM",
+                    "name": "flood"
+                  }
+                }
+              }
+            ],
+            "totalCount": 1,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQyMjo1Njo1MCswMjowMM2Cyg=="
+            }
+          },
+          "cvss": {
+            "score": 0.0,
+            "vectorString": null
+          },
+          "cwes": {
+            "edges": [],
+            "totalCount": 0,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
+          },
+          "withdrawnAt": null
+        }
+      ],
+      "totalCount": 4,
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": "Y3Vyc29yOnYyOpK5MjAyMy0wMS0wNlQwNjowMTo1NyswMTowMM0JCw=="
+      }
+    }
+  }
+}

--- a/mirror-service-x/src/test/resources/datasource/github/advisory.json
+++ b/mirror-service-x/src/test/resources/datasource/github/advisory.json
@@ -1,0 +1,106 @@
+{
+  "databaseId": 1275,
+  "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/",
+  "ghsaId": "GHSA-fxwm-579q-49qq",
+  "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLWZ4d20tNTc5cS00OXFx",
+  "identifiers": [
+    {
+      "type": "GHSA",
+      "value": "GHSA-fxwm-579q-49qq"
+    },
+    {
+      "type": "CVE",
+      "value": "CVE-2019-8331"
+    }
+  ],
+  "notificationsPermalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq/dependabot",
+  "origin": "UNSPECIFIED",
+  "permalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq",
+  "publishedAt": "2019-02-22T20:54:40Z",
+  "references": [
+    {
+      "url": "https://github.com/advisories/GHSA-fxwm-579q-49qq"
+    }
+  ],
+  "severity": "MODERATE",
+  "summary": "Moderate severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass",
+  "updatedAt": "2021-12-03T14:54:43Z",
+  "vulnerabilities": {
+    "edges": [
+      {
+        "node": {
+          "severity": "MODERATE",
+          "updatedAt": "2019-02-22T20:53:04Z",
+          "firstPatchedVersion": {
+            "identifier": "4.3.1"
+          },
+          "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
+          "package": {
+            "ecosystem": "NUGET",
+            "name": "bootstrap"
+          }
+        }
+      },
+      {
+        "node": {
+          "severity": "MODERATE",
+          "updatedAt": "2019-02-22T20:53:04Z",
+          "firstPatchedVersion": {
+            "identifier": "4.3.1"
+          },
+          "vulnerableVersionRange": "< 4.3.1",
+          "package": {
+            "ecosystem": "NUGET",
+            "name": "bootstrap.sass"
+          }
+        }
+      },
+      {
+        "node": {
+          "severity": "MODERATE",
+          "updatedAt": "2019-02-22T20:53:04Z",
+          "firstPatchedVersion": {
+            "identifier": "3.4.1"
+          },
+          "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
+          "package": {
+            "ecosystem": "NUGET",
+            "name": "bootstrap"
+          }
+        }
+      },
+      {
+        "node": {
+          "severity": "MODERATE",
+          "updatedAt": "2019-02-22T20:53:04Z",
+          "firstPatchedVersion": {
+            "identifier": "3.4.1"
+          },
+          "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
+          "package": {
+            "ecosystem": "NUGET",
+            "name": "Bootstrap.Less"
+          }
+        }
+      }
+    ],
+    "totalCount": 4,
+    "pageInfo": {
+      "hasNextPage": false,
+      "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQyMTo1MzowNCswMTowMM0H6w=="
+    }
+  },
+  "cvss": {
+    "score": 0.0,
+    "vectorString": null
+  },
+  "cwes": {
+    "edges": [],
+    "totalCount": 0,
+    "pageInfo": {
+      "hasNextPage": false,
+      "endCursor": null
+    }
+  },
+  "withdrawnAt": null
+}

--- a/mirror-service-x/src/test/resources/datasource/nvd/cve.json
+++ b/mirror-service-x/src/test/resources/datasource/nvd/cve.json
@@ -1,0 +1,79 @@
+{
+  "cve": {
+    "id": "CVE-2022-40489",
+    "sourceIdentifier": "cve@mitre.org",
+    "published": "2022-12-01T05:15:11.730",
+    "lastModified": "2022-12-02T17:17:02.303",
+    "vulnStatus": "Analyzed",
+    "descriptions": [
+      {
+        "lang": "en",
+        "value": "ThinkCMF version 6.0.7 is affected by a Cross Site Request Forgery (CSRF) vulnerability that allows a Super Administrator user to be injected into administrative users."
+      }
+    ],
+    "metrics": {
+      "cvssMetricV31": [
+        {
+          "source": "nvd@nist.gov",
+          "type": "Primary",
+          "cvssData": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1\/AV:N\/AC:L\/PR:N\/UI:R\/S:U\/C:H\/I:H\/A:H",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "REQUIRED",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH"
+          },
+          "exploitabilityScore": 2.8,
+          "impactScore": 5.9
+        }
+      ]
+    },
+    "weaknesses": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "description": [
+          {
+            "lang": "en",
+            "value": "CWE-352"
+          }
+        ]
+      }
+    ],
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*",
+                "matchCriteriaId": "3F02595D-FE6B-481C-87D7-E31A5C955FED"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "references": [
+      {
+        "url": "https:\/\/github.com\/thinkcmf\/thinkcmf\/issues\/736",
+        "source": "cve@mitre.org",
+        "tags": [
+          "Exploit",
+          "Issue Tracking",
+          "Third Party Advisory"
+        ]
+      }
+    ]
+  }
+}

--- a/mirror-service-x/src/test/resources/datasource/nvd/cves-page-01.json
+++ b/mirror-service-x/src/test/resources/datasource/nvd/cves-page-01.json
@@ -1,0 +1,168 @@
+{
+  "resultsPerPage": 2000,
+  "startIndex": 0,
+  "totalResults": 2001,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2023-03-27T11:03:55.510",
+  "vulnerabilities": [
+    {
+      "cve": {
+        "id": "CVE-2022-40489",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2022-12-01T05:15:11.730",
+        "lastModified": "2022-12-02T17:17:02.303",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "ThinkCMF version 6.0.7 is affected by a Cross Site Request Forgery (CSRF) vulnerability that allows a Super Administrator user to be injected into administrative users."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1\/AV:N\/AC:L\/PR:N\/UI:R\/S:U\/C:H\/I:H\/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-352"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3F02595D-FE6B-481C-87D7-E31A5C955FED"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https:\/\/github.com\/thinkcmf\/thinkcmf\/issues\/736",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Exploit",
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2022-40849",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2022-12-01T05:15:11.890",
+        "lastModified": "2022-12-02T17:24:33.243",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "ThinkCMF version 6.0.7 is affected by Stored Cross-Site Scripting (XSS). An attacker who successfully exploited this vulnerability could inject a Persistent XSS payload in the Slideshow Management section that execute arbitrary JavaScript code on the client side, e.g., to steal the administrator's PHP session token (PHPSESSID)."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1\/AV:N\/AC:L\/PR:L\/UI:R\/S:C\/C:L\/I:L\/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3F02595D-FE6B-481C-87D7-E31A5C955FED"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https:\/\/github.com\/thinkcmf\/thinkcmf\/issues\/737",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Exploit",
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/mirror-service-x/src/test/resources/datasource/nvd/cves-page-02.json
+++ b/mirror-service-x/src/test/resources/datasource/nvd/cves-page-02.json
@@ -1,0 +1,89 @@
+{
+  "resultsPerPage": 2000,
+  "startIndex": 2000,
+  "totalResults": 2001,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2023-03-27T11:06:38.933",
+  "vulnerabilities": [
+    {
+      "cve": {
+        "id": "CVE-2022-44262",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2022-12-01T05:15:11.973",
+        "lastModified": "2022-12-02T17:27:16.763",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "ff4j 1.8.1 is vulnerable to Remote Code Execution (RCE)."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1\/AV:N\/AC:L\/PR:N\/UI:N\/S:U\/C:H\/I:H\/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-noinfo"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ff4j:ff4j:1.8.1:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "AD352861-6DAA-40D4-95CC-EB9E83EBAA8D"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https:\/\/github.com\/ff4j\/ff4j\/issues\/624",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Exploit",
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds unit- and integration-tests for the existing mirroring logic.

A few additional minor changes are included as well:

* Sending of notifications when a mirroring operation succeeded or failed, [analog](https://github.com/DependencyTrack/dependency-track/blob/4.7.1/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java#L256-L275) to how it's done in vanilla DT
* Timer metrics for mirroring operations
* Health endpoint via [SmallRye Health](https://quarkus.io/guides/smallrye-health)
* Proper closing of the Kafka producer during application shutdown