### PR TITLE
Disable mapping of system properties in helm chart creation

### DIFF
--- a/mirror-service/src/main/resources/application.properties
+++ b/mirror-service/src/main/resources/application.properties
@@ -70,6 +70,7 @@ quarkus.helm.values.image-name.value=ghcr.io/dependencytrack/hyades-mirror-servi
 # quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_SSL_TRUSTSTORE_PASSWORD=
 quarkus.kubernetes.env.vars.KAFKA_SSL_ENABLED=false
 
+quarkus.helm.map-system-properties=false
 quarkus.kubernetes.env.vars.API_TOPIC_PREFIX=
 quarkus.kubernetes.env.vars.QUARKUS_LOG_CATEGORY_ORG_APACHE_KAFKA_LEVEL=WARN
 #for environments which need proxy quarkus proxy needs to be set.

--- a/notification-publisher/src/main/resources/application.properties
+++ b/notification-publisher/src/main/resources/application.properties
@@ -93,6 +93,7 @@ quarkus.helm.values.image-name.value=ghcr.io/dependencytrack/hyades-notification
 # quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_SSL_TRUSTSTORE_PASSWORD=
 quarkus.kubernetes.env.vars.KAFKA_SSL_ENABLED=false
 
+quarkus.helm.map-system-properties=false
 quarkus.kubernetes.env.vars.API_TOPIC_PREFIX=
 quarkus.kubernetes.env.vars.QUARKUS_LOG_CATEGORY_ORG_APACHE_KAFKA_LEVEL=WARN
 #for environments which need proxy quarkus proxy needs to be set.

--- a/repository-meta-analyzer/src/main/resources/application.properties
+++ b/repository-meta-analyzer/src/main/resources/application.properties
@@ -85,6 +85,7 @@ quarkus.helm.values.image-name.value=ghcr.io/dependencytrack/hyades-repository-m
 # quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_SSL_TRUSTSTORE_PASSWORD=
 quarkus.kubernetes.env.vars.KAFKA_SSL_ENABLED=false
 
+quarkus.helm.map-system-properties=false
 quarkus.kubernetes.env.vars.API_TOPIC_PREFIX=
 quarkus.kubernetes.env.vars.QUARKUS_LOG_CATEGORY_ORG_APACHE_KAFKA_LEVEL=WARN
 #for environments which need proxy quarkus proxy needs to be set.

--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -142,7 +142,7 @@ quarkus.hibernate-orm.active=true
 # quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_SSL_TRUSTSTORE_LOCATION=
 # quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_SSL_TRUSTSTORE_PASSWORD=
 quarkus.kubernetes.env.vars.KAFKA_SSL_ENABLED="false"
-
+quarkus.helm.map-system-properties=false
 quarkus.kubernetes.env.vars.API_TOPIC_PREFIX=
 quarkus.kubernetes.env.vars.QUARKUS_LOG_CATEGORY_ORG_APACHE_KAFKA_LEVEL=WARN
 #for environments which need proxy quarkus proxy needs to be set.


### PR DESCRIPTION
disabling system properties mapping in helm chart creation to avoid confusion.
For example: we have a property called api.topic.prefix that is part of application properties and used to set values of other properties in the same file as well. 
Due to this setup, quarkus helm extension is considering it as a system property and creating a corresponding entry in the deployment chart created like this:
api:
      topic:
        prefix: ""
This property is not being used and creates confusion with us also passing explicit environment variable called: API_TOPIC_PREFIX.
This change disables mapping of system properties so that these values are no longer added to automatically created deployment chart