### PR TITLE
Fix insufficient token permissions in `_build_native_meta.yml`

### DIFF
--- a/.github/workflows/build-native-mirror-service.yml
+++ b/.github/workflows/build-native-mirror-service.yml
@@ -23,3 +23,5 @@ jobs:
     uses: ./.github/workflows/_build-native-meta.yml
     with:
       module: mirror-service
+    permissions:
+      packages: write # Required to push images to ghcr.io

--- a/.github/workflows/build-native-notification-publisher.yml
+++ b/.github/workflows/build-native-notification-publisher.yml
@@ -23,3 +23,5 @@ jobs:
     uses: ./.github/workflows/_build-native-meta.yml
     with:
       module: notification-publisher
+    permissions:
+      packages: write # Required to push images to ghcr.io

--- a/.github/workflows/build-native-repository-meta-analyzer.yml
+++ b/.github/workflows/build-native-repository-meta-analyzer.yml
@@ -23,3 +23,5 @@ jobs:
     uses: ./.github/workflows/_build-native-meta.yml
     with:
       module: repository-meta-analyzer
+    permissions:
+      packages: write # Required to push images to ghcr.io

--- a/.github/workflows/build-native-vulnerability-analyzer.yml
+++ b/.github/workflows/build-native-vulnerability-analyzer.yml
@@ -23,3 +23,5 @@ jobs:
     uses: ./.github/workflows/_build-native-meta.yml
     with:
       module: vulnerability-analyzer
+    permissions:
+      packages: write # Required to push images to ghcr.io


### PR DESCRIPTION
Reusable workflows like this one cannot have more permissions than the workflow calling them (https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-and-permissions). 

Because `build-native-mirror-service.yml` etc. dropped all permissions, `_build-native-meta.yml` can't request the `packages: write` permission.

Build pipelines for native images are currently failing due to this, e.g. https://github.com/DependencyTrack/hyades/actions/runs/5248293048