### PR TITLE
Retry added to NvdMirror task

### DIFF
--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
+        <lib.resilience4j.version>2.0.2</lib.resilience4j.version>
     </properties>
 
     <dependencies>
@@ -117,6 +118,32 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jacoco</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Resilience4J -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>${lib.resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+            <version>${lib.resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-micrometer</artifactId>
+            <version>${lib.resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -128,23 +128,8 @@
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>
-            <artifactId>resilience4j-ratelimiter</artifactId>
-            <version>${lib.resilience4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-micrometer</artifactId>
             <version>${lib.resilience4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdConfig.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdConfig.java
@@ -1,6 +1,7 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 import java.util.Optional;
 
@@ -12,5 +13,17 @@ public interface NvdConfig {
     Optional<String> apiKey();
 
     int numThreads();
+
+    @WithDefault("2")
+    int retryBackoffInitialDurationSeconds();
+
+    @WithDefault("4")
+    int retryBackoffMultiplier();
+
+    @WithDefault("64")
+    int retryMaxDuration();
+
+    @WithDefault("3")
+    int retryMaxAttempts();
 
 }

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdMirror.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdMirror.java
@@ -1,11 +1,8 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
-import io.github.jeremylong.nvdlib.NvdApiException;
 import io.github.jeremylong.nvdlib.NvdCveApi;
 import io.github.jeremylong.nvdlib.nvd.DefCveItem;
 import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.retry.RetryConfig;
-import io.github.resilience4j.retry.RetryRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.apache.kafka.clients.producer.Producer;
 import org.cyclonedx.proto.v1_4.Bom;
@@ -24,7 +21,6 @@ import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
-import static io.github.resilience4j.core.IntervalFunction.ofExponentialBackoff;
 import static org.hyades.proto.notification.v1.Level.LEVEL_ERROR;
 import static org.hyades.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
 
@@ -39,19 +35,20 @@ class NvdMirror extends AbstractDatasourceMirror<NvdMirrorState> {
     private final ExecutorService executorService;
     private final Timer durationTimer;
 
-    private final NvdConfig config;
+    private final Retry retry;
+
 
     NvdMirror(final NvdApiClientFactory apiClientFactory,
               @Named("nvdExecutorService") final ExecutorService executorService,
               final MirrorStateStore mirrorStateStore,
               final VulnerabilityDigestStore vulnDigestStore,
               final Producer<String, byte[]> kafkaProducer,
-              @Named("nvdDurationTimer") final Timer durationTimer, NvdConfig config) {
+              @Named("nvdDurationTimer") final Timer durationTimer, @Named("nvdMirrorRetry") final Retry retry) {
         super(Datasource.NVD, mirrorStateStore, vulnDigestStore, kafkaProducer, NvdMirrorState.class);
         this.apiClientFactory = apiClientFactory;
         this.executorService = executorService;
         this.durationTimer = durationTimer;
-        this.config = config;
+        this.retry = retry;
     }
 
     @Override
@@ -64,25 +61,16 @@ class NvdMirror extends AbstractDatasourceMirror<NvdMirrorState> {
             } catch (InterruptedException e) {
                 LOGGER.warn("Thread was interrupted", e);
                 Thread.currentThread().interrupt();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 LOGGER.error("An unexpected error occurred mirroring the contents of the National Vulnerability Database", e);
                 dispatchNotification(LEVEL_ERROR, NOTIFICATION_TITLE,
-                        "An error occurred mirroring the contents of the National Vulnerability Database, cause being: "+e.getCause()+". Check log for details.");
+                        "An error occurred mirroring the contents of the National Vulnerability Database, cause being: " + e + ". Check log for details.");
             }
         });
     }
 
-    void mirrorInternal() throws Exception {
-        Retry retry;
-        final RetryRegistry retryRegistry = RetryRegistry.of(RetryConfig.custom().
-                intervalFunction(ofExponentialBackoff(
-                        Duration.ofSeconds(config.retryBackoffInitialDurationSeconds()),
-                        config.retryBackoffMultiplier(), Duration.ofSeconds(config.retryMaxDuration())))
-                .maxAttempts(config.retryMaxAttempts())
-                .retryOnException(NvdApiException.class::isInstance)
-                .retryOnResult(response -> false)
-                .build());
-        retry = retryRegistry.retry("nvd-api");
+    void mirrorInternal() throws Throwable {
+
         long lastModified = getState()
                 .map(NvdMirrorState::lastModifiedEpochSeconds)
                 .orElse(0L);
@@ -92,7 +80,7 @@ class NvdMirror extends AbstractDatasourceMirror<NvdMirrorState> {
 
         try (final NvdCveApi apiClient = apiClientFactory.createApiClient(lastModified)) {
             while (apiClient.hasNext()) {
-                final Collection<DefCveItem> cveItems = retry.executeCheckedSupplier(apiClient::next);
+                final Collection<DefCveItem> cveItems = this.retry.executeCheckedSupplier(apiClient::next);
                 if (cveItems == null) {
                     LOGGER.warn("No cve item in response from Nvd. Skipping to next item");
                     continue;
@@ -104,8 +92,6 @@ class NvdMirror extends AbstractDatasourceMirror<NvdMirrorState> {
             }
 
             updateState(new NvdMirrorState(apiClient.getLastModifiedRequest()));
-        } catch (Throwable e) {
-            throw new Exception(e);
         } finally {
             final long durationNanos = durationSample.stop(durationTimer);
             LOGGER.info("Mirroring of CVEs completed in {}", Duration.ofNanos(durationNanos));

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
@@ -1,6 +1,8 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonParseException;
+import io.github.jeremylong.nvdlib.NvdApiException;
 import io.github.jeremylong.nvdlib.NvdCveApi;
 import io.github.jeremylong.nvdlib.nvd.DefCveItem;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -20,11 +22,13 @@ import org.hyades.vulnmirror.TestConstants;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.hyades.proto.notification.v1.Group.GROUP_DATASOURCE_MIRRORING;
 import static org.hyades.proto.notification.v1.Level.LEVEL_ERROR;
@@ -111,7 +115,7 @@ class NvdMirrorTest {
                     assertThat(record.value().getGroup()).isEqualTo(GROUP_DATASOURCE_MIRRORING);
                     assertThat(record.value().getLevel()).isEqualTo(LEVEL_ERROR);
                     assertThat(record.value().getTitle()).isEqualTo("NVD Mirroring");
-                    assertThat(record.value().getContent()).isEqualTo("An error occurred mirroring the contents of the National Vulnerability Database. Check log for details.");
+                    assertThat(record.value().getContent()).isEqualTo("An error occurred mirroring the contents of the National Vulnerability Database, cause being: java.lang.IllegalStateException. Check log for details.");
                 }
         );
     }
@@ -162,4 +166,108 @@ class NvdMirrorTest {
         verify(apiClientFactoryMock).createApiClient(eq(1679922240L));
     }
 
+    @Test
+    void testRetryInCaseOfTwoConsecutiveExceptions() throws IOException {
+        final var apiClientMock = mock(NvdCveApi.class);
+        final var item = objectMapper.readValue(resourceToByteArray("/datasource/nvd/cve.json"), DefCveItem.class);
+
+        when(apiClientMock.hasNext())
+                .thenReturn(true)
+                .thenReturn(false);
+        when(apiClientMock.next())
+                .thenThrow(NvdApiException.class)
+                .thenThrow(NvdApiException.class)
+                .thenReturn(List.of(item));
+        when(apiClientMock.getLastModifiedRequest())
+                .thenReturn(1679922240L);
+
+        when(apiClientFactoryMock.createApiClient(anyLong()))
+                .thenReturn(apiClientMock);
+
+        assertThatNoException().isThrownBy(() -> nvdMirror.doMirror(null).get());
+        final List<ConsumerRecord<String, Bom>> vulnRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
+                .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(vulnRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isEqualTo("NVD/CVE-2022-40489");
+                    assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+
+                    final Vulnerability vuln = record.value().getVulnerabilities(0);
+                    assertThat(vuln.getId()).isEqualTo("CVE-2022-40489");
+                    assertThat(vuln.hasSource()).isTrue();
+                    assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+                }
+        );
+
+        // Trigger a mirror operation one more time.
+        // Verify that this time the previously stored "last updated" timestamp is used.
+        assertThatNoException().isThrownBy(() -> nvdMirror.mirrorInternal());
+    }
+
+    @Test
+    void testRetryWithDoMirrorInCaseOfThreeConsecutiveExceptions() throws IOException {
+        final var apiClientMock = mock(NvdCveApi.class);
+        final var item = objectMapper.readValue(resourceToByteArray("/datasource/nvd/cve.json"), DefCveItem.class);
+
+        when(apiClientMock.hasNext())
+                .thenReturn(true)
+                .thenReturn(false);
+        when(apiClientMock.next())
+                .thenThrow(NvdApiException.class)
+                .thenThrow(NvdApiException.class)
+                .thenThrow(NvdApiException.class)
+                .thenReturn(List.of(item));
+        when(apiClientMock.getLastModifiedRequest())
+                .thenReturn(1679922240L);
+
+        when(apiClientFactoryMock.createApiClient(anyLong()))
+                .thenReturn(apiClientMock);
+        assertThatNoException().isThrownBy(() -> nvdMirror.doMirror(null).get());
+
+        final List<ConsumerRecord<String, Notification>> notificationRecords = kafkaCompanion
+                .consume(Serdes.String(), new KafkaProtobufSerde<>(Notification.parser()))
+                .withGroupId(TestConstants.CONSUMER_GROUP_ID)
+                .withAutoCommit()
+                .fromTopics(KafkaTopic.NOTIFICATION_DATASOURCE_MIRRORING.getName(), 1, Duration.ofSeconds(5))
+                .awaitCompletion()
+                .getRecords();
+
+        assertThat(notificationRecords).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isNull();
+                    assertThat(record.value().getScope()).isEqualTo(SCOPE_SYSTEM);
+                    assertThat(record.value().getGroup()).isEqualTo(GROUP_DATASOURCE_MIRRORING);
+                    assertThat(record.value().getLevel()).isEqualTo(LEVEL_ERROR);
+                    assertThat(record.value().getTitle()).isEqualTo("NVD Mirroring");
+                    assertThat(record.value().getContent()).contains("io.github.jeremylong.nvdlib.NvdApiException");
+                }
+        );
+
+    }
+
+    @Test
+    void testRetryWithMirrorInternalInCaseOfThreeConsecutiveExceptions() throws IOException {
+        final var apiClientMock = mock(NvdCveApi.class);
+        final var item = objectMapper.readValue(resourceToByteArray("/datasource/nvd/cve.json"), DefCveItem.class);
+
+        when(apiClientMock.hasNext())
+                .thenReturn(true)
+                .thenReturn(false);
+        when(apiClientMock.next())
+                .thenThrow(NvdApiException.class)
+                .thenThrow(NvdApiException.class)
+                .thenThrow(NvdApiException.class)
+                .thenReturn(List.of(item));
+
+        when(apiClientFactoryMock.createApiClient(anyLong()))
+                .thenReturn(apiClientMock);
+        assertThatExceptionOfType(Exception.class).isThrownBy(() -> nvdMirror.mirrorInternal());
+
+    }
 }

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
@@ -1,7 +1,6 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.JsonParseException;
 import io.github.jeremylong.nvdlib.NvdApiException;
 import io.github.jeremylong.nvdlib.NvdCveApi;
 import io.github.jeremylong.nvdlib.nvd.DefCveItem;


### PR DESCRIPTION
**Description**

This PR adds retry logic to nvd mirror task that will help to deal with random gibberish seen while running NVD mirroring task as also raised here: https://github.com/jeremylong/vuln-tools/issues/42#issuecomment-1461860163
Closes issue: https://github.com/DependencyTrack/hyades/issues/489
Added corresponding unit tests as well

<img width="1258" alt="Screenshot 2023-04-13 at 22 18 50" src="https://user-images.githubusercontent.com/26340948/231885387-10c3a9ea-e54d-47b2-aaf0-65e957273e37.png">
<img width="1220" alt="Screenshot 2023-04-13 at 22 19 32" src="https://user-images.githubusercontent.com/26340948/231885394-1a36ccd4-447a-412a-9e83-1921c07ae696.png">
