### PR TITLE
Provide OSS Index credentials to E2E tests; Increase timeout

### DIFF
--- a/.github/workflows/publishJar.yml
+++ b/.github/workflows/publishJar.yml
@@ -62,4 +62,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Test
+      env:
+        OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
+        OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
       run: mvn -pl e2e clean verify -Pe2e-all

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadOssIndexAnalysisE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadOssIndexAnalysisE2ET.java
@@ -47,7 +47,7 @@ class BomUploadOssIndexAnalysisE2ET extends AbstractE2ET {
 
         // Wait up to 15sec for the BOM processing to complete.
         await("BOM processing")
-                .atMost(Duration.ofSeconds(15))
+                .atMost(Duration.ofSeconds(30))
                 .pollDelay(Duration.ofMillis(250))
                 .untilAsserted(() -> {
                     final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadSnykAnalysisE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadSnykAnalysisE2ET.java
@@ -60,7 +60,7 @@ class BomUploadSnykAnalysisE2ET extends AbstractE2ET {
 
         // Wait up to 15sec for the BOM processing to complete.
         await("BOM processing")
-                .atMost(Duration.ofSeconds(15))
+                .atMost(Duration.ofSeconds(30))
                 .pollDelay(Duration.ofMillis(250))
                 .untilAsserted(() -> {
                     final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());


### PR DESCRIPTION
Should hopefully suffice to be able to run E2E tests with OSS Index in CI.

Referenced secrets have been added on the repository level in GitHub.