### PR TITLE
Bump Redpanda

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
     restart: unless-stopped
 
   redpanda:
-    image: docker.redpanda.com/vectorized/redpanda:v23.1.2
+    image: docker.redpanda.com/vectorized/redpanda:v23.1.7
     container_name: dt-redpanda
     command:
       - redpanda
@@ -182,7 +182,7 @@ services:
     restart: unless-stopped
 
   redpanda-init:
-    image: docker.redpanda.com/vectorized/redpanda:v23.1.2
+    image: docker.redpanda.com/vectorized/redpanda:v23.1.7
     container_name: dt-redpanda-init
     depends_on:
       - redpanda
@@ -206,7 +206,7 @@ services:
     restart: on-failure
 
   redpanda-console:
-    image: docker.redpanda.com/vectorized/console:v2.2.2
+    image: docker.redpanda.com/vectorized/console:v2.2.3
     container_name: dt-redpanda-console
     entrypoint: "/bin/sh"
     command: "-c 'echo \"$$CONSOLE_CONFIG_FILE\" > \"$$CONFIG_FILEPATH\"; /app/console'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,6 +226,8 @@ services:
                 valueProtoType: org.hyades.notification.v1.Notification
               - topicName: dtrack.notification.bom-processed
                 valueProtoType: org.hyades.notification.v1.Notification
+              - topicName: dtrack.notification.bom-processing-failed
+                valueProtoType: org.hyades.notification.v1.Notification
               - topicName: dtrack.notification.configuration
                 valueProtoType: org.hyades.notification.v1.Notification
               - topicName: dtrack.notification.datasource-mirroring
@@ -265,6 +267,8 @@ services:
               - topicName: dtrack.vuln-analysis.result
                 keyProtoType: org.hyades.vulnanalysis.v1.ScanKey
                 valueProtoType: org.hyades.vulnanalysis.v1.ScanResult
+              - topicName: dtrack.vulnerability
+                valueProtoType: org.cyclonedx.v1_4.Bom
             fileSystem:
               enabled: true
               paths: ["/etc/protos"]


### PR DESCRIPTION
Bumps Redpanda to v23.1.7, and Redpanda Console to v2.2.3.

Also adds missing topic mappings for Redpanda Console.