### PR TITLE
Fix native image tests for mirror-service

### DIFF
--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/AbstractDatasourceMirror.java
@@ -101,6 +101,7 @@ public abstract class AbstractDatasourceMirror<T> implements DatasourceMirror {
         // TODO: Maybe perform some more validation here?
 
         final String recordKey = "%s/%s".formatted(datasource, vulnId);
+        LoggerFactory.getLogger(getClass()).info("Serializing " + bov);
         final byte[] serializedBov = bovSerializer.serialize("", bov);
         final byte[] bovDigest = DigestUtils.getSha256Digest().digest(serializedBov);
 

--- a/mirror-service/src/main/resources/application.properties
+++ b/mirror-service/src/main/resources/application.properties
@@ -5,7 +5,11 @@ quarkus.http.port=8093
 
 ## Native Image
 #
-quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl
+quarkus.native.additional-build-args=\
+  --initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl,\
+  -H:IncludeResources=securityAdvisories.mustache,\
+  -H:IncludeResources=securityAdvisoryVulnerabilities.mustache,\
+  -H:IncludeResources=securityAdvisoryCwes.mustache
 
 ## Kafka
 #

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/KafkaStreamsTopologyIT.java
@@ -10,6 +10,7 @@ import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import jakarta.ws.rs.core.MediaType;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -24,6 +25,7 @@ import org.hyades.util.WireMockTestResource.InjectWireMock;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.List;
@@ -205,7 +207,7 @@ class KafkaStreamsTopologyIT {
                     .withGroupId(TestConstants.CONSUMER_GROUP_ID)
                     .withAutoCommit()
                     .fromTopics(KafkaTopic.NEW_VULNERABILITY.getName(), 3, Duration.ofSeconds(15))
-                    .awaitCompletion()
+                    .awaitCompletion((throwable, canceled) -> LoggerFactory.getLogger(KafkaStreamsTopologyIT.class).error(ExceptionUtils.getStackTrace(throwable)))
                     .getRecords();
 
             // Ensure the vulnerability details are correct.

--- a/notification-publisher/src/main/java/org/hyades/notification/config/ProtoReflectionConfiguration.java
+++ b/notification-publisher/src/main/java/org/hyades/notification/config/ProtoReflectionConfiguration.java
@@ -8,6 +8,7 @@ import org.hyades.proto.notification.v1.Bom;
 import org.hyades.proto.notification.v1.BomConsumedOrProcessedSubject;
 import org.hyades.proto.notification.v1.BomProcessingFailedSubject;
 import org.hyades.proto.notification.v1.Component;
+import org.hyades.proto.notification.v1.ComponentVulnAnalysisCompleteSubject;
 import org.hyades.proto.notification.v1.Group;
 import org.hyades.proto.notification.v1.Level;
 import org.hyades.proto.notification.v1.NewVulnerabilitySubject;
@@ -20,6 +21,7 @@ import org.hyades.proto.notification.v1.PolicyViolationAnalysis;
 import org.hyades.proto.notification.v1.PolicyViolationAnalysisDecisionChangeSubject;
 import org.hyades.proto.notification.v1.PolicyViolationSubject;
 import org.hyades.proto.notification.v1.Project;
+import org.hyades.proto.notification.v1.ProjectVulnAnalysisCompleteSubject;
 import org.hyades.proto.notification.v1.Scope;
 import org.hyades.proto.notification.v1.VexConsumedOrProcessedSubject;
 import org.hyades.proto.notification.v1.Vulnerability;
@@ -38,6 +40,7 @@ import org.hyades.proto.notification.v1.VulnerabilityAnalysisDecisionChangeSubje
                 BomConsumedOrProcessedSubject.class,
                 BomProcessingFailedSubject.class,
                 Component.class,
+                ComponentVulnAnalysisCompleteSubject.class,
                 Group.class,
                 NewVulnerabilitySubject.class,
                 NewVulnerableDependencySubject.class,
@@ -50,6 +53,7 @@ import org.hyades.proto.notification.v1.VulnerabilityAnalysisDecisionChangeSubje
                 PolicyViolationAnalysisDecisionChangeSubject.class,
                 PolicyViolationSubject.class,
                 Project.class,
+                ProjectVulnAnalysisCompleteSubject.class,
                 Scope.class,
                 Timestamp.class,
                 VexConsumedOrProcessedSubject.class,

--- a/proto/src/main/java/org/hyades/proto/KafkaProtobufSerializer.java
+++ b/proto/src/main/java/org/hyades/proto/KafkaProtobufSerializer.java
@@ -4,6 +4,9 @@ import com.google.protobuf.MessageLite;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 public class KafkaProtobufSerializer<T extends MessageLite> implements Serializer<T> {
 
     @Override
@@ -12,9 +15,10 @@ public class KafkaProtobufSerializer<T extends MessageLite> implements Serialize
             return null;
         }
 
-        try {
-            return data.toByteArray();
-        } catch (RuntimeException e) {
+        try (final var outStream = new ByteArrayOutputStream()) {
+            data.writeTo(outStream);
+            return outStream.toByteArray();
+        } catch (IOException | RuntimeException e) {
             throw new SerializationException(e);
         }
     }

--- a/proto/src/test/java/org/hyades/proto/KafkaProtobufSerdeTest.java
+++ b/proto/src/test/java/org/hyades/proto/KafkaProtobufSerdeTest.java
@@ -5,12 +5,15 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.hyades.proto.vulnanalysis.v1.Component;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class KafkaProtobufSerdeTest {
 
@@ -38,12 +41,11 @@ class KafkaProtobufSerdeTest {
 
     @Test
     @SuppressWarnings({"resource", "rawtypes"})
-    void testSerializationException() {
+    void testSerializationException() throws IOException {
         final var serializer = new KafkaProtobufSerializer<AbstractMessageLite>();
 
         final var mockMessage = mock(AbstractMessageLite.class);
-        when(mockMessage.toByteArray())
-                .thenThrow(IllegalStateException.class);
+        doThrow(IllegalStateException.class).when(mockMessage).writeTo(any(OutputStream.class));
 
         assertThatExceptionOfType(SerializationException.class)
                 .isThrownBy(() -> serializer.serialize("topic", mockMessage))


### PR DESCRIPTION
The GitHub advisory client loads template files from classpath, which are not packaged into the native image by default.