### PR TITLE
Enable Snappy compression for notification-publisher and repository-meta-analyzer

### DIFF
--- a/notification-publisher/src/main/resources/application.properties
+++ b/notification-publisher/src/main/resources/application.properties
@@ -36,6 +36,8 @@ kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=earliest
 kafka-streams.metrics.recording.level=DEBUG
 kafka-streams.num.stream.threads=3
+kafka-streams.compression.type=snappy
+quarkus.kafka.snappy.enabled=true
 
 ##quarkus hibernate properties
 quarkus.datasource.db-kind=postgresql

--- a/repository-meta-analyzer/src/main/resources/application.properties
+++ b/repository-meta-analyzer/src/main/resources/application.properties
@@ -21,6 +21,8 @@ kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=earliest
 kafka-streams.metrics.recording.level=DEBUG
 kafka-streams.num.stream.threads=3
+kafka-streams.compression.type=snappy
+quarkus.kafka.snappy.enabled=true
 
 ## Dev Services for Kafka
 #


### PR DESCRIPTION
To make compression consistent across services.

Event though the notification publisher does not emit any events by itself, enabling snappy will cause the libsnappy.so library to be embedded into the native image of the service. That library is required to decompress received events.

Required for compatibility with https://github.com/DependencyTrack/hyades-apiserver/pull/79