### PR TITLE
Avoid parse exceptions showing up as errors in the osv mirror log

### DIFF
--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/osv/OsvMirrorConfiguration.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/osv/OsvMirrorConfiguration.java
@@ -22,7 +22,7 @@ class OsvMirrorConfiguration {
                 .namingPattern("hyades-mirror-osv-%d")
                 .uncaughtExceptionHandler((thread, exception) -> {
                     final Logger logger = LoggerFactory.getLogger(OsvMirror.class);
-                    logger.error("An uncaught exception was thrown while mirroring NVD", exception);
+                    logger.error("An uncaught exception was thrown while mirroring OSV", exception);
                 })
                 .build();
 

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/osv/OsvToCyclonedxParser.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/osv/OsvToCyclonedxParser.java
@@ -99,8 +99,12 @@ public class OsvToCyclonedxParser {
             JSONObject osvAffectedObj = osvAffectedArray.getJSONObject(i);
             String purl = parsePackageUrl(osvAffectedObj);
             try {
-                packageUrl = new PackageURL(purl);
-                ecoSystem = packageUrl.getType();
+                if (purl != null) {
+                    packageUrl = new PackageURL(purl);
+                    ecoSystem = packageUrl.getType();
+                } else {
+                    LOGGER.debug("Package url was null");
+                }
             } catch (MalformedPackageURLException ex) {
                 LOGGER.info("Error while parsing purl: {}", purl, ex);
             }
@@ -319,7 +323,7 @@ public class OsvToCyclonedxParser {
         return cpeObj != null ? cpeObj.optString("purl", null) : null;
     }
 
-    private <T>T deserialize(String stringToConvert, Class<T> type) {
+    private <T> T deserialize(String stringToConvert, Class<T> type) {
         try {
             return this.objectMapper.readValue(stringToConvert, type);
         } catch (Exception ex) {


### PR DESCRIPTION
Currently the OSV mirror functionality throws a malformed purl exception whenever the purl is empty. This happens for a lot of cases which results in a lot of error logs coming up in the osv mirror task:
`2023-06-15 20:44:45,596 INFO  [org.hya.vul.dat.osv.OsvToCyclonedxParser] (hyades-mirror-osv-1) Error while parsing purl: null: com.github.packageurl.MalformedPackageURLException: Invalid purl: Contains an empty or null value
        at com.github.packageurl.PackageURL.parse(PackageURL.java:478)
        at com.github.packageurl.PackageURL.<init>(PackageURL.java:68)
        at org.hyades.vulnmirror.datasource.osv.OsvToCyclonedxParser.parseAffectedRanges(OsvToCyclonedxParser.java:102)
        at org.hyades.vulnmirror.datasource.osv.OsvToCyclonedxParser.parse(OsvToCyclonedxParser.java:83)
        at org.hyades.vulnmirror.datasource.osv.OsvMirror.parseZipInputAndPublishIfChanged(OsvMirror.java:74)
        at org.hyades.vulnmirror.datasource.osv.OsvMirror.performMirror(OsvMirror.java:58)
        at org.hyades.vulnmirror.datasource.osv.OsvMirror.lambda$doMirror$0(OsvMirror.java:91)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
`

The null check would print a debug message and not generate an explicit exception. 
1. Added null check on purl to avoid parse exceptions showing up as errors in the osv mirror log. 
2. Corrected exception message stating NVD instead of OSV