### PR TITLE
Fix mirror service demo setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - postgres
       - redpanda
     environment:
-      QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
+      KAFKA_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
       KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
       QUARKUS_DATASOURCE_USERNAME: "dtrack"
@@ -26,7 +26,7 @@ services:
       - postgres
       - redpanda
     environment:
-      QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
+      KAFKA_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
       KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
       QUARKUS_DATASOURCE_USERNAME: "dtrack"
@@ -48,7 +48,7 @@ services:
       - postgres
       - redpanda
     environment:
-      QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
+      KAFKA_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
       KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
       QUARKUS_DATASOURCE_USERNAME: "dtrack"
@@ -78,7 +78,7 @@ services:
       - postgres
       - redpanda
     environment:
-      QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
+      KAFKA_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
       KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
     ports:
       # Dynamic host port binding to allow for scaling of the service.

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubReflectionConfiguration.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubReflectionConfiguration.java
@@ -1,0 +1,32 @@
+package org.hyades.vulnmirror.datasource.github;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Register classes of {@code open-vulnerability-clients} for the GitHub data source for reflection.
+ */
+@SuppressWarnings("unused")
+@RegisterForReflection(
+        // Some classes of the library are package-private, so we can't reference them directly.
+        classNames = {
+                "io.github.jeremylong.openvulnerability.client.ghsa.AbstractPageable",
+                "io.github.jeremylong.openvulnerability.client.ghsa.CVSS",
+                "io.github.jeremylong.openvulnerability.client.ghsa.CWE",
+                "io.github.jeremylong.openvulnerability.client.ghsa.CWEs",
+                "io.github.jeremylong.openvulnerability.client.ghsa.Identifier",
+                "io.github.jeremylong.openvulnerability.client.ghsa.Package",
+                "io.github.jeremylong.openvulnerability.client.ghsa.PackageVersion",
+                "io.github.jeremylong.openvulnerability.client.ghsa.PageInfo",
+                "io.github.jeremylong.openvulnerability.client.ghsa.RateLimit",
+                "io.github.jeremylong.openvulnerability.client.ghsa.Reference",
+                "io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisories",
+                "io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisory",
+                "io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisoryResponse",
+                "io.github.jeremylong.openvulnerability.client.ghsa.Severity",
+                "io.github.jeremylong.openvulnerability.client.ghsa.Vulnerabilities",
+                "io.github.jeremylong.openvulnerability.client.ghsa.Vulnerability"
+        },
+        ignoreNested = false
+)
+class GitHubReflectionConfiguration {
+}

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdReflectionConfiguration.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdReflectionConfiguration.java
@@ -1,0 +1,35 @@
+package org.hyades.vulnmirror.datasource.nvd;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Register classes of {@code open-vulnerability-clients} for the NVD data source for reflection.
+ * <p>
+ * The model classes are generated from JSON in {@code nvd-lib}.
+ * When inspecting the library's code on GitHub, you won't find these classes.
+ */
+@SuppressWarnings("unused")
+@RegisterForReflection(
+        targets = {
+                io.github.jeremylong.openvulnerability.client.nvd.Config.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CpeMatch.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CveApiJson20.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CveItem.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CvssV2.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CvssV20.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CvssV30.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CvssV30Data.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CvssV31.class,
+                io.github.jeremylong.openvulnerability.client.nvd.CvssV31Data.class,
+                io.github.jeremylong.openvulnerability.client.nvd.DefCveItem.class,
+                io.github.jeremylong.openvulnerability.client.nvd.LangString.class,
+                io.github.jeremylong.openvulnerability.client.nvd.Metrics.class,
+                io.github.jeremylong.openvulnerability.client.nvd.Node.class,
+                io.github.jeremylong.openvulnerability.client.nvd.Reference.class,
+                io.github.jeremylong.openvulnerability.client.nvd.VendorComment.class,
+                io.github.jeremylong.openvulnerability.client.nvd.Weakness.class
+        },
+        ignoreNested = false
+)
+class NvdReflectionConfiguration {
+}

--- a/mirror-service/src/main/resources/application.properties
+++ b/mirror-service/src/main/resources/application.properties
@@ -27,7 +27,6 @@ kafka.compression.type=snappy
 
 ## Kafka Streams
 #
-%dev.quarkus.kafka-streams.bootstrap-servers=localhost:9092
 api.topic.prefix=
 quarkus.kafka-streams.application-id=${api.topic.prefix}hyades-mirror-service
 quarkus.kafka-streams.application-server=localhost:8093
@@ -62,7 +61,6 @@ mirror.datasource.osv.base-url=https://osv-vulnerabilities.storage.googleapis.co
 quarkus.kubernetes-client.devservices.enabled=false
 quarkus.kubernetes.replicas=1
 quarkus.kubernetes.env.vars.KAFKA_BOOTSTRAP_SERVERS=host.minikube.internal:9093
-quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS=host.minikube.internal:9093
 quarkus.helm.values.image-name.property=image
 quarkus.helm.values.image-name.value=ghcr.io/dependencytrack/hyades-mirror-service:1.0.0-snapshot
 

--- a/notification-publisher/src/main/resources/application.properties
+++ b/notification-publisher/src/main/resources/application.properties
@@ -5,8 +5,7 @@ quarkus.http.port=8090
 
 ## Kafka
 #
-kafka.bootstrap.servers=localhost:9092
-quarkus.kafka-streams.bootstrap-servers=localhost:9092
+%dev.kafka.bootstrap.servers=localhost:9092
 api.topic.prefix=
 quarkus.kafka-streams.application-id=${api.topic.prefix}hyades-notification-publisher
 quarkus.kafka-streams.application-server=localhost:8090
@@ -80,7 +79,6 @@ quarkus.mailer.ssl=false
 quarkus.kubernetes-client.devservices.enabled=false
 quarkus.kubernetes.replicas=1
 quarkus.kubernetes.env.vars.KAFKA_BOOTSTRAP_SERVERS=test
-quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_USERNAME=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_PASSWORD=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_JDBC_URL=test

--- a/repository-meta-analyzer/src/main/resources/application.properties
+++ b/repository-meta-analyzer/src/main/resources/application.properties
@@ -6,7 +6,6 @@ quarkus.http.port=8091
 ## Kafka
 #
 %dev.kafka.bootstrap.servers=localhost:9092
-%dev.quarkus.kafka-streams.bootstrap-servers=localhost:9092
 api.topic.prefix=
 quarkus.kafka-streams.application-id=${api.topic.prefix}hyades-repository-meta-analyzer
 quarkus.kafka-streams.application-server=localhost:8091
@@ -72,7 +71,6 @@ quarkus.cache.caffeine."metaAnalyzer".initial-capacity=5
 quarkus.kubernetes-client.devservices.enabled=false
 quarkus.kubernetes.replicas=1
 quarkus.kubernetes.env.vars.KAFKA_BOOTSTRAP_SERVERS=test
-quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_USERNAME=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_PASSWORD=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_JDBC_URL=test

--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -6,7 +6,6 @@ quarkus.http.port=8092
 ## Kafka
 #
 %dev.kafka.bootstrap.servers=localhost:9092
-%dev.quarkus.kafka-streams.bootstrap-servers=localhost:9092
 api.topic.prefix=
 quarkus.kafka-streams.application-id=${api.topic.prefix}hyades-vulnerability-analyzer
 quarkus.kafka-streams.application-server=localhost:8092
@@ -165,7 +164,6 @@ quarkus.kubernetes.env.vars.SCANNER_SNYK_API_BASE_URL=https://api.snyk.io
 quarkus.kubernetes-client.devservices.enabled=false
 quarkus.kubernetes.replicas=1
 quarkus.kubernetes.env.vars.KAFKA_BOOTSTRAP_SERVERS=test
-quarkus.kubernetes.env.vars.QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_USERNAME=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_PASSWORD=test
 quarkus.kubernetes.env.vars.QUARKUS_DATASOURCE_JDBC_URL=test


### PR DESCRIPTION
The mirror service was failing in the demo setup, because:

* Only `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS` was set, but this env variable is not picked up by the internal Kafka producer that is not managed by Kafka Streams
* The reflection registration for NVD and GitHub classes was missing, causing deserialization issues when running the native image

I have also gone ahead and replaced all usages of `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS` with `KAFKA_BOOTSTRAP_SERVERS`. It will be picked up by both non-Kafka Streams, and Kafka Streams clients.