### PR TITLE
build(deps): bump open-vulnerability-clients from 3.0.0 to 4.0.1

### DIFF
--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubAdvisoryToCdxParser.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubAdvisoryToCdxParser.java
@@ -47,7 +47,7 @@ public class GitHubAdvisoryToCdxParser {
 
         VulnerabilityRating.Builder rating = VulnerabilityRating.newBuilder()
                 .setSeverity(mapSeverity(advisory.getSeverity().value()))
-                .setScore(advisory.getCvss().getScore());
+                .setScore(advisory.getCvss().getScore().doubleValue());
 
         Optional.ofNullable(advisory.getCvss().getVectorString()).ifPresent(rating::setVector);
         vuln.addRatings(rating.build());

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
@@ -177,7 +177,7 @@ public final class NvdToCyclonedxParser {
             baseMetricV2.forEach(baseMetric -> {
                 CvssV20 cvss = baseMetric.getCvssData();
                 Optional.ofNullable(cvss).map(cvss20 -> VulnerabilityRating.newBuilder()
-                        .setScore(cvss20.getBaseScore())
+                        .setScore(cvss20.getBaseScore().doubleValue())
                         .setMethod(ScoreMethod.SCORE_METHOD_CVSSV2)
                         .setVector(cvss20.getVectorString())
                         .setSeverity(mapSeverity(baseMetric.getBaseSeverity()))
@@ -191,7 +191,7 @@ public final class NvdToCyclonedxParser {
             baseMetricV3.forEach(baseMetric -> {
                 CvssV30Data cvss = baseMetric.getCvssData();
                 Optional.ofNullable(cvss).map(cvssx -> VulnerabilityRating.newBuilder()
-                        .setScore(cvssx.getBaseScore())
+                        .setScore(cvssx.getBaseScore().doubleValue())
                         .setMethod(ScoreMethod.SCORE_METHOD_CVSSV3)
                         .setVector(cvssx.getVectorString())
                         .setSeverity(mapSeverity(cvssx.getBaseSeverity().value()))
@@ -205,7 +205,7 @@ public final class NvdToCyclonedxParser {
             baseMetricV31.forEach(baseMetric -> {
                 CvssV31Data cvss = baseMetric.getCvssData();
                 Optional.ofNullable(cvss).map(cvss31 -> VulnerabilityRating.newBuilder()
-                        .setScore(cvss.getBaseScore())
+                        .setScore(cvss.getBaseScore().doubleValue())
                         .setMethod(ScoreMethod.SCORE_METHOD_CVSSV31)
                         .setVector(cvss.getVectorString())
                         .setSeverity(mapSeverity(cvss.getBaseSeverity().value()))

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <lib.pebble.version>3.2.0</lib.pebble.version>
     <lib.quarkus-helm.version>0.2.8</lib.quarkus-helm.version>
     <lib.resilience4j.version>2.0.2</lib.resilience4j.version>
-    <lib.open.vulnerability.clients.version>3.0.0</lib.open.vulnerability.clients.version>
+    <lib.open.vulnerability.clients.version>4.0.0</lib.open.vulnerability.clients.version>
     <lib.wiremock.version>2.35.0</lib.wiremock.version>
     <lib.xercesimpl.version>2.12.2</lib.xercesimpl.version>
     <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <lib.pebble.version>3.2.0</lib.pebble.version>
     <lib.quarkus-helm.version>0.2.8</lib.quarkus-helm.version>
     <lib.resilience4j.version>2.0.2</lib.resilience4j.version>
-    <lib.open.vulnerability.clients.version>4.0.0</lib.open.vulnerability.clients.version>
+    <lib.open.vulnerability.clients.version>4.0.1</lib.open.vulnerability.clients.version>
     <lib.wiremock.version>2.35.0</lib.wiremock.version>
     <lib.xercesimpl.version>2.12.2</lib.xercesimpl.version>
     <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>


### PR DESCRIPTION
Upgrade to the latest version of the `open-vulnerability-clients` library; supersedes #509.

- [Release notes for 4.0.0](https://github.com/jeremylong/Open-Vulnerability-Project/releases/tag/v4.0.0)
   - Add data feed client for First.org [Exploit Prediction Scoring System (EPSS)](https://www.first.org/epss/)
   - Add data feed client for CISA's [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
   - Breaking change: updated all usage of Float data types for scores to BigDecimal to preserve accuracy
- [Release notes for 4.0.1](https://github.com/jeremylong/Open-Vulnerability-Project/releases/tag/v4.0.1)
   - minor update to the dependencies of the vulnz cli
   - removed the use of deprecated function