### PR TITLE
Fix inconsistent usage of labels in Helm chart

### DIFF
--- a/helm-charts/hyades/templates/api-server/ingress.yaml
+++ b/helm-charts/hyades/templates/api-server/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "hyades.apiServerFullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.apiServer.ingress.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm-charts/hyades/templates/api-server/pvc.yaml
+++ b/helm-charts/hyades/templates/api-server/pvc.yaml
@@ -2,8 +2,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
   name: {{ include "hyades.apiServerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/helm-charts/hyades/templates/frontend/deployment.yaml
+++ b/helm-charts/hyades/templates/frontend/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: {{ include "hyades.frontendFullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "hyades.frontendSelectorLabels" . | nindent 4 }}
+  labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.frontend.replicaCount }}
   selector:

--- a/helm-charts/hyades/templates/frontend/ingress.yaml
+++ b/helm-charts/hyades/templates/frontend/ingress.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "hyades.frontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
   {{- with .Values.frontend.ingress.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm-charts/hyades/templates/mirror-service/deployment.yaml
+++ b/helm-charts/hyades/templates/mirror-service/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: {{ include "hyades.mirrorServiceFullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "hyades.mirrorServiceSelectorLabels" . | nindent 4 }}
+  labels: {{- include "hyades.mirrorServiceLabels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:

--- a/helm-charts/hyades/templates/repo-meta-analyzer/deployment.yaml
+++ b/helm-charts/hyades/templates/repo-meta-analyzer/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "hyades.repoMetaAnalyzerFullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "hyades.repoMetaAnalyzerSelectorLabels" .  | nindent 4 }}
+  labels: {{- include "hyades.repoMetaAnalyzerLabels" .  | nindent 4 }}
 spec:
   replicas: {{ .Values.repoMetaAnalyzer.replicaCount }}
   selector:


### PR DESCRIPTION
I missed to move some resources from `*SelectorLabels` to `*Labels` for `metadata.labels` fields in #583, leading to inconsistencies in labels across resources.