### PR TITLE
Fix broken native images after KStreams upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,5 @@ jobs:
         mvn -pl commons,commons-persistence,proto,${{ matrix.module }} clean install -Pnative -DskipTests
     - name: Test Native Image
       run: |-
-        mvn -pl commons,commons-persistence,proto,${{ matrix.module }} test-compile failsafe:integration-test -Pnative
+        mvn -pl commons,commons-persistence,proto,${{ matrix.module }} \
+        test-compile failsafe:integration-test failsafe:verify -Pnative

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/config/KafkaStreamsReflectionConfiguration.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/config/KafkaStreamsReflectionConfiguration.java
@@ -1,0 +1,12 @@
+package org.hyades.vulnmirror.config;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+
+@RegisterForReflection(targets = {
+        // Introduced in kafka-streams 3.5.0 and not recognized by Quarkus <= 3.1.x.
+        // Can be removed once Quarkus' KStreams integration supports it.
+        DefaultKafkaClientSupplier.class,
+})
+public class KafkaStreamsReflectionConfiguration {
+}

--- a/repository-meta-analyzer/src/main/java/org/hyades/config/KafkaStreamsReflectionConfiguration.java
+++ b/repository-meta-analyzer/src/main/java/org/hyades/config/KafkaStreamsReflectionConfiguration.java
@@ -1,0 +1,12 @@
+package org.hyades.config;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+
+@RegisterForReflection(targets = {
+        // Introduced in kafka-streams 3.5.0 and not recognized by Quarkus <= 3.1.x.
+        // Can be removed once Quarkus' KStreams integration supports it.
+        DefaultKafkaClientSupplier.class,
+})
+public class KafkaStreamsReflectionConfiguration {
+}

--- a/vulnerability-analyzer/src/main/java/org/hyades/config/KafkaStreamsReflectionConfiguration.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/config/KafkaStreamsReflectionConfiguration.java
@@ -1,0 +1,12 @@
+package org.hyades.config;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+
+@RegisterForReflection(targets = {
+        // Introduced in kafka-streams 3.5.0 and not recognized by Quarkus <= 3.1.x.
+        // Can be removed once Quarkus' KStreams integration supports it.
+        DefaultKafkaClientSupplier.class,
+})
+public class KafkaStreamsReflectionConfiguration {
+}


### PR DESCRIPTION
As of kafka-streams 3.5.0, users can configure a KafkaClientSupplier, with the default implementation being `DefaultKafkaClientSupplier` (https://issues.apache.org/jira/browse/KAFKA-14395).

The supplier is called via reflection, but Quarkus <= 3.1.x doesn't yet register it as such for GraalVM.