### PR TITLE
Optimize state store usage

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -11,9 +11,9 @@ options that are expected to be changed by users.
 Kafka topics (including internal topics) can be configured with custom prefix. In order to provide custom prefix, below
 environment variable can be used.
 
-| Environment Variable               | Description                     | Default      | Required  |
-|:-----------------------------------|:--------------------------------|:-------------|:---------:|
-| `API_TOPIC_PREFIX`                 | Prefix for topic names          | -            |     ❌     |
+| Environment Variable | Description            | Default | Required |
+|:---------------------|:-----------------------|:--------|:--------:|
+| `API_TOPIC_PREFIX`   | Prefix for topic names | -       |    ❌     |
 
 ### Notification Publisher
 
@@ -58,30 +58,32 @@ to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/mai
 
 ### Vulnerability Analyzer
 
-| Environment Variable                      | Description                                               | Default                |       Required      |
-|:------------------------------------------|:----------------------------------------------------------|:-----------------------|:-------------------:|
-| `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS` | Comma-separated list of Kafka servers                     | `localhost:9092`       |          ✅          |
-| `KAFKA_SSL_ENABLED`                       | SSL enabled for using kafka broker                    | `false`          |          ❌          |
-| `KAFKA_STREAMS_NUM_STREAM_THREADS`        | Number of Kafka Streams threads                           | `3`                    |          ❌          |
-| `QUARKUS_DATASOURCE_DB_KIND`              | The database type                                         | `postgresql`           |          ✅          |
-| `QUARKUS_DATASOURCE_JDBC_URL`             | The database JDBC URL                                     | -                      |          ✅          |
-| `QUARKUS_DATASOURCE_USERNAME`             | The database username                                     | -                      |          ✅          |
-| `QUARKUS_DATASOURCE_PASSWORD`             | The database password                                     | -                      |          ✅          |
-| `SCANNER_INTERNAL_ENABLED`                | Enable the internal vulnerability scanner                 | `true`                 |          ❌          |
-| `SCANNER_OSSINDEX_ENABLED`                | Enable the OSS Index vulnerability scanner                | `true`                 |          ❌          |
-| `SCANNER_OSSINDEX_API_USERNAME`           | OSS Index API username                                    | -                      |          ❌          |
-| `SCANNER_OSSINDEX_API_TOKEN`              | OSS Index API token                                       | -                      |          ❌          |
-| `SCANNER_OSSINDEX_BATCH_INTERVAL`         | Max time to wait before submitting incomplete batches     | `5S`                   |          ❌          |
-| `SCANNER_SNYK_ENABLED`                    | Enable the Snyk vulnerability scanner                     | `false`                |          ❌          |
-| `SCANNER_SNYK_API_ORG_ID`                 | Snyk organization ID                                      | -                      | When Snyk is enabled |
-| `SCANNER_SNYK_API_TOKENS`                 | Comma-separated list of Snyk API tokens                   | -                      | When Snyk is enabled |
-| `SCANNER_SNYK_API_VERSION`                | Version of the Snyk API to use                            | `2022-12-15`           | When Snyk is enabled |
-| `SCANNER_SNYK_SEVERITY_SOURCE_PRIORITY`   | Priority of preferred source for vulnerability severities | `nvd,snyk,redhat,suse` | When Snyk is enabled |
-| `SCANNER_SNYK_BATCH_INTERVAL`             | Max time to wait before submitting incomplete batches     | `5S`                   | When Snyk is enabled |
-| `SCANNER_SNYK_BATCH_SIZE`                 | Max size of batch at which it will be submitted           | `100`                  | When Snyk is enabled |
-| `SCANNER_SNYK_ALIAS_SYNC_ENABLED`         | Alias synching enabled for snyk analyzer              | `false`          |          ❌          |
-| `SCANNER_OSS_ALIAS_SYNC_ENABLED`          | Alias synching enabled for oss index analyzer         | `false`          |          ❌          |
-| `SCANNER_INTERNAL_ALIAS_SYNC_ENABLED`     | Alias synching enabled for internal analyzer          | `false`          |          ❌          |
+| Environment Variable                      | Description                                                                 | Default                |       Required       |
+|:------------------------------------------|:----------------------------------------------------------------------------|:-----------------------|:--------------------:|
+| `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS` | Comma-separated list of Kafka servers                                       | `localhost:9092`       |          ✅           |
+| `KAFKA_SSL_ENABLED`                       | SSL enabled for using kafka broker                                          | `false`                |          ❌           |
+| `KAFKA_STREAMS_NUM_STREAM_THREADS`        | Number of Kafka Streams threads                                             | `3`                    |          ❌           |
+| `STATE_STORE_TYPE`                        | Whether to use in-memory or persistent (RocksDB) Kafka Streams state stores | `in_memory`            |          ✅           |
+| `STATE_STORE_ROCKS_DB_COMPACTION_STYLE`   | Compaction style to use for RocksDB state stores                            | -                      |          ❌           |
+| `STATE_STORE_ROCKS_DB_COMPRESSION_TYPE`   | Compression type to use for RocksDB state stores                            | -                      |          ❌           |  
+| `QUARKUS_DATASOURCE_DB_KIND`              | The database type                                                           | `postgresql`           |          ✅           |
+| `QUARKUS_DATASOURCE_JDBC_URL`             | The database JDBC URL                                                       | -                      |          ✅           |
+| `QUARKUS_DATASOURCE_USERNAME`             | The database username                                                       | -                      |          ✅           |
+| `QUARKUS_DATASOURCE_PASSWORD`             | The database password                                                       | -                      |          ✅           | 
+| `SCANNER_INTERNAL_ENABLED`                | Enable the internal vulnerability scanner                                   | `true`                 |          ❌           |
+| `SCANNER_OSSINDEX_ENABLED`                | Enable the OSS Index vulnerability scanner                                  | `true`                 |          ❌           |
+| `SCANNER_OSSINDEX_API_USERNAME`           | OSS Index API username                                                      | -                      |          ❌           |
+| `SCANNER_OSSINDEX_API_TOKEN`              | OSS Index API token                                                         | -                      |          ❌           |
+| `SCANNER_OSSINDEX_BATCH_INTERVAL`         | Max time to wait before submitting incomplete batches                       | `5S`                   |          ❌           |
+| `SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED`     | Alias synching enabled for oss index analyzer                               | `false`                |          ❌           |
+| `SCANNER_SNYK_ENABLED`                    | Enable the Snyk vulnerability scanner                                       | `false`                |          ❌           |
+| `SCANNER_SNYK_API_ORG_ID`                 | Snyk organization ID                                                        | -                      | When Snyk is enabled |
+| `SCANNER_SNYK_API_TOKENS`                 | Comma-separated list of Snyk API tokens                                     | -                      | When Snyk is enabled |
+| `SCANNER_SNYK_API_VERSION`                | Version of the Snyk API to use                                              | `2022-12-15`           | When Snyk is enabled |
+| `SCANNER_SNYK_SEVERITY_SOURCE_PRIORITY`   | Priority of preferred source for vulnerability severities                   | `nvd,snyk,redhat,suse` | When Snyk is enabled |
+| `SCANNER_SNYK_BATCH_INTERVAL`             | Max time to wait before submitting incomplete batches                       | `5S`                   | When Snyk is enabled |
+| `SCANNER_SNYK_BATCH_SIZE`                 | Max size of batch at which it will be submitted                             | `100`                  | When Snyk is enabled |
+| `SCANNER_SNYK_ALIAS_SYNC_ENABLED`         | Alias synching enabled for snyk analyzer                                    | `false`                |          ❌           |
 
 > **Note**
 > Refer
@@ -89,16 +91,15 @@ to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/mai
 to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/vulnerability-analyzer/src/main/resources/application.properties)
 > for a complete overview of available config options.
 
-
 ### Mirror Service
 
-| Environment Variable                          | Description                                  | Default          |       Required      |
-|:----------------------------------------------|:---------------------------------------------|:-----------------|:-------------------:|
-| `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS`     | Comma-separated list of Kafka servers        | `localhost:9092` |          ✅          |
-| `KAFKA_SSL_ENABLED`                           | SSL enabled for using kafka broker           | `false`          |          ❌          |
-| `KAFKA_STREAMS_NUM_STREAM_THREADS`            | Number of Kafka Streams threads              | `3`              |          ❌          |
-| `MIRROR_DATASOURCE_GITHUB_ALIAS_SYNC_ENABLED` | Alias synching enabled for github mirroring  | `false`          |          ❌          |
-| `MIRROR_DATASOURCE_OSV_ALIAS_SYNC_ENABLED`    | Alias synching enabled for osv mirroring     | `false`          |          ❌          |
+| Environment Variable                          | Description                                | Default          | Required |
+|:----------------------------------------------|:-------------------------------------------|:-----------------|:--------:|
+| `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS`     | Comma-separated list of Kafka servers      | `localhost:9092` |    ✅     |
+| `KAFKA_SSL_ENABLED`                           | SSL enabled for using kafka broker         | `false`          |    ❌     |
+| `KAFKA_STREAMS_NUM_STREAM_THREADS`            | Number of Kafka Streams threads            | `3`              |    ❌     |
+| `MIRROR_DATASOURCE_GITHUB_ALIAS_SYNC_ENABLED` | Alias syncing enabled for github mirroring | `false`          |    ❌     |
+| `MIRROR_DATASOURCE_OSV_ALIAS_SYNC_ENABLED`    | Alias syncing enabled for osv mirroring    | `false`          |    ❌     |
 
 > **Note**
 > Refer

--- a/TOPICS.md
+++ b/TOPICS.md
@@ -1,45 +1,45 @@
 # Topics
 
-| Name                                                                                              | Partitions | Config                   |
-|:--------------------------------------------------------------------------------------------------|:-----------|:-------------------------|
-| `dtrack-apiserver-processed-vuln-scan-result-by-scan-token-repartition`<sup>1A</sup>              | 3          |                          |
-| `dtrack-apiserver-vuln-scan-result-by-component-uuid-repartition`<sup>1A</sup>                    | 3          |                          |
-| `dtrack.notification.analyzer`                                                                    | 3          |                          |
-| `dtrack.notification.bom-consumed`                                                                | 3          |                          |
-| `dtrack.notification.bom-processed`                                                               | 3          |                          |
-| `dtrack.notification.configuration`                                                               | 3          |                          |
-| `dtrack.notification.datasource-mirroring`                                                        | 3          |                          |
-| `dtrack.notification.file-system`                                                                 | 3          |                          |
-| `dtrack.notification.indexing-service`                                                            | 3          |                          |
-| `dtrack.notification.integration`                                                                 | 3          |                          |
-| `dtrack.notification.new-vulnerability`                                                           | 3          |                          |
-| `dtrack.notification.new-vulnerable-dependency`                                                   | 3          |                          |
-| `dtrack.notification.policy-violation`                                                            | 3          |                          |
-| `dtrack.notification.project-audit-change`                                                        | 3          |                          |
-| `dtrack.notification.project-created`                                                             | 3          |                          |
-| `dtrack.notification.repository`                                                                  | 3          |                          |
-| `dtrack.notification.vex-consumed`                                                                | 3          |                          |
-| `dtrack.notification.vex-processed`                                                               | 3          |                          |
-| `dtrack.repo-meta-analysis.component`<sup>1B</sup>                                                | 3          |                          |
-| `dtrack.repo-meta-analysis.result`                                                                | 3          |                          |
-| `dtrack.vuln-analysis.component`<sup>1C</sup>                                                     | 3          |                          |
-| `dtrack.vuln-analysis.result`<sup>1A</sup>                                                        | 3          |                          |
-| `dtrack.vuln-analysis.scanner.result`<sup>1C</sup>                                                | 3          |                          |
-| `dtrack.vulnerability`                                                                            | 3          | `cleanup.policy=compact` |
-| `dtrack.vulnerability.digest`<sup>2</sup>                                                         | 1          | `cleanup.policy=compact` |
-| `dtrack.vulnerability.mirror.command`<sup>2</sup>                                                 | 1          |                          |
-| `dtrack.vulnerability.mirror.state`<sup>2</sup>                                                   | 1          | `cleanup.policy=compact` |
-| `hyades-repository-meta-analyzer-command-by-purl-coordinates-repartition`<sup>1B</sup>            | 3          |                          |
-| `hyades-vulnerability-analyzer-completed-scans-table-changelog`<sup>1C</sup>                      | 3          | `cleanup.policy=compact` |
-| `hyades-vulnerability-analyzer-expected-scanner-results-last-update-store-changelog`<sup>1C</sup> | 3          | `cleanup.policy=compact` |
-| `hyades-vulnerability-analyzer-expected-scanner-results-table-changelog`<sup>1C</sup>             | 3          | `cleanup.policy=compact` |
-| `hyades-vulnerability-analyzer-ossindex-batch-store-changelog`<sup>1D</sup>                       | 3          | `cleanup.policy=compact` |
-| `hyades-vulnerability-analyzer-ossindex-retry-store-changelog`<sup>1D</sup>                       | 3          | `cleanup.policy=compact` |
-| `hyades-vulnerability-analyzer-scan-task-internal-repartition`                                    | 3          |                          |
-| `hyades-vulnerability-analyzer-scan-task-ossindex-repartition`<sup>1D</sup>                       | 3          |                          |
-| `hyades-vulnerability-analyzer-scan-task-snyk-repartition`<sup>1E</sup>                           | 3          |                          |
-| `hyades-vulnerability-analyzer-snyk-batch-store-changelog`<sup>1E</sup>                           | 3          | `cleanup.policy=compact` |
-| `hyades-vulnerability-analyzer-snyk-retry-store-changelog`<sup>1E</sup>                           | 3          | `cleanup.policy=compact` |
+| Name                                                                                              | Partitions | Config                                                                              |
+|:--------------------------------------------------------------------------------------------------|:-----------|:------------------------------------------------------------------------------------|
+| `dtrack-apiserver-processed-vuln-scan-result-by-scan-token-repartition`<sup>1A</sup>              | 3          |                                                                                     |
+| `dtrack-apiserver-vuln-scan-result-by-component-uuid-repartition`<sup>1A</sup>                    | 3          |                                                                                     |
+| `dtrack.notification.analyzer`                                                                    | 3          |                                                                                     |
+| `dtrack.notification.bom-consumed`                                                                | 3          |                                                                                     |
+| `dtrack.notification.bom-processed`                                                               | 3          |                                                                                     |
+| `dtrack.notification.configuration`                                                               | 3          |                                                                                     |
+| `dtrack.notification.datasource-mirroring`                                                        | 3          |                                                                                     |
+| `dtrack.notification.file-system`                                                                 | 3          |                                                                                     |
+| `dtrack.notification.indexing-service`                                                            | 3          |                                                                                     |
+| `dtrack.notification.integration`                                                                 | 3          |                                                                                     |
+| `dtrack.notification.new-vulnerability`                                                           | 3          |                                                                                     |
+| `dtrack.notification.new-vulnerable-dependency`                                                   | 3          |                                                                                     |
+| `dtrack.notification.policy-violation`                                                            | 3          |                                                                                     |
+| `dtrack.notification.project-audit-change`                                                        | 3          |                                                                                     |
+| `dtrack.notification.project-created`                                                             | 3          |                                                                                     |
+| `dtrack.notification.repository`                                                                  | 3          |                                                                                     |
+| `dtrack.notification.vex-consumed`                                                                | 3          |                                                                                     |
+| `dtrack.notification.vex-processed`                                                               | 3          |                                                                                     |
+| `dtrack.repo-meta-analysis.component`<sup>1B</sup>                                                | 3          |                                                                                     |
+| `dtrack.repo-meta-analysis.result`                                                                | 3          |                                                                                     |
+| `dtrack.vuln-analysis.component`<sup>1C</sup>                                                     | 3          |                                                                                     |
+| `dtrack.vuln-analysis.result`<sup>1A</sup>                                                        | 3          |                                                                                     |
+| `dtrack.vuln-analysis.scanner.result`<sup>1C</sup>                                                | 3          |                                                                                     |
+| `dtrack.vulnerability`                                                                            | 3          | `cleanup.policy=compact`                                                            |
+| `dtrack.vulnerability.digest`<sup>2</sup>                                                         | 1          | `cleanup.policy=compact`                                                            |
+| `dtrack.vulnerability.mirror.command`<sup>2</sup>                                                 | 1          |                                                                                     |
+| `dtrack.vulnerability.mirror.state`<sup>2</sup>                                                   | 1          | `cleanup.policy=compact`                                                            |
+| `hyades-repository-meta-analyzer-command-by-purl-coordinates-repartition`<sup>1B</sup>            | 3          |                                                                                     |
+| `hyades-vulnerability-analyzer-completed-scans-table-changelog`<sup>1C</sup>                      | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-expected-scanner-results-last-update-store-changelog`<sup>1C</sup> | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-expected-scanner-results-table-changelog`<sup>1C</sup>             | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-ossindex-batch-store-changelog`<sup>1D</sup>                       | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-ossindex-retry-store-changelog`<sup>1D</sup>                       | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-scan-task-internal-repartition`                                    | 3          |                                                                                     |
+| `hyades-vulnerability-analyzer-scan-task-ossindex-repartition`<sup>1D</sup>                       | 3          |                                                                                     |
+| `hyades-vulnerability-analyzer-scan-task-snyk-repartition`<sup>1E</sup>                           | 3          |                                                                                     |
+| `hyades-vulnerability-analyzer-snyk-batch-store-changelog`<sup>1E</sup>                           | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-snyk-retry-store-changelog`<sup>1E</sup>                           | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
 
 *<sup>1X</sup> The topic is subject to [co-partitioning requirements](#co-partitioning-requirements)*  
 *<sup>2</sup> The partition number of this topic should not be changed*

--- a/TOPICS.md
+++ b/TOPICS.md
@@ -31,7 +31,6 @@
 | `dtrack.vulnerability.mirror.state`<sup>2</sup>                                                   | 1          | `cleanup.policy=compact` |
 | `hyades-repository-meta-analyzer-command-by-purl-coordinates-repartition`<sup>1B</sup>            | 3          |                          |
 | `hyades-vulnerability-analyzer-completed-scans-table-changelog`<sup>1C</sup>                      | 3          | `cleanup.policy=compact` |
-| `hyades-vulnerability-analyzer-completed-scans-table-last-update-store-changelog`<sup>1C</sup>    | 3          | `cleanup.policy=compact` |
 | `hyades-vulnerability-analyzer-expected-scanner-results-last-update-store-changelog`<sup>1C</sup> | 3          | `cleanup.policy=compact` |
 | `hyades-vulnerability-analyzer-expected-scanner-results-table-changelog`<sup>1C</sup>             | 3          | `cleanup.policy=compact` |
 | `hyades-vulnerability-analyzer-ossindex-batch-store-changelog`<sup>1D</sup>                       | 3          | `cleanup.policy=compact` |

--- a/proto/src/main/proto/org/hyades/vulnanalysis/internal/v1beta1/vuln_analysis_internal.proto
+++ b/proto/src/main/proto/org/hyades/vulnanalysis/internal/v1beta1/vuln_analysis_internal.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 // Internal API for Hyades vulnerability analysis.
 package org.hyades.vulnanalysis.internal.v1beta1;
 
+import "google/protobuf/timestamp.proto";
 import "org/hyades/vulnanalysis/v1/vuln_analysis.proto";
 
 option java_multiple_files = true;
@@ -20,8 +21,11 @@ message ScannerResultAggregate {
   // Scanner results by scanner name.
   map<string, org.hyades.vulnanalysis.v1.ScannerResult> results = 1;
 
-  // Whether this event represents a tombstone.
-  optional bool tombstone = 2;
+  // When the aggregate was last updated.
+  optional google.protobuf.Timestamp last_updated = 3;
+
+  reserved 2;
+  reserved "tombstone";
 }
 
 message ScanTask {

--- a/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
@@ -51,6 +51,7 @@ import static org.hyades.commonutil.KafkaStreamsUtil.processorNameConsume;
 import static org.hyades.commonutil.KafkaStreamsUtil.processorNameProduce;
 import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_PENDING;
 import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_NONE;
+import static org.hyades.util.StateStoreUtil.defaultChangelogTopicConfig;
 
 @ApplicationScoped
 public class VulnerabilityAnalyzerTopology {
@@ -182,7 +183,8 @@ public class VulnerabilityAnalyzerTopology {
                                 .<ScanKey, ExpectedScannerResults, KeyValueStore<Bytes, byte[]>>as("expected-scanner-results-table")
                                 .withKeySerde(scanKeySerde)
                                 .withValueSerde(expectedScannerResultsSerde)
-                                .withStoreType(stateStoreConfig.type()));
+                                .withStoreType(stateStoreConfig.type())
+                                .withLoggingEnabled(defaultChangelogTopicConfig()));
 
         // Join the results we receive from scanners with the table of expected scanner results.
         final KStream<ScanKey, ScannerResultAggregate> completedScansStream = scannerResultStream

--- a/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Repartitioned;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.hyades.common.KafkaTopic;
+import org.hyades.processor.misc.ScannerResultAggregatorSupplier;
 import org.hyades.processor.misc.TombstoneEmittingProcessorSupplier;
 import org.hyades.processor.scanner.ScanProcessorSupplier;
 import org.hyades.proto.KafkaProtobufSerde;
@@ -44,7 +45,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.hyades.commonutil.KafkaStreamsUtil.processorNameConsume;
 import static org.hyades.commonutil.KafkaStreamsUtil.processorNameProduce;
@@ -70,7 +70,6 @@ public class VulnerabilityAnalyzerTopology {
         final var expectedScannerResultsSerde = new KafkaProtobufSerde<>(ExpectedScannerResults.parser());
         final var scanCommandSerde = new KafkaProtobufSerde<>(ScanCommand.parser());
         final var scanKeySerde = new KafkaProtobufSerde<>(ScanKey.parser());
-        final var scannerResultAggregateSerde = new KafkaProtobufSerde<>(ScannerResultAggregate.parser());
         final var scannerResultSerde = new KafkaProtobufSerde<>(ScannerResult.parser());
         final var scanResultSerde = new KafkaProtobufSerde<>(ScanResult.parser());
         final var scanTaskSerde = new KafkaProtobufSerde<>(ScanTask.parser());
@@ -197,41 +196,12 @@ public class VulnerabilityAnalyzerTopology {
                         .with(scanKeySerde, scannerResultSerde, expectedScannerResultsSerde)
                         .withName("join_results_with_expected_scanner_results"));
 
-        // Aggregate scanner results per scan key and materialize this data in a table.
-        final KTable<ScanKey, ScannerResultAggregate> completedScansTable = completedScansStream
-                // Emit tombstone events for ScanKeys for which no events have been received
-                // for >= 1h (stream time). Check every 5min (also stream time) for eligible keys.
-                // This keeps the KTable from growing indefinitely.
-                .processValues(new TombstoneEmittingProcessorSupplier<>(
-                        "completed-scans-table-last-update-store",
-                        scanKeySerde, Duration.ofMinutes(5), Duration.ofHours(1),
-                        scanKey -> ScannerResultAggregate.newBuilder().setTombstone(true).build()
-                ), Named.as("emit_completed_scans_table_tombstones"))
-                .groupByKey(Grouped
-                        .with(scanKeySerde, scannerResultAggregateSerde)
-                        .withName("completed-scans-by-scan-key"))
-                .aggregate(
-                        ScannerResultAggregate.newBuilder()::build,
-                        this::aggregateCompletedScans,
-                        Named.as("aggregate_completed_scans"),
-                        Materialized
-                                .<ScanKey, ScannerResultAggregate, KeyValueStore<Bytes, byte[]>>as("completed-scans-table")
-                                .withKeySerde(scanKeySerde)
-                                .withValueSerde(scannerResultAggregateSerde)
-                                .withStoreType(Materialized.StoreType.IN_MEMORY)
-                                .withCachingDisabled()); // Ensure all changes will be forwarded
-
         // Once all expected scans for a given scan key are completed (not PENDING),
         // emit the final result for that scan key to the result stream.
-        completedScansTable
-                .toStream(Named.as("stream_completed_scans"))
-                // We receive an event for every change of the aggregate here,
-                // so suppress events that do not represent a completed scan.
-                .filter((scanKey, completedScans) -> completedScans != null
-                                && completedScans.getResultsMap().values().stream()
-                                .map(ScannerResult::getStatus)
-                                .noneMatch(SCAN_STATUS_PENDING::equals),
-                        Named.as("filter_completed_scans"))
+        completedScansStream
+                .processValues(new ScannerResultAggregatorSupplier("completed-scans-table",
+                                Duration.ofMinutes(5), Duration.ofHours(1)),
+                        Named.as("aggregate_completed_scans"))
                 .mapValues((scanKey, scannerResultAggregate) -> ScanResult.newBuilder()
                                 .setKey(scanKey)
                                 .addAllScannerResults(scannerResultAggregate.getResultsMap().values())
@@ -306,27 +276,6 @@ public class VulnerabilityAnalyzerTopology {
 
         return ExpectedScannerResults.newBuilder(aggregate)
                 .addScanners(scanTask.getScanner())
-                .build();
-    }
-
-    private <K> ScannerResultAggregate aggregateCompletedScans(final K key, final ScannerResultAggregate scans,
-                                                               final ScannerResultAggregate aggregate) {
-        if (scans.hasTombstone() && scans.getTombstone()) {
-            return null;
-        }
-
-        final Map<String, ScannerResult> results;
-        if (aggregate.getResultsCount() > 0) {
-            results = new HashMap<>(aggregate.getResultsMap());
-            scans.getResultsMap().entrySet().stream()
-                    .filter(entry -> entry.getValue().getStatus() != SCAN_STATUS_PENDING)
-                    .forEach(entry -> results.put(entry.getKey(), entry.getValue()));
-        } else {
-            results = scans.getResultsMap();
-        }
-
-        return ScannerResultAggregate.newBuilder()
-                .putAllResults(results)
                 .build();
     }
 

--- a/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Repartitioned;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.hyades.common.KafkaTopic;
+import org.hyades.config.StateStoreConfig;
 import org.hyades.processor.misc.ScannerResultAggregatorSupplier;
 import org.hyades.processor.misc.TombstoneEmittingProcessorSupplier;
 import org.hyades.processor.scanner.ScanProcessorSupplier;
@@ -57,10 +58,13 @@ public class VulnerabilityAnalyzerTopology {
     private static final Logger LOGGER = LoggerFactory.getLogger(VulnerabilityAnalyzerTopology.class);
 
     private final Instance<ScanProcessorSupplier> scanProcessorSuppliers;
+    private final StateStoreConfig stateStoreConfig;
 
     @Inject
-    public VulnerabilityAnalyzerTopology(final Instance<ScanProcessorSupplier> scanProcessorSuppliers) {
+    public VulnerabilityAnalyzerTopology(final Instance<ScanProcessorSupplier> scanProcessorSuppliers,
+                                         final StateStoreConfig stateStoreConfig) {
         this.scanProcessorSuppliers = scanProcessorSuppliers;
+        this.stateStoreConfig = stateStoreConfig;
     }
 
     @Produces
@@ -178,7 +182,7 @@ public class VulnerabilityAnalyzerTopology {
                                 .<ScanKey, ExpectedScannerResults, KeyValueStore<Bytes, byte[]>>as("expected-scanner-results-table")
                                 .withKeySerde(scanKeySerde)
                                 .withValueSerde(expectedScannerResultsSerde)
-                                .withStoreType(Materialized.StoreType.IN_MEMORY));
+                                .withStoreType(stateStoreConfig.type()));
 
         // Join the results we receive from scanners with the table of expected scanner results.
         final KStream<ScanKey, ScannerResultAggregate> completedScansStream = scannerResultStream

--- a/vulnerability-analyzer/src/main/java/org/hyades/config/RocksDbConfigSetter.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/config/RocksDbConfigSetter.java
@@ -3,10 +3,18 @@ package org.hyades.config;
 import io.smallrye.config.SmallRyeConfig;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.hyades.config.StateStoreConfig.RocksDbConfig;
 import org.rocksdb.Options;
 
 import java.util.Map;
 
+/**
+ * An implementation of {@link RocksDBConfigSetter} for customizing RocksDB.
+ * <p>
+ * Customizations are configurable via Quarkus Config. Available configuration options are defined in {@link RocksDbConfig}.
+ *
+ * @see <a href="https://kafka.apache.org/34/documentation/streams/developer-guide/config-streams#rocksdb-config-setter">Kafka Streams Documentation</a>
+ */
 public class RocksDbConfigSetter implements RocksDBConfigSetter {
 
     @Override

--- a/vulnerability-analyzer/src/main/java/org/hyades/config/RocksDbConfigSetter.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/config/RocksDbConfigSetter.java
@@ -1,0 +1,25 @@
+package org.hyades.config;
+
+import io.smallrye.config.SmallRyeConfig;
+import org.apache.kafka.streams.state.RocksDBConfigSetter;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.rocksdb.Options;
+
+import java.util.Map;
+
+public class RocksDbConfigSetter implements RocksDBConfigSetter {
+
+    @Override
+    public void setConfig(final String storeName, final Options options, final Map<String, Object> configs) {
+        final SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        final StateStoreConfig stateStoreConfig = config.getConfigMapping(StateStoreConfig.class);
+
+        stateStoreConfig.rocksDb().compactionStyle().ifPresent(options::setCompactionStyle);
+        stateStoreConfig.rocksDb().compressionType().ifPresent(options::setCompressionType);
+    }
+
+    @Override
+    public void close(final String storeName, final Options options) {
+    }
+
+}

--- a/vulnerability-analyzer/src/main/java/org/hyades/config/StateStoreConfig.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/config/StateStoreConfig.java
@@ -1,0 +1,27 @@
+package org.hyades.config;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import org.apache.kafka.streams.kstream.Materialized.StoreType;
+import org.rocksdb.CompactionStyle;
+import org.rocksdb.CompressionType;
+
+import java.util.Optional;
+
+@ConfigMapping(prefix = "state-store")
+public interface StateStoreConfig {
+
+    @WithDefault("in_memory")
+    StoreType type();
+
+    RocksDbConfig rocksDb();
+
+    interface RocksDbConfig {
+
+        Optional<CompactionStyle> compactionStyle();
+
+        Optional<CompressionType> compressionType();
+
+    }
+
+}

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregator.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregator.java
@@ -64,28 +64,14 @@ public class ScannerResultAggregator extends ContextualFixedKeyProcessor<ScanKey
 
     @Override
     public void process(final FixedKeyRecord<ScanKey, ScannerResultAggregate> record) {
-        ScannerResultAggregate aggregate = Optional.ofNullable(store.get(record.key()))
-                .orElseGet(ScannerResultAggregate.newBuilder()::build);
+        final ScannerResultAggregate aggregate = doAggregate(store.get(record.key()), record.value());
 
-        final Map<String, ScannerResult> results;
-        if (aggregate.getResultsCount() > 0) {
-            results = new HashMap<>(aggregate.getResultsMap());
-            record.value().getResultsMap().entrySet().stream()
-                    .filter(entry -> entry.getValue().getStatus() != SCAN_STATUS_PENDING)
-                    .forEach(entry -> results.put(entry.getKey(), entry.getValue()));
-        } else {
-            results = record.value().getResultsMap();
-        }
-
-        aggregate = ScannerResultAggregate.newBuilder()
-                .setLastUpdated(currentStreamTimestamp())
-                .putAllResults(results)
-                .build();
         if (isComplete(aggregate)) {
             LOGGER.debug("Forwarding completed aggregate for {}", record.key());
             store.delete(record.key());
             context().forward(record.withValue(aggregate));
         } else {
+            LOGGER.debug("Updating aggregate for {}", record.key());
             store.put(record.key(), aggregate);
         }
     }
@@ -109,6 +95,31 @@ public class ScannerResultAggregator extends ContextualFixedKeyProcessor<ScanKey
                 }
             }
         }
+    }
+
+    private ScannerResultAggregate doAggregate(final ScannerResultAggregate existingAggregate,
+                                               final ScannerResultAggregate incomingAggregate) {
+        final ScannerResultAggregate.Builder resultAggregateBuilder;
+        if (existingAggregate != null) {
+            resultAggregateBuilder = ScannerResultAggregate.newBuilder(existingAggregate);
+        } else {
+            resultAggregateBuilder = ScannerResultAggregate.newBuilder();
+        }
+
+        final Map<String, ScannerResult> scannerResults;
+        if (resultAggregateBuilder.getResultsCount() > 0) {
+            scannerResults = new HashMap<>(resultAggregateBuilder.getResultsMap());
+            incomingAggregate.getResultsMap().entrySet().stream()
+                    .filter(entry -> entry.getValue().getStatus() != SCAN_STATUS_PENDING)
+                    .forEach(entry -> scannerResults.put(entry.getKey(), entry.getValue()));
+        } else {
+            scannerResults = incomingAggregate.getResultsMap();
+        }
+
+        return resultAggregateBuilder
+                .setLastUpdated(currentStreamTimestamp())
+                .putAllResults(scannerResults)
+                .build();
     }
 
     private Timestamp currentStreamTimestamp() {

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregator.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregator.java
@@ -1,0 +1,126 @@
+package org.hyades.processor.misc;
+
+import com.google.protobuf.Timestamp;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.Cancellable;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.ContextualFixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.hyades.proto.vulnanalysis.internal.v1beta1.ScannerResultAggregate;
+import org.hyades.proto.vulnanalysis.v1.ScanKey;
+import org.hyades.proto.vulnanalysis.v1.ScannerResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_PENDING;
+
+/**
+ * A {@link ContextualFixedKeyProcessor} that aggregates {@link ScannerResultAggregate}s
+ * and automatically removes them from the underlying state store.
+ * <p>
+ * Removal is triggered by any of the following situations:
+ * <ol>
+ *     <li>The aggregate is considered to be complete</li>
+ *     <li>The aggregate has not been updated for a certain amount of (stream) time</li>
+ * </ol>
+ * <p>
+ * In the former case, the complete aggregate is forwarded to the next processor in the topology.
+ * <p>
+ * Removal and expiration mechanisms are necessary as aggregates are based on unbounded
+ * sets of keys, thus have the potential to grow indefinitely.
+ */
+public class ScannerResultAggregator extends ContextualFixedKeyProcessor<ScanKey, ScannerResultAggregate, ScannerResultAggregate> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScannerResultAggregator.class);
+
+    private final String storeName;
+    private final Duration checkInterval;
+    private final Duration maxLifetime;
+    private KeyValueStore<ScanKey, ScannerResultAggregate> store;
+    private Cancellable punctuator;
+
+    ScannerResultAggregator(final String storeName, final Duration checkInterval, final Duration maxLifetime) {
+        this.storeName = storeName;
+        this.checkInterval = checkInterval;
+        this.maxLifetime = maxLifetime;
+    }
+
+    @Override
+    public void init(final FixedKeyProcessorContext<ScanKey, ScannerResultAggregate> context) {
+        super.init(context);
+
+        store = context().getStateStore(storeName);
+        punctuator = context().schedule(checkInterval, PunctuationType.STREAM_TIME, this::punctuate);
+    }
+
+    @Override
+    public void process(final FixedKeyRecord<ScanKey, ScannerResultAggregate> record) {
+        ScannerResultAggregate aggregate = Optional.ofNullable(store.get(record.key()))
+                .orElseGet(ScannerResultAggregate.newBuilder()::build);
+
+        final Map<String, ScannerResult> results;
+        if (aggregate.getResultsCount() > 0) {
+            results = new HashMap<>(aggregate.getResultsMap());
+            record.value().getResultsMap().entrySet().stream()
+                    .filter(entry -> entry.getValue().getStatus() != SCAN_STATUS_PENDING)
+                    .forEach(entry -> results.put(entry.getKey(), entry.getValue()));
+        } else {
+            results = record.value().getResultsMap();
+        }
+
+        aggregate = ScannerResultAggregate.newBuilder()
+                .setLastUpdated(currentStreamTimestamp())
+                .putAllResults(results)
+                .build();
+        if (isComplete(aggregate)) {
+            LOGGER.debug("Forwarding completed aggregate for {}", record.key());
+            store.delete(record.key());
+            context().forward(record.withValue(aggregate));
+        } else {
+            store.put(record.key(), aggregate);
+        }
+    }
+
+    @Override
+    public void close() {
+        Optional.ofNullable(punctuator).ifPresent(Cancellable::cancel);
+    }
+
+    private void punctuate(final long timestamp) {
+        final Instant cutoffTimestamp = Instant.ofEpochMilli(timestamp).minus(maxLifetime);
+
+        try (final KeyValueIterator<ScanKey, ScannerResultAggregate> all = store.all()) {
+            while (all.hasNext()) {
+                final KeyValue<ScanKey, ScannerResultAggregate> record = all.next();
+                final Instant lastUpdated = Instant.ofEpochSecond(record.value.getLastUpdated().getSeconds());
+
+                if (isComplete(record.value) || lastUpdated.isBefore(cutoffTimestamp)) {
+                    LOGGER.debug("Deleting expired aggregate for {}", record.key);
+                    store.delete(record.key);
+                }
+            }
+        }
+    }
+
+    private Timestamp currentStreamTimestamp() {
+        return Timestamp.newBuilder()
+                .setSeconds(context().currentStreamTimeMs() / 1000)
+                .build();
+    }
+
+    private static boolean isComplete(final ScannerResultAggregate aggregate) {
+        return aggregate.getResultsMap().values().stream()
+                .map(ScannerResult::getStatus)
+                .noneMatch(SCAN_STATUS_PENDING::equals);
+    }
+
+}

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregatorSupplier.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregatorSupplier.java
@@ -1,5 +1,6 @@
 package org.hyades.processor.misc;
 
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -11,8 +12,9 @@ import org.hyades.proto.vulnanalysis.v1.ScanKey;
 import java.time.Duration;
 import java.util.Set;
 
-import static org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore;
 import static org.apache.kafka.streams.state.Stores.keyValueStoreBuilder;
+import static org.hyades.util.StateStoreUtil.configurableKeyValueStore;
+import static org.hyades.util.StateStoreUtil.defaultChangelogTopicConfig;
 
 public class ScannerResultAggregatorSupplier implements FixedKeyProcessorSupplier<ScanKey, ScannerResultAggregate, ScannerResultAggregate> {
 
@@ -21,9 +23,10 @@ public class ScannerResultAggregatorSupplier implements FixedKeyProcessorSupplie
     private final Duration maxLifetime;
 
     public ScannerResultAggregatorSupplier(final String storeName, final Duration checkInterval, final Duration maxLifetime) {
-        this.storeBuilder = keyValueStoreBuilder(inMemoryKeyValueStore(storeName),
-                new KafkaProtobufSerde<>(ScanKey.parser()),
-                new KafkaProtobufSerde<>(ScannerResultAggregate.parser()));
+        final Serde<ScanKey> keySerde = new KafkaProtobufSerde<>(ScanKey.parser());
+        final Serde<ScannerResultAggregate> valueSerde = new KafkaProtobufSerde<>(ScannerResultAggregate.parser());
+        this.storeBuilder = keyValueStoreBuilder(configurableKeyValueStore(storeName), keySerde, valueSerde)
+                .withLoggingEnabled(defaultChangelogTopicConfig());
         this.checkInterval = checkInterval;
         this.maxLifetime = maxLifetime;
     }

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregatorSupplier.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregatorSupplier.java
@@ -1,0 +1,41 @@
+package org.hyades.processor.misc;
+
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.hyades.proto.KafkaProtobufSerde;
+import org.hyades.proto.vulnanalysis.internal.v1beta1.ScannerResultAggregate;
+import org.hyades.proto.vulnanalysis.v1.ScanKey;
+
+import java.time.Duration;
+import java.util.Set;
+
+import static org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore;
+import static org.apache.kafka.streams.state.Stores.keyValueStoreBuilder;
+
+public class ScannerResultAggregatorSupplier implements FixedKeyProcessorSupplier<ScanKey, ScannerResultAggregate, ScannerResultAggregate> {
+
+    private final StoreBuilder<KeyValueStore<ScanKey, ScannerResultAggregate>> storeBuilder;
+    private final Duration checkInterval;
+    private final Duration maxLifetime;
+
+    public ScannerResultAggregatorSupplier(final String storeName, final Duration checkInterval, final Duration maxLifetime) {
+        this.storeBuilder = keyValueStoreBuilder(inMemoryKeyValueStore(storeName),
+                new KafkaProtobufSerde<>(ScanKey.parser()),
+                new KafkaProtobufSerde<>(ScannerResultAggregate.parser()));
+        this.checkInterval = checkInterval;
+        this.maxLifetime = maxLifetime;
+    }
+
+    @Override
+    public FixedKeyProcessor<ScanKey, ScannerResultAggregate, ScannerResultAggregate> get() {
+        return new ScannerResultAggregator(storeBuilder.name(), checkInterval, maxLifetime);
+    }
+
+    @Override
+    public Set<StoreBuilder<?>> stores() {
+        return Set.of(storeBuilder);
+    }
+
+}

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/TombstoneEmittingProcessorSupplier.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/TombstoneEmittingProcessorSupplier.java
@@ -11,8 +11,9 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.function.Function;
 
-import static org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore;
 import static org.apache.kafka.streams.state.Stores.keyValueStoreBuilder;
+import static org.hyades.util.StateStoreUtil.configurableKeyValueStore;
+import static org.hyades.util.StateStoreUtil.defaultChangelogTopicConfig;
 
 public class TombstoneEmittingProcessorSupplier<K, V> implements FixedKeyProcessorSupplier<K, V, V> {
 
@@ -24,7 +25,8 @@ public class TombstoneEmittingProcessorSupplier<K, V> implements FixedKeyProcess
     public TombstoneEmittingProcessorSupplier(final String storeName, final Serde<K> keySerde,
                                               final Duration checkInterval, final Duration maxLifetime,
                                               final Function<K, V> tombstoneSupplier) {
-        this.storeBuilder = keyValueStoreBuilder(inMemoryKeyValueStore(storeName), keySerde, Serdes.Long());
+        this.storeBuilder = keyValueStoreBuilder(configurableKeyValueStore(storeName), keySerde, Serdes.Long())
+                .withLoggingEnabled(defaultChangelogTopicConfig());
         this.checkInterval = checkInterval;
         this.maxLifetime = maxLifetime;
         this.tombstoneSupplier = tombstoneSupplier;

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/ossindex/OssIndexProcessorConfiguration.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/ossindex/OssIndexProcessorConfiguration.java
@@ -9,7 +9,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
-import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.hyades.config.CircuitBreakerConfig;
@@ -24,8 +24,10 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 
-import static org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore;
+import static org.apache.kafka.common.serialization.Serdes.serdeFrom;
 import static org.apache.kafka.streams.state.Stores.keyValueStoreBuilder;
+import static org.hyades.util.StateStoreUtil.configurableKeyValueStore;
+import static org.hyades.util.StateStoreUtil.defaultChangelogTopicConfig;
 
 class OssIndexProcessorConfiguration {
 
@@ -33,22 +35,28 @@ class OssIndexProcessorConfiguration {
     @ApplicationScoped
     @Named("ossIndexBatchStoreBuilder")
     StoreBuilder<KeyValueStore<ScanKey, RetryableRecord<String, ScanTask>>> batchStoreBuilder() {
-        return keyValueStoreBuilder(inMemoryKeyValueStore("ossindex-batch-store"),
-                new ObjectMapperSerde<>(ScanKey.class),
-                Serdes.serdeFrom(new ObjectMapperSerializer<>(),
-                        new ObjectMapperDeserializer<>(new TypeReference<>() {
-                        })));
+        final Serde<ScanKey> keySerde = new ObjectMapperSerde<>(ScanKey.class);
+        final Serde<RetryableRecord<String, ScanTask>> valueSerde = serdeFrom(
+                new ObjectMapperSerializer<>(),
+                new ObjectMapperDeserializer<>(new TypeReference<>() {
+                }));
+
+        return keyValueStoreBuilder(configurableKeyValueStore("ossindex-batch-store"), keySerde, valueSerde)
+                .withLoggingEnabled(defaultChangelogTopicConfig());
     }
 
     @Produces
     @ApplicationScoped
     @Named("ossIndexRetryStoreBuilder")
     StoreBuilder<KeyValueStore<ScanKey, RetryableRecord<String, ScanTask>>> retryStoreBuilder() {
-        return keyValueStoreBuilder(inMemoryKeyValueStore("ossindex-retry-store"),
-                new ObjectMapperSerde<>(ScanKey.class),
-                Serdes.serdeFrom(new ObjectMapperSerializer<>(),
-                        new ObjectMapperDeserializer<>(new TypeReference<>() {
-                        })));
+        final Serde<ScanKey> keySerde = new ObjectMapperSerde<>(ScanKey.class);
+        final Serde<RetryableRecord<String, ScanTask>> valueSerde = serdeFrom(
+                new ObjectMapperSerializer<>(),
+                new ObjectMapperDeserializer<>(new TypeReference<>() {
+                }));
+
+        return keyValueStoreBuilder(configurableKeyValueStore("ossindex-retry-store"), keySerde, valueSerde)
+                .withLoggingEnabled(defaultChangelogTopicConfig());
     }
 
     @Produces

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/snyk/SnykProcessorConfiguration.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/snyk/SnykProcessorConfiguration.java
@@ -9,7 +9,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
-import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.hyades.config.CircuitBreakerConfig;
@@ -24,8 +24,10 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 
-import static org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore;
+import static org.apache.kafka.common.serialization.Serdes.serdeFrom;
 import static org.apache.kafka.streams.state.Stores.keyValueStoreBuilder;
+import static org.hyades.util.StateStoreUtil.configurableKeyValueStore;
+import static org.hyades.util.StateStoreUtil.defaultChangelogTopicConfig;
 
 class SnykProcessorConfiguration {
 
@@ -33,22 +35,28 @@ class SnykProcessorConfiguration {
     @ApplicationScoped
     @Named("snykBatchStoreBuilder")
     StoreBuilder<KeyValueStore<ScanKey, RetryableRecord<String, ScanTask>>> batchStoreBuilder() {
-        return keyValueStoreBuilder(inMemoryKeyValueStore("snyk-batch-store"),
-                new ObjectMapperSerde<>(ScanKey.class),
-                Serdes.serdeFrom(new ObjectMapperSerializer<>(),
-                        new ObjectMapperDeserializer<>(new TypeReference<>() {
-                        })));
+        final Serde<ScanKey> keySerde = new ObjectMapperSerde<>(ScanKey.class);
+        final Serde<RetryableRecord<String, ScanTask>> valueSerde = serdeFrom(
+                new ObjectMapperSerializer<>(),
+                new ObjectMapperDeserializer<>(new TypeReference<>() {
+                }));
+
+        return keyValueStoreBuilder(configurableKeyValueStore("snyk-batch-store"), keySerde, valueSerde)
+                .withLoggingEnabled(defaultChangelogTopicConfig());
     }
 
     @Produces
     @ApplicationScoped
     @Named("snykRetryStoreBuilder")
     StoreBuilder<KeyValueStore<ScanKey, RetryableRecord<String, ScanTask>>> retryStoreBuilder() {
-        return keyValueStoreBuilder(inMemoryKeyValueStore("snyk-retry-store"),
-                new ObjectMapperSerde<>(ScanKey.class),
-                Serdes.serdeFrom(new ObjectMapperSerializer<>(),
-                        new ObjectMapperDeserializer<>(new TypeReference<>() {
-                        })));
+        final Serde<ScanKey> keySerde = new ObjectMapperSerde<>(ScanKey.class);
+        final Serde<RetryableRecord<String, ScanTask>> valueSerde = serdeFrom(
+                new ObjectMapperSerializer<>(),
+                new ObjectMapperDeserializer<>(new TypeReference<>() {
+                }));
+
+        return keyValueStoreBuilder(configurableKeyValueStore("snyk-retry-store"), keySerde, valueSerde)
+                .withLoggingEnabled(defaultChangelogTopicConfig());
     }
 
     @Produces

--- a/vulnerability-analyzer/src/main/java/org/hyades/util/StateStoreUtil.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/util/StateStoreUtil.java
@@ -29,12 +29,11 @@ public final class StateStoreUtil {
      * @return A {@link KeyValueBytesStoreSupplier}
      */
     public static KeyValueBytesStoreSupplier configurableKeyValueStore(final String name) {
-        final SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
-
         final StateStoreConfig stateStoreConfig;
         try {
+            final SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
             stateStoreConfig = config.getConfigMapping(StateStoreConfig.class);
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException | UnsupportedOperationException e) {
             // When running tests without @QuarkusTest, resolving of the ConfigMapping will not work.
             LOGGER.debug("State store config could not be resolved; Falling back to in-memory store", e);
             return Stores.inMemoryKeyValueStore(name);

--- a/vulnerability-analyzer/src/main/java/org/hyades/util/StateStoreUtil.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/util/StateStoreUtil.java
@@ -1,0 +1,49 @@
+package org.hyades.util;
+
+import io.smallrye.config.SmallRyeConfig;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.streams.kstream.Materialized.StoreType;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.Stores;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.hyades.config.StateStoreConfig;
+
+import java.util.Map;
+
+public final class StateStoreUtil {
+
+    private StateStoreUtil() {
+    }
+
+    /**
+     * Provide a {@link KeyValueBytesStoreSupplier} implementation, depending on whether
+     * {@link StateStoreConfig#type()} is configured to be {@link StoreType#IN_MEMORY}
+     * or {@link StoreType#ROCKS_DB}.
+     *
+     * @param name The name of the store
+     * @return A {@link KeyValueBytesStoreSupplier}
+     */
+    public static KeyValueBytesStoreSupplier configurableKeyValueStore(final String name) {
+        final SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        final StateStoreConfig stateStoreConfig = config.getConfigMapping(StateStoreConfig.class);
+
+        return switch (stateStoreConfig.type()) {
+            case IN_MEMORY -> Stores.inMemoryKeyValueStore(name);
+            case ROCKS_DB -> Stores.persistentKeyValueStore(name);
+        };
+    }
+
+    /**
+     * Provide a default configuration to be used for changelog topics.
+     *
+     * @return The default topic configuration
+     */
+    public static Map<String, String> defaultChangelogTopicConfig() {
+        return Map.of(
+                TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
+                TopicConfig.SEGMENT_BYTES_CONFIG, String.valueOf(64 * 1024 * 1024), // 64 MiB
+                TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, "0" // Perform compaction ASAP
+        );
+    }
+
+}

--- a/vulnerability-analyzer/src/main/java/org/hyades/util/StateStoreUtil.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/util/StateStoreUtil.java
@@ -7,10 +7,15 @@ import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.Stores;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.hyades.config.StateStoreConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 public final class StateStoreUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StateStoreUtil.class);
 
     private StateStoreUtil() {
     }
@@ -25,7 +30,15 @@ public final class StateStoreUtil {
      */
     public static KeyValueBytesStoreSupplier configurableKeyValueStore(final String name) {
         final SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
-        final StateStoreConfig stateStoreConfig = config.getConfigMapping(StateStoreConfig.class);
+
+        final StateStoreConfig stateStoreConfig;
+        try {
+            stateStoreConfig = config.getConfigMapping(StateStoreConfig.class);
+        } catch (NoSuchElementException e) {
+            // When running tests without @QuarkusTest, resolving of the ConfigMapping will not work.
+            LOGGER.debug("State store config could not be resolved; Falling back to in-memory store", e);
+            return Stores.inMemoryKeyValueStore(name);
+        }
 
         return switch (stateStoreConfig.type()) {
             case IN_MEMORY -> Stores.inMemoryKeyValueStore(name);

--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -33,8 +33,8 @@ kafka-streams.compression.type=snappy
 ## Kafka Streams State Stores
 #
 state-store.type=in_memory
-# state-store.rocks-db.compaction-style=level
-# state-store.rocks-db.compression-type=zstd_compression
+# state-store.rocks-db.compaction-style=
+# state-store.rocks-db.compression-type=
 
 ## Dev Services for Kafka
 #
@@ -68,6 +68,7 @@ scanner.ossindex.retry.initial-delay=5S
 scanner.ossindex.retry.multiplier=2
 scanner.ossindex.retry.max-attempts=6
 scanner.ossindex.retry.max-duration=2M
+scanner.ossindex.alias-sync-enabled=false
 quarkus.rest-client."org.hyades.client.ossindex.OssIndexClient".url=${scanner.ossindex.api.baseurl}
 quarkus.rest-client."org.hyades.client.ossindex.OssIndexClient".connect-timeout=3000
 quarkus.rest-client."org.hyades.client.ossindex.OssIndexClient".read-timeout=3000
@@ -96,7 +97,6 @@ scanner.snyk.retry.randomization-factor=0.3
 scanner.snyk.retry.max-attempts=6
 scanner.snyk.retry.max-duration=2M
 scanner.snyk.alias-sync-enabled=false
-scanner.oss.alias-sync-enabled=false
 quarkus.rest-client."org.hyades.client.snyk.SnykClient".url=${scanner.snyk.api.baseurl}
 quarkus.rest-client."org.hyades.client.snyk.SnykClient".connect-timeout=3000
 quarkus.rest-client."org.hyades.client.snyk.SnykClient".read-timeout=3000

--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -19,6 +19,7 @@ quarkus.log.category."org.apache.kafka".level=WARN
 quarkus.kafka.snappy.enabled=true
 kafka.retry-attempts=2
 kafka-streams.topology.optimization=all
+kafka-streams.rocksdb.config.setter=org.hyades.config.RocksDbConfigSetter
 kafka-streams.default.deserialization.exception.handler=org.apache.kafka.streams.errors.LogAndContinueExceptionHandler
 kafka-streams.cache.max.bytes.buffering=10240
 kafka-streams.commit.interval.ms=1000
@@ -28,6 +29,12 @@ kafka-streams.metrics.recording.level=DEBUG
 kafka-streams.num.stream.threads=3
 kafka-streams.max.task.idle.ms=1000
 kafka-streams.compression.type=snappy
+
+## Kafka Streams State Stores
+#
+state-store.type=in_memory
+# state-store.rocks-db.compaction-style=level
+# state-store.rocks-db.compression-type=zstd_compression
 
 ## Dev Services for Kafka
 #

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/misc/ScannerResultAggregatorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/misc/ScannerResultAggregatorTest.java
@@ -1,0 +1,200 @@
+package org.hyades.processor.misc;
+
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.hyades.proto.KafkaProtobufSerde;
+import org.hyades.proto.vulnanalysis.internal.v1beta1.ScannerResultAggregate;
+import org.hyades.proto.vulnanalysis.v1.ScanKey;
+import org.hyades.proto.vulnanalysis.v1.ScannerResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_FAILED;
+import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_PENDING;
+import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_SUCCESSFUL;
+import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL;
+import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_OSSINDEX;
+import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_SNYK;
+
+class ScannerResultAggregatorTest {
+
+    private TopologyTestDriver testDriver;
+    private TestInputTopic<ScanKey, ScannerResultAggregate> inputTopic;
+    private TestOutputTopic<ScanKey, ScannerResultAggregate> outputTopic;
+    private KeyValueStore<ScanKey, ScannerResultAggregate> stateStore;
+
+    @BeforeEach
+    void beforeEach() {
+        final var processorSupplier = new ScannerResultAggregatorSupplier("aggregator-store", Duration.ofSeconds(5), Duration.ofSeconds(30));
+
+        final var keySerde = new KafkaProtobufSerde<>(ScanKey.parser());
+        final var valueSerde = new KafkaProtobufSerde<>(ScannerResultAggregate.parser());
+
+        final var streamsBuilder = new StreamsBuilder();
+        streamsBuilder
+                .stream("input-topic", Consumed.with(keySerde, valueSerde))
+                .processValues(processorSupplier)
+                .to("output-topic", Produced.with(keySerde, valueSerde));
+
+        testDriver = new TopologyTestDriver(streamsBuilder.build());
+        inputTopic = testDriver.createInputTopic("input-topic", keySerde.serializer(), valueSerde.serializer());
+        outputTopic = testDriver.createOutputTopic("output-topic", keySerde.deserializer(), valueSerde.deserializer());
+        stateStore = testDriver.getKeyValueStore("aggregator-store");
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (testDriver != null) {
+            testDriver.close();
+        }
+    }
+
+    @Test
+    void testWithSingleResult() {
+        final var scanKey = ScanKey.newBuilder()
+                .setComponentUuid(UUID.randomUUID().toString())
+                .setScanToken(UUID.randomUUID().toString())
+                .build();
+
+        final var aggregate = ScannerResultAggregate.newBuilder()
+                .putResults(SCANNER_OSSINDEX.name(), ScannerResult.newBuilder()
+                        .setScanner(SCANNER_OSSINDEX)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .build())
+                .build();
+
+        inputTopic.pipeInput(scanKey, aggregate);
+
+        // The aggregate is complete (contains no results with status PENDING),
+        // and must be forwarded.
+        assertThat(outputTopic.readRecordsToList()).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isEqualTo(scanKey);
+                    assertThat(record.value().getResultsCount()).isEqualTo(1);
+                    assertThat(record.value().getResultsOrThrow(SCANNER_OSSINDEX.name()).getStatus()).isEqualTo(SCAN_STATUS_SUCCESSFUL);
+                    assertThat(record.value().getLastUpdated().getSeconds()).isNotZero();
+                }
+        );
+
+        // The aggregate is complete (contains no results with status PENDING),
+        // thus there's no need to hold on to it.
+        assertThat(stateStore.get(scanKey)).isNull();
+    }
+
+    @Test
+    void testWithMultipleResults() {
+        final var scanKey = ScanKey.newBuilder()
+                .setComponentUuid(UUID.randomUUID().toString())
+                .setScanToken(UUID.randomUUID().toString())
+                .build();
+
+        inputTopic.pipeInput(scanKey, ScannerResultAggregate.newBuilder()
+                .putResults(SCANNER_OSSINDEX.name(), ScannerResult.newBuilder()
+                        .setScanner(SCANNER_OSSINDEX)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .build())
+                .putResults(SCANNER_SNYK.name(), ScannerResult.newBuilder()
+                        .setScanner(SCANNER_SNYK)
+                        .setStatus(SCAN_STATUS_PENDING)
+                        .build())
+                .build());
+
+        // The aggregate is incomplete (contains results with status PENDING),
+        // thus no record must be forwarded, and a record in the state store must exist.
+        assertThat(outputTopic.readRecordsToList()).isEmpty();
+        assertThat(stateStore.get(scanKey)).isNotNull();
+
+        inputTopic.pipeInput(scanKey, ScannerResultAggregate.newBuilder()
+                .putResults(SCANNER_OSSINDEX.name(), ScannerResult.newBuilder()
+                        .setScanner(SCANNER_OSSINDEX)
+                        .setStatus(SCAN_STATUS_PENDING)
+                        .build())
+                .putResults(SCANNER_SNYK.name(), ScannerResult.newBuilder()
+                        .setScanner(SCANNER_SNYK)
+                        .setStatus(SCAN_STATUS_FAILED)
+                        .build())
+                .build());
+
+        // The aggregate is complete now (contains no results with status PENDING),
+        // and must be forwarded.
+        assertThat(outputTopic.readRecordsToList()).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isEqualTo(scanKey);
+                    assertThat(record.value().getResultsCount()).isEqualTo(2);
+                    assertThat(record.value().getResultsOrThrow(SCANNER_OSSINDEX.name()).getStatus()).isEqualTo(SCAN_STATUS_SUCCESSFUL);
+                    assertThat(record.value().getResultsOrThrow(SCANNER_SNYK.name()).getStatus()).isEqualTo(SCAN_STATUS_FAILED);
+                    assertThat(record.value().getLastUpdated().getSeconds()).isNotZero();
+                }
+        );
+
+        // The aggregate is complete (contains no results with status PENDING),
+        // thus there's no need to hold on to it anymore.
+        assertThat(stateStore.get(scanKey)).isNull();
+    }
+
+    @Test
+    void testExpiration() {
+        final var scanKey = ScanKey.newBuilder()
+                .setComponentUuid(UUID.randomUUID().toString())
+                .setScanToken(UUID.randomUUID().toString())
+                .build();
+
+        inputTopic.pipeInput(scanKey, ScannerResultAggregate.newBuilder()
+                .putResults(SCANNER_OSSINDEX.name(), ScannerResult.newBuilder()
+                        .setScanner(SCANNER_OSSINDEX)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .build())
+                .putResults(SCANNER_SNYK.name(), ScannerResult.newBuilder()
+                        .setScanner(SCANNER_SNYK)
+                        .setStatus(SCAN_STATUS_PENDING)
+                        .build())
+                .build());
+
+        // The aggregate is incomplete (contains results with status PENDING),
+        // thus no record must be forwarded, and a record in the state store must exist.
+        assertThat(outputTopic.readRecordsToList()).isEmpty();
+        assertThat(stateStore.get(scanKey)).isNotNull();
+
+        // Publish a complete aggregate for a different scanKey, and for a different scanner,
+        // but 45 seconds (stream time) AFTER the previous one.
+        inputTopic.pipeInput(
+                ScanKey.newBuilder()
+                        .setComponentUuid(UUID.randomUUID().toString())
+                        .setScanToken(UUID.randomUUID().toString())
+                        .build(),
+                ScannerResultAggregate.newBuilder()
+                        .putResults(SCANNER_INTERNAL.name(), ScannerResult.newBuilder()
+                                .setScanner(SCANNER_INTERNAL)
+                                .setStatus(SCAN_STATUS_SUCCESSFUL)
+                                .build())
+                        .build(),
+                Instant.now().plusSeconds(45));
+
+        assertThat(outputTopic.readRecordsToList()).satisfiesExactly(
+                record -> {
+                    assertThat(record.key()).isNotEqualTo(scanKey);
+                    assertThat(record.value().getResultsCount()).isEqualTo(1);
+                    assertThat(record.value().getResultsOrThrow(SCANNER_INTERNAL.name()).getStatus()).isEqualTo(SCAN_STATUS_SUCCESSFUL);
+                    assertThat(record.value().getLastUpdated().getSeconds()).isNotZero();
+                }
+        );
+
+        // The first partial aggregate has expired (maxLifeTime is 30 seconds),
+        // and its store entry was removed. The second record was complete and
+        // never persisted to the store in the first place.
+        // Thus, the store must be empty at this point.
+        assertThat(stateStore.approximateNumEntries()).isZero();
+    }
+
+}

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/misc/TombstoneEmittingProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/misc/TombstoneEmittingProcessorTest.java
@@ -43,7 +43,9 @@ class TombstoneEmittingProcessorTest {
 
     @AfterEach
     void afterEach() {
-        testDriver.close();
+        if (testDriver != null) {
+            testDriver.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR introduces some improvements to how Kafka Streams state stores are used in the vulnerability-analyzer.

### Automatic cleanup of `completed-scans-table` state store

The `completed-scans-table` store is where we aggregate results from all applicable scanners, per `ScanKey`. The intention is to only forward a result events to `dtrack.vuln-analysis.result` once all scanners completed their work. The store was prone to accumulating lots of data, for the following reasons:

1. Scanner results can be quite big (depending on how many vulnerabilities were identified). The data is compressed in Kafka topics, but it's uncompressed in the local state store.
2. `KTable`s do not support manual deletions or TTL policies, so entries never expire and stay around forever
3. The default `segment.bytes` for changelog topics is 256 MiB. Kafka can only delete records of "inactive" segments, meaning that partitions in the changelog topic must accumulate >256 MiB of data first before compaction can kick in.

All of the above are amplified by the fact that `ScanKey`s are unbounded, as there is no finite set of keys.

We worked around (2) by introducing [a processor that emits Tombstone records](https://github.com/DependencyTrack/hyades/blob/main/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/TombstoneEmittingProcessor.java) for `ScanKey`s for which no update to the `completed-scans-table` was observed for over an hour. This approach is [recommended by Confluent](https://developer.confluent.io/tutorials/schedule-ktable-ttl/kstreams.html).

While this *does* keep the table from growing indefinitely, we could still run into situations where lots of unique keys accumulate over the course of 1h. This is unfortunate because we don't *need* the aggregated scanner results anymore, once they are "complete" and we forwarded them.

This PR adds a custom `Processor` that replaces the previously used KTable. It includes logic to delete completed aggregates from the store, but it also still performs TTL enforcement to regularly clean up old records. This change is backward-compatible, because it reuses the existing state store.

> **Note**  
> The topic `hyades-vulnerability-analyzer-completed-scans-table-last-update-store-changelog` is no longer necessary and should be removed after deploying the updated vulnerability-analyzer service.

### Configurable state stores

It is now possible to configure whether in-memory or persistent state stores shall be used. Further, certain customizations to RocksDB are configurable (e.g. the compaction style and compression type). These settings are currently applied globally to all state stores. In the future we can scope them to individual state stores, too.

To switch all state stores to RocksDB, and enable compression, the following properties may be used

```ini
state-store.type=rocks_db
state-store.rocks-db.compression-type=lz4_compression
```

### Smaller changelog topics

When using state stores, Kafka Streams will, per default, create changelog topics with `segment.bytes` set to 256 MiB, which is a lot (too much) data in many cases. It artificially increases restoration times.

We now have a centralized default configuration for changelog topics, that applies a few stricter limits:

https://github.com/DependencyTrack/hyades/blob/33bee8685498bbf70db0658dd3dfa850e8dbb8a7/vulnerability-analyzer/src/main/java/org/hyades/util/StateStoreUtil.java#L54-L59

Log segments are limited to 64 MiB, and records are [signaled to be eligible for compaction](https://cwiki.apache.org/confluence/display/KAFKA/KIP-354%3A+Add+a+Maximum+Log+Compaction+Lag) immediately after they've been written. This should help with keeping topics smaller, and having compaction kick in sooner.

This config has also been added to `TOPICS.md`.

For some topics it may even be practical to reduce the `segment.bytes` even further, but I am not quite sure yet what the actual performance impact on the broker side is yet.