### PR TITLE
Add filters to `instance` variable of Grafana dashboards

### DIFF
--- a/monitoring/grafana/dashboards/mirror-service_dashboard.json
+++ b/monitoring/grafana/dashboards/mirror-service_dashboard.json
@@ -1441,7 +1441,7 @@
           "type": "prometheus",
           "uid": "Prometheus"
         },
-        "definition": "label_values(kafka_stream_alive_stream_threads, instance)",
+        "definition": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-mirror-service.*\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -1449,7 +1449,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(kafka_stream_alive_stream_threads, instance)",
+          "query": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-mirror-service.*\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/monitoring/grafana/dashboards/notification-publisher_dashboard.json
+++ b/monitoring/grafana/dashboards/notification-publisher_dashboard.json
@@ -1248,7 +1248,7 @@
           "type": "prometheus",
           "uid": "Prometheus"
         },
-        "definition": "label_values(kafka_stream_alive_stream_threads, instance)",
+        "definition": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-notification-publisher.*\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -1256,7 +1256,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(kafka_stream_alive_stream_threads, instance)",
+          "query": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-notification-publisher.*\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/monitoring/grafana/dashboards/repo-meta-analyzer_dashboard.json
+++ b/monitoring/grafana/dashboards/repo-meta-analyzer_dashboard.json
@@ -1249,7 +1249,7 @@
           "type": "prometheus",
           "uid": "Prometheus"
         },
-        "definition": "label_values(kafka_stream_alive_stream_threads, instance)",
+        "definition": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-repository-meta-analyzer.*\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -1257,7 +1257,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(kafka_stream_alive_stream_threads, instance)",
+          "query": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-repository-meta-analyzer.*\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/monitoring/grafana/dashboards/vuln-analyzer_dashboard.json
+++ b/monitoring/grafana/dashboards/vuln-analyzer_dashboard.json
@@ -3498,7 +3498,7 @@
           "type": "prometheus",
           "uid": "Prometheus"
         },
-        "definition": "label_values(kafka_stream_alive_stream_threads, instance)",
+        "definition": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-vulnerability-analyzer.*\"}, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -3506,7 +3506,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(kafka_stream_alive_stream_threads, instance)",
+          "query": "label_values(kafka_stream_alive_stream_threads{client_id=~\".*hyades-vulnerability-analyzer.*\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/notification-publisher/src/main/resources/application.properties
+++ b/notification-publisher/src/main/resources/application.properties
@@ -8,7 +8,7 @@ quarkus.http.port=8090
 kafka.bootstrap.servers=localhost:9092
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
 api.topic.prefix=
-quarkus.kafka-streams.application-id=${api.topic.prefix}dtrack-notification-publisher
+quarkus.kafka-streams.application-id=${api.topic.prefix}hyades-notification-publisher
 quarkus.kafka-streams.application-server=localhost:8090
 quarkus.kafka-streams.topics=\
   ${api.topic.prefix}dtrack.notification.analyzer,\


### PR DESCRIPTION
This ensures that the dashboards do not include data from ALL hyades services, but only from the services the respective dashboard is supposed to display.