### PR TITLE
DataNucleus: Add logging bridge

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
+    <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
   </properties>
 
   <dependencies>
@@ -99,6 +100,12 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>${lib.log4j-over-slf4j.version}</version>
     </dependency>
   </dependencies>
 

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -10,6 +10,10 @@
     </parent>
     <artifactId>e2e</artifactId>
 
+    <properties>
+        <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -44,6 +48,12 @@
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail-junit5</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${lib.log4j-over-slf4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
         <lib.resilience4j.version>2.0.2</lib.resilience4j.version>
+        <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
     </properties>
 
     <dependencies>
@@ -122,6 +123,12 @@
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-micrometer</artifactId>
             <version>${lib.resilience4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${lib.log4j-over-slf4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
+    <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
   </properties>
 
   <dependencies>
@@ -100,6 +101,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-kubernetes</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>${lib.log4j-over-slf4j.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <lib.wiremock.version>2.35.0</lib.wiremock.version>
     <lib.xercesimpl.version>2.12.2</lib.xercesimpl.version>
     <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>
+    <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
 
     <!-- Plugin Versions -->
     <plugin.jacoco.version>0.8.10</plugin.jacoco.version>
@@ -210,6 +211,12 @@
         <groupId>com.icegreen</groupId>
         <artifactId>greenmail-junit5</artifactId>
         <version>${lib.greenmail.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${lib.log4j-over-slf4j.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
+    <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
   </properties>
 
   <dependencies>
@@ -140,6 +141,12 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>${lib.log4j-over-slf4j.version}</version>
     </dependency>
   </dependencies>
 

--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
+        <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
     </properties>
 
     <dependencies>
@@ -136,6 +137,12 @@
           <groupId>net.javacrumbs.json-unit</groupId>
           <artifactId>json-unit-assertj</artifactId>
           <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${lib.log4j-over-slf4j.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Adds the log4j-over-slf4j logging bridge which is needed to see DataNucleus log output.

https://github.com/DependencyTrack/hyades/issues/374