### PR TITLE
Helm: Add port definition to vuln analyzer service

### DIFF
--- a/helm-charts/hyades/templates/vuln-analyzer/service.yaml
+++ b/helm-charts/hyades/templates/vuln-analyzer/service.yaml
@@ -7,4 +7,7 @@ metadata:
   labels: {{- include "hyades.vulnAnalyzerLabels" . | nindent 4 }}
 spec:
   clusterIP: None
+  ports:
+  - port: 80
+    targetPort: web
   selector: {{- include "hyades.vulnAnalyzerSelectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Port definition is required for binding ingress or routes to the service (although this should be rare).