### PR TITLE
Run integration tests in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      run: |-
+        mvn -pl '!e2e' clean verify \
+          failsafe:integration-test -DskipITs=false \
+          org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
 
   test-native-image:
     name: Test Native Image


### PR DESCRIPTION
Integration tests cover cases that unit tests do not. 

At the moment, we only run ITs against native binaries, because that's the only way we can test those.

Quarkus will execute ITs against the built JARs.