### PR TITLE
Add end-to-end tests for OSS Index and Snyk analysis

### DIFF
--- a/e2e/src/main/java/org/hyades/apiserver/model/Finding.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/Finding.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Finding(Component component, Project project, Vulnerability vulnerability) {
+public record Finding(Component component, Project project, Vulnerability vulnerability, Attribution attribution) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Component(UUID uuid, String name, String version) {
@@ -17,6 +17,11 @@ public record Finding(Component component, Project project, Vulnerability vulner
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Vulnerability(UUID uuid, String vulnId, String source) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Attribution(String analyzerIdentity, String attributedOn, String alternateIdentifier,
+                              String referenceUrl) {
     }
 
 }

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadOssIndexAnalysisE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadOssIndexAnalysisE2ET.java
@@ -1,0 +1,82 @@
+package org.hyades.e2e;
+
+import org.hyades.apiserver.model.BomProcessingResponse;
+import org.hyades.apiserver.model.BomUploadRequest;
+import org.hyades.apiserver.model.BomUploadResponse;
+import org.hyades.apiserver.model.Finding;
+import org.hyades.apiserver.model.Project;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class BomUploadOssIndexAnalysisE2ET extends AbstractE2ET {
+
+    @Override
+    protected void customizeVulnAnalyzerContainer(GenericContainer<?> container) {
+        // Username and token are optional, OSS Index can be used without authentication.
+        final String ossIndexUsername = Optional.ofNullable(System.getenv("OSSINDEX_USERNAME")).orElse("");
+        final String ossIndexToken = Optional.ofNullable(System.getenv("OSSINDEX_TOKEN")).orElse("");
+
+        container
+                // Enable OSS Index
+                .withEnv("SCANNER_OSSINDEX_ENABLED", "true")
+                .withEnv("SCANNER_OSSINDEX_API_USERNAME", ossIndexUsername)
+                .withEnv("SCANNER_OSSINDEX_API_TOKEN", ossIndexToken)
+                // Disable all other scanners
+                .withEnv("SCANNER_INTERNAL_ENABLED", "false")
+                .withEnv("SCANNER_SNYK_ENABLED", "false");
+    }
+
+    @Test
+    void test() throws Exception {
+        // Parse and base64 encode a BOM.
+        final byte[] bomBytes = IOUtils.resourceToByteArray("/dtrack-apiserver-4.5.0.bom.json");
+        final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
+
+        // Upload the BOM
+        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        assertThat(response.token()).isNotEmpty();
+
+        // Wait up to 15sec for the BOM processing to complete.
+        await("BOM processing")
+                .atMost(Duration.ofSeconds(15))
+                .pollDelay(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    assertThat(processingResponse.processing()).isFalse();
+                });
+
+        // Lookup the project we just created.
+        final Project project = apiServerClient.lookupProject("foo", "bar");
+
+        // Ensure that vulnerabilities have been reported correctly.
+        final List<Finding> findings = apiServerClient.getFindings(project.uuid());
+        assertThat(findings)
+                .hasSizeGreaterThan(1)
+                .allSatisfy(
+                        finding -> {
+                            assertThat(finding.vulnerability()).satisfiesAnyOf(
+                                    vuln -> {
+                                        assertThat(vuln.vulnId()).startsWith("CVE-");
+                                        assertThat(vuln.source()).isEqualTo("NVD");
+                                    },
+                                    vuln -> {
+                                        assertThat(vuln.vulnId()).startsWith("sonatype-");
+                                        assertThat(vuln.source()).isEqualTo("OSSINDEX");
+                                    }
+                            );
+                            assertThat(finding.attribution().analyzerIdentity()).isEqualTo("OSSINDEX_ANALYZER");
+                            assertThat(finding.attribution().attributedOn()).isNotBlank();
+                        }
+                );
+    }
+
+}

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
@@ -39,7 +39,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-public class BomUploadProcessingE2ET extends AbstractE2ET {
+class BomUploadProcessingE2ET extends AbstractE2ET {
 
     @RegisterExtension
     static WireMockExtension wireMock = WireMockExtension.newInstance()
@@ -49,6 +49,7 @@ public class BomUploadProcessingE2ET extends AbstractE2ET {
     @RegisterExtension
     static GreenMailExtension greenMail = new GreenMailExtension(ServerSetup.SMTP.dynamicPort());
 
+    @Override
     @BeforeEach
     void beforeEach() throws Exception {
         // host.docker.internal may not always be available, so use testcontainer's
@@ -156,6 +157,8 @@ public class BomUploadProcessingE2ET extends AbstractE2ET {
                 finding -> {
                     assertThat(finding.component().name()).isEqualTo("jackson-databind");
                     assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-123");
+                    assertThat(finding.attribution().analyzerIdentity()).isEqualTo("INTERNAL_ANALYZER");
+                    assertThat(finding.attribution().attributedOn()).isNotBlank();
                 }
         );
 

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadSnykAnalysisE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadSnykAnalysisE2ET.java
@@ -1,0 +1,87 @@
+package org.hyades.e2e;
+
+import org.hyades.apiserver.model.BomProcessingResponse;
+import org.hyades.apiserver.model.BomUploadRequest;
+import org.hyades.apiserver.model.BomUploadResponse;
+import org.hyades.apiserver.model.Finding;
+import org.hyades.apiserver.model.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class BomUploadSnykAnalysisE2ET extends AbstractE2ET {
+
+    private String snykOrgId;
+    private String snykToken;
+
+    @Override
+    @BeforeEach
+    void beforeEach() throws Exception {
+        snykOrgId = System.getenv("SNYK_ORG_ID");
+        snykToken = System.getenv("SNYK_TOKEN");
+
+        // Snyk does not allow unauthenticated usage; No point in running the test without credentials.
+        assumeTrue(snykOrgId != null, "No Snyk organization ID provided");
+        assumeTrue(snykToken != null, "No Snyk token provided");
+
+        super.beforeEach();
+    }
+
+    @Override
+    protected void customizeVulnAnalyzerContainer(GenericContainer<?> container) {
+        container
+                // Enable Snyk
+                .withEnv("SCANNER_SNYK_ENABLED", "true")
+                .withEnv("SCANNER_SNYK_API_ORG_ID", snykOrgId)
+                .withEnv("SCANNER_SNYK_API_TOKENS", snykToken)
+                // Disable all other scanners
+                .withEnv("SCANNER_INTERNAL_ENABLED", "false")
+                .withEnv("SCANNER_OSSINDEX_ENABLED", "false");
+    }
+
+    @Test
+    void test() throws Exception {
+        // Parse and base64 encode a BOM.
+        final byte[] bomBytes = IOUtils.resourceToByteArray("/dtrack-apiserver-4.5.0.bom.json");
+        final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
+
+        // Upload the BOM
+        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        assertThat(response.token()).isNotEmpty();
+
+        // Wait up to 15sec for the BOM processing to complete.
+        await("BOM processing")
+                .atMost(Duration.ofSeconds(15))
+                .pollDelay(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    assertThat(processingResponse.processing()).isFalse();
+                });
+
+        // Lookup the project we just created.
+        final Project project = apiServerClient.lookupProject("foo", "bar");
+
+        // Ensure that vulnerabilities have been reported correctly.
+        final List<Finding> findings = apiServerClient.getFindings(project.uuid());
+        assertThat(findings)
+                .hasSizeGreaterThan(1)
+                .allSatisfy(
+                        finding -> {
+                            assertThat(finding.vulnerability().vulnId()).startsWith("SNYK-");
+                            assertThat(finding.vulnerability().source()).isEqualTo("SNYK");
+                            assertThat(finding.attribution().analyzerIdentity()).isEqualTo("SNYK_ANALYZER");
+                            assertThat(finding.attribution().attributedOn()).isNotBlank();
+                        }
+                );
+    }
+
+}


### PR DESCRIPTION
This will make it easier to quickly verify if the analyzers still work as expected.

> **Note**  
> In order to run the Snyk test, the `SNYK_ORG_ID` and `SNYK_TOKEN` environment variables need to be set.