### PR TITLE
Temporarily disable Linux package types for Snyk

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/snyk/SnykProcessorSupplier.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/snyk/SnykProcessorSupplier.java
@@ -32,11 +32,11 @@ import static org.hyades.util.PurlUtils.parsePurl;
 public class SnykProcessorSupplier implements ScanProcessorSupplier {
 
     private static final Set<String> SUPPORTED_PURL_TYPES = Set.of(
-            "apk", // Not defined in StandardTypes
+            // "apk", // Not defined in StandardTypes
             PackageURL.StandardTypes.CARGO,
             "cocoapods", // Not defined in StandardTypes
             PackageURL.StandardTypes.COMPOSER,
-            PackageURL.StandardTypes.DEBIAN,
+            // PackageURL.StandardTypes.DEBIAN,
             PackageURL.StandardTypes.GEM,
             PackageURL.StandardTypes.GENERIC,
             PackageURL.StandardTypes.HEX,
@@ -44,7 +44,7 @@ public class SnykProcessorSupplier implements ScanProcessorSupplier {
             PackageURL.StandardTypes.NPM,
             PackageURL.StandardTypes.NUGET,
             PackageURL.StandardTypes.PYPI,
-            PackageURL.StandardTypes.RPM,
+            // PackageURL.StandardTypes.RPM,
             "swift" // Not defined in StandardTypes
     );
 

--- a/vulnerability-analyzer/src/test/java/org/hyades/processor/scanner/snyk/SnykProcessorSupplierTest.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/processor/scanner/snyk/SnykProcessorSupplierTest.java
@@ -44,7 +44,7 @@ class SnykProcessorSupplierTest {
 
     @ParameterizedTest
     @CsvSource(value = {
-            "apk, true",
+            "apk, false",
             "bitbucket, false",
             "cargo, true",
             "cocoapods, true",
@@ -52,7 +52,7 @@ class SnykProcessorSupplierTest {
             "conan, false",
             "conda, false",
             "cran, false",
-            "deb, true",
+            "deb, false",
             "docker, false",
             "foobar, false",
             "gem, true",
@@ -64,7 +64,7 @@ class SnykProcessorSupplierTest {
             "npm, true",
             "nuget, true",
             "pypi, true",
-            "rpm, true",
+            "rpm, false",
             "swift, true",
     })
     void testCanProcessPurlTypes(final String type, final boolean expectedResult) {


### PR DESCRIPTION
There are discrepancies between what SBOM generators report as PURL namespace and `distro` qualifier, and what Snyk expects.

For example, trivy uses `redhat` for both, whereas Snyk expects `rhel`. The latter is also used by Syft.

Problem is that batch requests to Snyk will fail entirely when at least one PURL in the batch does not comply with Snyk's preferred identifiers. There is no indication in the response as to which PURL caused the failure, so we can't filter them out and re-try the batch.

Disabling Linux package types for now to not impact analysis of other package types.

Reverts some changed made in #552