### PR TITLE
Ensure timestamps for Go modules are parsed as UTC

### DIFF
--- a/repository-meta-analyzer/src/main/java/org/hyades/repositories/GoModulesMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/hyades/repositories/GoModulesMetaAnalyzer.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 
 /**
  * @author Steve Springett
@@ -101,7 +103,9 @@ public class GoModulesMetaAnalyzer extends AbstractMetaAnalyzer {
 
                 final String commitTimestamp = jsonObject.getString("Time");
                 if (StringUtils.isNotBlank(commitTimestamp)) { // Time is optional
-                    meta.setPublishedTimestamp(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(commitTimestamp));
+                    final var dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+                    dateFormat.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC));
+                    meta.setPublishedTimestamp(dateFormat.parse(commitTimestamp));
                 }
             }
         } catch (ParseException e) {

--- a/repository-meta-analyzer/src/test/java/org/hyades/RepositoryMetaAnalyzerIT.java
+++ b/repository-meta-analyzer/src/test/java/org/hyades/RepositoryMetaAnalyzerIT.java
@@ -122,7 +122,7 @@ class RepositoryMetaAnalyzerIT {
                     assertThat(result.hasLatestVersion()).isTrue();
                     assertThat(result.getLatestVersion()).isEqualTo("v6.6.6");
                     assertThat(result.hasPublished()).isTrue();
-                    assertThat(result.getPublished().getSeconds()).isEqualTo(1664395172);
+                    assertThat(result.getPublished().getSeconds()).isEqualTo(1664402372);
                 }
         );
     }


### PR DESCRIPTION
Timestamps in responses of the Go module proxy are specified for the UTC timezone, but we currently parse it at the system's default time zone instead.