### PR TITLE
Remove `quarkus-maven-plugin` from `commons-persistence`

### DIFF
--- a/commons-persistence/pom.xml
+++ b/commons-persistence/pom.xml
@@ -67,10 +67,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus.platform</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
The plugin is only needed for applications, but not for libs. 

At the moment, building the project with `-Pnative` will cause Quarkus to build a native executable for `commons-persistence`, unnecessarily increasing build times.