### PR TITLE
Add support for logging in JSON format

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,6 +29,7 @@ environment variable can be used.
 | `QUARKUS_DATASOURCE_JDBC_URL`                  | The database JDBC URL                               | -                |                  ✅                   |
 | `QUARKUS_DATASOURCE_USERNAME`                  | The database username                               | -                |                  ✅                   |
 | `QUARKUS_DATASOURCE_PASSWORD`                  | The database password                               | -                |                  ✅                   |
+| `QUARKUS_LOG_CONSOLE_JSON`                     | Enable logging in JSON format                       | `false`          |                  ❌                   |
 | `QUARKUS_MAILER_FROM`                          | The sender name for email notifications             | -                | When email notifications are enabled |
 | `QUARKUS_MAILER_HOST`                          | Address of the mail server for email notifications  | -                | When email notifications are enabled |
 | `QUARKUS_MAILER_PORT`                          | Port of the mail server for email notifications     | -                | When email notifications are enabled |
@@ -37,10 +38,8 @@ environment variable can be used.
 | `QUARKUS_MAILER_USERNAME`                      | Username to authenticate with the email server      | -                | When email notifications are enabled |
 | `QUARKUS_MAILER_PASSWORD`                      | Password to authenticate with the email server      | -                | When email notifications are enabled |
 
-> **Note**
-> Refer
->
-to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/notification-publisher/src/main/resources/application.properties)
+> **Note**  
+> Refer to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/notification-publisher/src/main/resources/application.properties)
 > for a complete overview of available config options.
 
 ### Repository Meta Analyzer
@@ -53,11 +52,10 @@ to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/mai
 | `QUARKUS_DATASOURCE_JDBC_URL`      | The database JDBC URL                 | -                |    ✅     |
 | `QUARKUS_DATASOURCE_USERNAME`      | The database username                 | -                |    ✅     |
 | `QUARKUS_DATASOURCE_PASSWORD`      | The database password                 | -                |    ✅     |
+| `QUARKUS_LOG_CONSOLE_JSON`         | Enable logging in JSON format         | `false`          |    ❌     |
 
-> **Note**
-> Refer
->
-to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/repository-meta-analyzer/src/main/resources/application.properties)
+> **Note**  
+> Refer to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/repository-meta-analyzer/src/main/resources/application.properties)
 > for a complete overview of available config options.
 
 ### Vulnerability Analyzer
@@ -74,12 +72,13 @@ to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/mai
 | `QUARKUS_DATASOURCE_JDBC_URL`           | The database JDBC URL                                                       | -                      |          ✅           |
 | `QUARKUS_DATASOURCE_USERNAME`           | The database username                                                       | -                      |          ✅           |
 | `QUARKUS_DATASOURCE_PASSWORD`           | The database password                                                       | -                      |          ✅           | 
+| `QUARKUS_LOG_CONSOLE_JSON`              | Enable logging in JSON format                                               | `false`                |          ❌           |
 | `SCANNER_INTERNAL_ENABLED`              | Enable the internal vulnerability scanner                                   | `true`                 |          ❌           |
 | `SCANNER_OSSINDEX_ENABLED`              | Enable the OSS Index vulnerability scanner                                  | `true`                 |          ❌           |
 | `SCANNER_OSSINDEX_API_USERNAME`         | OSS Index API username                                                      | -                      |          ❌           |
 | `SCANNER_OSSINDEX_API_TOKEN`            | OSS Index API token                                                         | -                      |          ❌           |
 | `SCANNER_OSSINDEX_BATCH_INTERVAL`       | Max time to wait before submitting incomplete batches                       | `5S`                   |          ❌           |
-| `SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED`   | Alias synching enabled for oss index analyzer                               | `false`                |          ❌           |
+| `SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED`   | Enable alias syncing for OSS Index                                          | `false`                |          ❌           |
 | `SCANNER_SNYK_ENABLED`                  | Enable the Snyk vulnerability scanner                                       | `false`                |          ❌           |
 | `SCANNER_SNYK_API_ORG_ID`               | Snyk organization ID                                                        | -                      | When Snyk is enabled |
 | `SCANNER_SNYK_API_TOKENS`               | Comma-separated list of Snyk API tokens                                     | -                      | When Snyk is enabled |
@@ -87,12 +86,10 @@ to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/mai
 | `SCANNER_SNYK_SEVERITY_SOURCE_PRIORITY` | Priority of preferred source for vulnerability severities                   | `nvd,snyk,redhat,suse` | When Snyk is enabled |
 | `SCANNER_SNYK_BATCH_INTERVAL`           | Max time to wait before submitting incomplete batches                       | `5S`                   | When Snyk is enabled |
 | `SCANNER_SNYK_BATCH_SIZE`               | Max size of batch at which it will be submitted                             | `100`                  | When Snyk is enabled |
-| `SCANNER_SNYK_ALIAS_SYNC_ENABLED`       | Alias synching enabled for snyk analyzer                                    | `false`                |          ❌           |
+| `SCANNER_SNYK_ALIAS_SYNC_ENABLED`       | Enable alias syncing for Snyk                                               | `false`                |          ❌           |
 
-> **Note**
-> Refer
->
-to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/vulnerability-analyzer/src/main/resources/application.properties)
+> **Note**  
+> Refer to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/vulnerability-analyzer/src/main/resources/application.properties)
 > for a complete overview of available config options.
 
 ### Mirror Service
@@ -102,13 +99,12 @@ to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/mai
 | `KAFKA_BOOTSTRAP_SERVERS`                     | Comma-separated list of Kafka servers      | `localhost:9092` |    ✅     |
 | `KAFKA_SSL_ENABLED`                           | SSL enabled for using kafka broker         | `false`          |    ❌     |
 | `KAFKA_STREAMS_NUM_STREAM_THREADS`            | Number of Kafka Streams threads            | `3`              |    ❌     |
-| `MIRROR_DATASOURCE_GITHUB_ALIAS_SYNC_ENABLED` | Alias syncing enabled for github mirroring | `false`          |    ❌     |
-| `MIRROR_DATASOURCE_OSV_ALIAS_SYNC_ENABLED`    | Alias syncing enabled for osv mirroring    | `false`          |    ❌     |
+| `MIRROR_DATASOURCE_GITHUB_ALIAS_SYNC_ENABLED` | Enable alias syncing for GitHub Advisories | `false`          |    ❌     |
+| `MIRROR_DATASOURCE_OSV_ALIAS_SYNC_ENABLED`    | Enable alias syncing for OSV               | `false`          |    ❌     |
+| `QUARKUS_LOG_CONSOLE_JSON`                    | Enable logging in JSON format              | `false`          |    ❌     |
 
-> **Note**
-> Refer
->
-to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/mirror-service/src/main/resources/application.properties)
+> **Note**  
+> Refer to [`application.properties`](https://github.com/DependencyTrack/hyades/blob/main/mirror-service/src/main/resources/application.properties)
 > for a complete overview of available config options.
 
 [Quarkus docs]: https://quarkus.io/guides/config-reference#configuration-sources

--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -42,6 +42,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-docker</artifactId>
         </dependency>
         <dependency>

--- a/mirror-service/src/main/resources/application.properties
+++ b/mirror-service/src/main/resources/application.properties
@@ -3,6 +3,11 @@
 quarkus.application.name=hyades-mirror-service
 quarkus.http.port=8093
 
+## Logging
+#
+quarkus.log.console.json=false
+quarkus.log.category."org.apache.kafka".level=WARN
+
 ## Native Image
 #
 quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl
@@ -30,7 +35,6 @@ quarkus.kafka-streams.topics=\
   ${api.topic.prefix}dtrack.vulnerability.mirror.command,\
   ${api.topic.prefix}dtrack.vulnerability.mirror.state
 %dev.quarkus.kafka.devservices.enabled=false
-quarkus.log.category."org.apache.kafka".level=WARN
 kafka-streams.num.stream.threads=3
 kafka-streams.commit.interval.ms=1000
 kafka-streams.default.deserialization.exception.handler=org.apache.kafka.streams.errors.LogAndContinueExceptionHandler

--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-logging-json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-all</artifactId>
     </dependency>

--- a/notification-publisher/src/main/resources/application.properties
+++ b/notification-publisher/src/main/resources/application.properties
@@ -3,17 +3,18 @@
 quarkus.application.name=hyades-notification-publisher
 quarkus.http.port=8090
 
+## Logging
+#
+quarkus.log.console.json=false
+quarkus.log.category."org.apache.kafka".level=WARN
+quarkus.log.category."pl.tlinkowski.unij".level=ERROR
+
 ## Native Image
 #
 quarkus.native.additional-build-args=\
   -H:IncludeResources=META-INF/services/pl.tlinkowski.unij.service.api.collect.UnmodifiableListFactory,\
   -H:IncludeResources=META-INF/services/pl.tlinkowski.unij.service.api.collect.UnmodifiableMapFactory,\
   -H:IncludeResources=META-INF/services/pl.tlinkowski.unij.service.api.collect.UnmodifiableSetFactory
-
-## Logging
-#
-quarkus.log.category."org.apache.kafka".level=WARN
-quarkus.log.category."pl.tlinkowski.unij".level=ERROR
 
 ## Kafka
 #

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -71,6 +71,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-logging-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/repository-meta-analyzer/src/main/resources/application.properties
+++ b/repository-meta-analyzer/src/main/resources/application.properties
@@ -3,6 +3,11 @@
 quarkus.application.name=hyades-repository-meta-analyzer
 quarkus.http.port=8091
 
+## Logging
+#
+quarkus.log.console.json=false
+quarkus.log.category."org.apache.kafka".level=WARN
+
 ## Kafka
 #
 %dev.kafka.bootstrap.servers=localhost:9092
@@ -12,7 +17,6 @@ quarkus.kafka-streams.application-server=localhost:8091
 quarkus.kafka-streams.topics=\
   ${api.topic.prefix}dtrack.repo-meta-analysis.component,\
   ${api.topic.prefix}dtrack.repo-meta-analysis.result
-quarkus.log.category."org.apache.kafka".level=WARN
 kafka.retry-attempts=2
 kafka-streams.cache.max.bytes.buffering=10240
 kafka-streams.commit.interval.ms=1000

--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -53,6 +53,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -3,6 +3,11 @@
 quarkus.application.name=hyades-vulnerability-analyzer
 quarkus.http.port=8092
 
+## Logging
+#
+quarkus.log.console.json=false
+quarkus.log.category."org.apache.kafka".level=WARN
+
 ## Kafka
 #
 %dev.kafka.bootstrap.servers=localhost:9092
@@ -14,7 +19,6 @@ quarkus.kafka-streams.topics=\
   ${api.topic.prefix}dtrack.vuln-analysis.scanner.result,\
   ${api.topic.prefix}dtrack.vuln-analysis.result
 
-quarkus.log.category."org.apache.kafka".level=WARN
 quarkus.kafka.snappy.enabled=true
 kafka.retry-attempts=2
 kafka-streams.topology.optimization=all


### PR DESCRIPTION
Defaults to off in order to be more human-readable.

Example log entry:

```json
{"timestamp":"2023-06-23T11:55:24.627+02:00","sequence":2333,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus.deployment.dev.RuntimeUpdatesProcessor","level":"INFO","message":"Live reload total time: 1.348s ","threadName":"Aesh InputStream Reader","threadId":91,"mdc":{},"ndc":"","hostName":"ctrl","processName":"mirror-service-dev.jar","processId":33646}
```

Closes #618