### PR TITLE
Lock down GitHub Actions workflows

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -6,6 +6,8 @@ on:
         required: true
         description: "Name of the Maven module to build"
 
+permissions: { }
+
 jobs:
   build-native-image:
     name: Build Native Image
@@ -20,17 +22,17 @@ jobs:
       fail-fast: true
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # tag=v3.11.0
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2.2.0
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # tag=v2.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.6.0
+      uses: docker/setup-buildx-action@6a58db7e0d21ca03e6c44877909e80e45217eed2 # tag=v2.6.0
       with:
         install: true
     - name: Build Native Image
@@ -67,7 +69,7 @@ jobs:
       run: |-
         mvn -pl commons,proto,${{ inputs.module }} test-compile failsafe:integration-test -Pnative
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag=v3.1.2
       with:
         name: native-image-${{ matrix.arch.name }}
         path: |-
@@ -76,37 +78,39 @@ jobs:
   build-container-image:
     name: Build Container Image
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # Required to push images to ghcr.io
     timeout-minutes: 5
     needs:
     - build-native-image
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
     - name: Download amd64 Binary
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
       with:
         name: native-image-amd64
         path: ${{ inputs.module }}/target/amd64
     - name: Download arm64 Binary
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
       with:
         name: native-image-arm64
         path: ${{ inputs.module }}/target/arm64
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2.2.0
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # tag=v2.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.6.0
+      uses: docker/setup-buildx-action@6a58db7e0d21ca03e6c44877909e80e45217eed2 # tag=v2.6.0
       with:
         install: true
     - name: Docker login
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # tag=v2.2.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ startsWith(github.repository, 'DependencyTrack/') }}
     - name: Build Container Image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf # tag=v4.1.0
       with:
         context: ./${{ inputs.module }}
         file: ./${{ inputs.module }}/src/main/docker/Dockerfile.native-multiarch

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -13,17 +13,17 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
     - name: Setup buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-setup-action@0b2634d023322ed4186879e9a60c01783a8963d4 # tag=v1.21.0
       with:
         github_token: ${{ github.token }}
     - name: Lint Protobuf
-      uses: bufbuild/buf-lint-action@v1
+      uses: bufbuild/buf-lint-action@bd48f53224baaaf0fc55de9a913e7680ca6dbea4 # tag=v1.0.3
       with:
         input: proto/src/main/proto
     - name: Detect Breaking Changes
-      uses: bufbuild/buf-breaking-action@v1
+      uses: bufbuild/buf-breaking-action@f47418c81c00bfd65394628385593542f64db477 # tag=v1.1.2
       with:
         input: proto/src/main/proto
         against: https://github.com/${{ github.repository }}.git#branch=main,subdir=proto/src/main/proto

--- a/.github/workflows/build-native-mirror-service.yml
+++ b/.github/workflows/build-native-mirror-service.yml
@@ -12,6 +12,8 @@ on:
     - "pom.xml"
   workflow_dispatch: { }
 
+permissions: { }
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-native-notification-publisher.yml
+++ b/.github/workflows/build-native-notification-publisher.yml
@@ -12,6 +12,8 @@ on:
     - "pom.xml"
   workflow_dispatch: { }
 
+permissions: { }
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-native-repository-meta-analyzer.yml
+++ b/.github/workflows/build-native-repository-meta-analyzer.yml
@@ -12,6 +12,8 @@ on:
     - "pom.xml"
   workflow_dispatch: { }
 
+permissions: { }
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-native-vulnerability-analyzer.yml
+++ b/.github/workflows/build-native-vulnerability-analyzer.yml
@@ -12,6 +12,8 @@ on:
     - "pom.xml"
   workflow_dispatch: { }
 
+permissions: { }
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions: { }
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # tag=v3.11.0
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -47,9 +49,9 @@ jobs:
       fail-fast: true
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # tag=v3.11.0
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -7,6 +7,8 @@ on:
     paths:
     - helm-charts/**
 
+permissions: { }
+
 jobs:
   lint:
     name: Lint
@@ -14,16 +16,16 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
     - name: Set up Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # tag=v3.5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # tag=v4.6.1
       with:
         python-version: "3.9"
         check-latest: true
     - name: Set up Chart Testing
-      uses: helm/chart-testing-action@v2.4.0
+      uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # tag=v2.4.0
     - name: Lint Chart
       run: |-
         ct lint --charts ./helm-charts/hyades

--- a/.github/workflows/publishJar.yml
+++ b/.github/workflows/publishJar.yml
@@ -4,27 +4,31 @@ on:
   push:
     branches: [ "main" ]
 
+permissions: { }
+
 jobs:
   publish-container-image:
     name: Publish Jar based Container Images
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # Required to push images to ghcr.io
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # tag=v3.11.0
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.2.0
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # tag=v2.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.6.0
+        uses: docker/setup-buildx-action@6a58db7e0d21ca03e6c44877909e80e45217eed2 # tag=v2.6.0
         with:
           install: true
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # tag=v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -54,9 +58,9 @@ jobs:
     # only trigger them after building the images completed.
     - publish-container-image
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # tag=v3.11.0
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout project source
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
 
       # Scan code using project's configuration on https://semgrep.dev/manage
-      - uses: returntocorp/semgrep-action@316a1751c53ffb6689b8726910e8204ffb591b4f
+      - uses: returntocorp/semgrep-action@316a1751c53ffb6689b8726910e8204ffb591b4f # tag=v0.51.0
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
           publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
@@ -43,7 +43,7 @@ jobs:
 
       # Upload SARIF file generated in previous step
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@1245696032ecf7d39f87d54daa406e22ddf769a8 # v2.3.6
         with:
           sarif_file: semgrep.sarif
         if: always()


### PR DESCRIPTION
Pin versions of Actions to their digest, and drop token permissions wherever possible.

Dependabot will take care of updating the actions properly, as it is capable of interpreting the `tag=vX.X.X` comment.

Token permissions are dropped globally for every GHA workflow. When specific permissions are required (e.g. to publish container images), those permissions are specified on the `jobs` level.

See also:

* https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
* https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions