### PR TITLE
Register `RocksDbConfigSetter` for reflection

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/config/RocksDbConfigSetter.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/config/RocksDbConfigSetter.java
@@ -1,5 +1,6 @@
 package org.hyades.config;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.config.SmallRyeConfig;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -15,6 +16,7 @@ import java.util.Map;
  *
  * @see <a href="https://kafka.apache.org/34/documentation/streams/developer-guide/config-streams#rocksdb-config-setter">Kafka Streams Documentation</a>
  */
+@RegisterForReflection
 public class RocksDbConfigSetter implements RocksDBConfigSetter {
 
     @Override


### PR DESCRIPTION
Kafka streams instantiates the configured class via reflection. Because the class is not directly referenced right now, the vuln analyzer currently does not start when running via native image.