### PR TITLE
Replace Flyway with testcontainers init script

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -88,11 +88,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-flyway</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
     </dependency>

--- a/commons/src/test/resources/application.properties
+++ b/commons/src/test/resources/application.properties
@@ -10,8 +10,5 @@ quarkus.hibernate-orm.database.globally-quoted-identifiers=true
 # Hibernate should only validate that the existing schema matches our entity classes,
 # but it should never generate a schema by itself.
 quarkus.hibernate-orm.database.generation=validate
-# Use Flyway only in test mode to populate the DB with the schema generated
-# by the API server. In production or dev mode, this will be handled by the
-# API server itself. See https://quarkus.io/guides/flyway
-quarkus.flyway.migrate-at-start=true
-quarkus.flyway.locations=migrations/postgres
+
+quarkus.datasource.devservices.init-script-path=migrations/postgres/V0.0.1__API-Server-4.8.2.sql

--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -66,11 +66,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-flyway</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams-test-utils</artifactId>
       <scope>test</scope>

--- a/notification-publisher/src/main/resources/application.properties
+++ b/notification-publisher/src/main/resources/application.properties
@@ -55,13 +55,7 @@ quarkus.hibernate-orm.database.generation=validate
 %dev.quarkus.datasource.username=dtrack
 %dev.quarkus.datasource.password=dtrack
 %dev.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/dtrack
-#%dev.quarkus.hibernate-orm.log.sql=true
-
-# Use Flyway only in test mode to populate the DB with the schema generated
-# by the API server. In production or dev mode, this will be handled by the
-# API server itself. See https://quarkus.io/guides/flyway
-%test.quarkus.flyway.migrate-at-start=true
-%test.quarkus.flyway.locations=migrations/postgres
+quarkus.datasource.devservices.init-script-path=migrations/postgres/V0.0.1__API-Server-4.8.2.sql
 
 quarkus.hibernate-orm.active=true
 

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -85,17 +85,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-flyway</artifactId>
-      <!--
-          Despite not being used in production, Flyway must be included in
-          "compile" (default) scope. Integration tests are running in the "prod" profile,
-          and we need Flyway in order to initialize the DB schema.
-          Scope may be changed to "test" when we find a better way to handle
-          schema initialization in integration tests.
-      -->
-    </dependency>
-    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams-test-utils</artifactId>
       <scope>test</scope>

--- a/repository-meta-analyzer/src/main/resources/application.properties
+++ b/repository-meta-analyzer/src/main/resources/application.properties
@@ -50,13 +50,7 @@ quarkus.hibernate-orm.database.generation=validate
 %dev.quarkus.datasource.username=dtrack
 %dev.quarkus.datasource.password=dtrack
 %dev.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/dtrack
-
-# Use Flyway only in test mode to populate the DB with the schema generated
-# by the API server. In production or dev mode, this will be handled by the
-# API server itself. See https://quarkus.io/guides/flyway
-quarkus.flyway.migrate-at-start=false
-%test.quarkus.flyway.migrate-at-start=true
-quarkus.flyway.locations=migrations/postgres
+quarkus.datasource.devservices.init-script-path=migrations/postgres/V0.0.1__API-Server-4.8.2.sql
 
 #%dev.quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.active=true

--- a/repository-meta-analyzer/src/test/java/org/hyades/RepositoryMetaAnalyzerIT.java
+++ b/repository-meta-analyzer/src/test/java/org/hyades/RepositoryMetaAnalyzerIT.java
@@ -6,8 +6,6 @@ import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
@@ -30,25 +28,13 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusIntegrationTest
-@TestProfile(RepositoryMetaAnalyzerIT.TestProfile.class)
 @QuarkusTestResource(KafkaCompanionResource.class)
 @QuarkusTestResource(WireMockTestResource.class)
 class RepositoryMetaAnalyzerIT {
-
-    public static class TestProfile implements QuarkusTestProfile {
-
-        @Override
-        public Map<String, String> getConfigOverrides() {
-            return Map.of(
-                    "quarkus.flyway.migrate-at-start", "true"
-            );
-        }
-    }
 
     @InjectKafkaCompanion
     KafkaCompanion kafkaCompanion;

--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -75,17 +75,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway</artifactId>
-            <!--
-                Despite not being used in production, Flyway must be included in
-                "compile" (default) scope. Integration tests are running in the "prod" profile,
-                and we need Flyway in order to initialize the DB schema.
-                Scope may be changed to "test" when we find a better way to handle
-                schema initialization in integration tests.
-            -->
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jacoco</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -128,16 +128,7 @@ quarkus.hibernate-orm.database.generation=validate
 %dev.quarkus.datasource.username=dtrack
 %dev.quarkus.datasource.password=dtrack
 %dev.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/dtrack
-%prod.quarkus.datasource.username=dtrack
-%prod.quarkus.datasource.password=dtrack
-%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/dtrack
-
-# Use Flyway only in test mode to populate the DB with the schema generated
-# by the API server. In production or dev mode, this will be handled by the
-# API server itself. See https://quarkus.io/guides/flyway
-quarkus.flyway.migrate-at-start=false
-%test.quarkus.flyway.migrate-at-start=true
-quarkus.flyway.locations=migrations/postgres
+quarkus.datasource.devservices.init-script-path=migrations/postgres/V0.0.1__API-Server-4.8.2.sql
 
 #%dev.quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.active=true

--- a/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerIT.java
+++ b/vulnerability-analyzer/src/test/java/org/hyades/VulnerabilityAnalyzerIT.java
@@ -38,7 +38,6 @@ class VulnerabilityAnalyzerIT {
                     "scanner.internal.enabled", "true",
                     "scanner.ossindex.enabled", "false",
                     "scanner.snyk.enabled", "false",
-                    "quarkus.flyway.migrate-at-start", "true",
                     "quarkus.kafka.snappy.enabled", "true"
             );
         }


### PR DESCRIPTION
As of Quarkus 2.16.3 it is possible to provide an init script to the database testcontainer (https://github.com/quarkusio/quarkus/pull/30455).

We previously had to use Flyway to initialize the container with the API server SQL schema. This is no longer necessary.