### PR TITLE
Fix failing native image ITs not failing the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,5 @@ jobs:
         mvn -pl commons,commons-persistence,proto,${{ matrix.module }} clean install -Pnative -DskipTests
     - name: Test Native Image
       run: |-
-        mvn -pl commons,commons-persistence,proto,${{ matrix.module }} test-compile failsafe:integration-test -Pnative
+        mvn -pl commons,commons-persistence,proto,${{ matrix.module }} \
+        test-compile failsafe:integration-test failsafe:verify -Pnative


### PR DESCRIPTION
The build was succeeding despite the actual integration tests failing, causing #622 to slip through.