### PR TITLE
fix SIGTERM container handling

### DIFF
--- a/mirror-service/src/main/docker/Dockerfile.jvm
+++ b/mirror-service/src/main/docker/Dockerfile.jvm
@@ -16,6 +16,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 EXPOSE 8093
 USER 185
 WORKDIR /deployments
-CMD java ${JAVA_OPTS} -jar quarkus-run.jar \
+CMD exec java ${JAVA_OPTS} -jar quarkus-run.jar \
     -Dquarkus.http.host=0.0.0.0 \
     -Djava.util.logging.manager=org.jboss.logmanager.LogManager

--- a/notification-publisher/src/main/docker/Dockerfile.jvm
+++ b/notification-publisher/src/main/docker/Dockerfile.jvm
@@ -16,6 +16,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 EXPOSE 8090
 USER 185
 WORKDIR /deployments
-CMD java ${JAVA_OPTS} -jar quarkus-run.jar \
+CMD exec java ${JAVA_OPTS} -jar quarkus-run.jar \
     -Dquarkus.http.host=0.0.0.0 \
     -Djava.util.logging.manager=org.jboss.logmanager.LogManager

--- a/repository-meta-analyzer/src/main/docker/Dockerfile.jvm
+++ b/repository-meta-analyzer/src/main/docker/Dockerfile.jvm
@@ -16,6 +16,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 EXPOSE 8091
 USER 185
 WORKDIR /deployments
-CMD java ${JAVA_OPTS} -jar quarkus-run.jar \
+CMD exec java ${JAVA_OPTS} -jar quarkus-run.jar \
     -Dquarkus.http.host=0.0.0.0 \
     -Djava.util.logging.manager=org.jboss.logmanager.LogManager

--- a/vulnerability-analyzer/src/main/docker/Dockerfile.jvm
+++ b/vulnerability-analyzer/src/main/docker/Dockerfile.jvm
@@ -16,6 +16,6 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 EXPOSE 8092
 USER 185
 WORKDIR /deployments
-CMD java ${JAVA_OPTS} -jar quarkus-run.jar \
+CMD exec java ${JAVA_OPTS} -jar quarkus-run.jar \
     -Dquarkus.http.host=0.0.0.0 \
     -Djava.util.logging.manager=org.jboss.logmanager.LogManager


### PR DESCRIPTION
https://github.com/DependencyTrack/hyades/issues/561 

Fix signals (e.g. SIGTERM) not being handled by the JVM process inside the container image, preventing graceful shutdown.