### PR TITLE
Add release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+  - title: Enhancements 🚀
+    labels:
+    - enhancement 🚀
+  - title: Bug Fixes 🐛
+    labels:
+    - bug 🐛
+  - title: Dependency Updates 🤖
+    labels:
+    - dependencies
+  - title: Other Changes
+    labels:
+    - "*"

--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -116,4 +116,4 @@ jobs:
         file: ./${{ inputs.module }}/src/main/docker/Dockerfile.native-multiarch
         platforms: linux/amd64,linux/arm64
         push: ${{ startsWith(github.repository, 'DependencyTrack/') }}
-        tags: ghcr.io/dependencytrack/hyades-${{ inputs.module }}:latest-native
+        tags: ghcr.io/dependencytrack/hyades-${{ inputs.module }}:snapshot-native

--- a/.github/workflows/publishJar.yml
+++ b/.github/workflows/publishJar.yml
@@ -33,20 +33,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ startsWith(github.repository, 'DependencyTrack/') }}
-      - name: Determine project version
-        id: determine-project-version
-        run: |-
-          PROJECT_VERSION=$(yq -p=xml '.project.version' pom.xml)
-          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_OUTPUT
       - name: Build and push container images
         run: |-
           mvn clean install -DskipTests \
             -Dquarkus.container-image.registry=ghcr.io \
-            -Dquarkus.container-image.group=dependencytrack \
-            -Dquarkus.container-image.additional-tags=latest \
+            -Dquarkus.container-image.group=${{ github.repository_owner }} \
+            -Dquarkus.container-image.additional-tags=snapshot \
             -Dquarkus.container-image.build=true \
-            -Dquarkus.container-image.push=${{ startsWith(github.repository, 'DependencyTrack/') }} \
+            -Dquarkus.container-image.push=true \
             -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64
 
   e2e-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Perform Release
       run: |-
-        git config user.name "dependencytrack-bot"
-        git config user.email "106437498+dependencytrack-bot@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         
         BUILD_ARGS=(
           '-Dcheckstyle.skip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  workflow_dispatch: { }
+
+permissions: { }
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # Required to create releases
+      packages: write # Required to push images to ghcr.io
+    if: "${{ github.repository_owner == 'DependencyTrack' }}"
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
+    - name: Set up JDK
+      uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # tag=v3.12.0
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # tag=v2.2.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # tag=v2.9.1
+      with:
+        install: true
+    - name: Docker login
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # tag=v2.2.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Perform Release
+      run: |-
+        git config user.name "dependencytrack-bot"
+        git config user.email "106437498+dependencytrack-bot@users.noreply.github.com"
+        
+        BUILD_ARGS=(
+          '-Dcheckstyle.skip'
+          '-DskipTests'
+          '-Dquarkus.container-image.registry=ghcr.io'
+          "-Dquarkus.container-image.group=${{ github.repository_owner }}"
+          '-Dquarkus.container-image.additional-tags=latest'
+          '-Dquarkus.container-image.build=true'
+          '-Dquarkus.container-image.push=true'
+          '-Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64'
+        )
+        
+        mvn -B release:prepare \
+          -DpreparationGoals="clean cyclonedx:makeBom verify" \
+          -Darguments="${BUILD_ARGS[*]}"
+    - name: Determine Release Tag
+      id: determine-release-tag
+      run: |-
+        TAG_NAME="$(sed -nr 's/^scm.tag=(v[0-9.]+)$/\1/p' release.properties)"
+        echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_OUTPUT
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |-
+        gh release create "${{ steps.determine-release-tag.outputs.TAG_NAME }}" \
+          --target ${{ github.ref_name }} \
+          --verify-tag \
+          --generate-notes
+    - name: Upload BOMs to GitHub Release
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |-
+        gh release upload "${{ steps.determine-release-tag.outputs.TAG_NAME }}" \
+          ./*/target/*.cdx.json --clobber

--- a/commons-kstreams/pom.xml
+++ b/commons-kstreams/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>commons-kstreams</artifactId>
 
     <properties>
+        <cyclonedx.skip>true</cyclonedx.skip>
         <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
     </properties>
 

--- a/commons-persistence/pom.xml
+++ b/commons-persistence/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>commons-persistence</artifactId>
 
     <properties>
+        <cyclonedx.skip>true</cyclonedx.skip>
         <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
     </properties>
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -7,12 +7,10 @@
     <artifactId>hyades</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
-
   <artifactId>commons</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
 
   <properties>
+    <cyclonedx.skip>true</cyclonedx.skip>
     <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
   </properties>
 

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -10,6 +10,10 @@
     </parent>
     <artifactId>e2e</artifactId>
 
+    <properties>
+        <cyclonedx.skip>true</cyclonedx.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -7,9 +7,7 @@
     <artifactId>hyades</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
-
   <artifactId>notification-publisher</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
 
   <properties>
     <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:https://github.com/DependencyTrack/hyades.git</connection>
-    <url>https://github.com/DependencyTrack/hyades.git</url>
-    <developerConnection>scm:git:https://github.com/DependencyTrack/hyades.git</developerConnection>
+    <connection>${scm.connection}</connection>
+    <developerConnection>${scm.developer.connection}</developerConnection>
+    <url>${scm.url}</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -76,6 +76,11 @@
 
     <!-- Tool Versions -->
     <tool.protoc.version>com.google.protobuf:protoc:3.21.12</tool.protoc.version>
+
+    <!-- Default SCM Properties -->
+    <scm.connection>scm:git:ssh://git@github.com/DependencyTrack/hyades.git</scm.connection>
+    <scm.developer.connection>scm:git:ssh://git@github.com/DependencyTrack/hyades.git</scm.developer.connection>
+    <scm.url>https://github.com/DependencyTrack/hyades.git</scm.url>
 
     <!-- SonarCloud -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -461,6 +466,33 @@
       <properties>
         <skipITs>false</skipITs>
         <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+
+    <profile>
+      <!--
+        When running in GitHub Actions, the SCM connection must be via HTTPS
+        so that the GITHUB_TOKEN injected by Actions can be used to authenticate.
+        In other environments, SSH keys should be used instead.
+
+        Additionally, this allows for SCM connections to be dependent on the
+        repository the GHA workflow is executed on, making it possible to test
+        the e.g. the release process in forks, without having to modify the POM.
+
+        For details on the environment variables used, see:
+          https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      -->
+      <id>github-actions</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <scm.connection>scm:git:https://github.com/${env.GITHUB_REPOSITORY}.git</scm.connection>
+        <scm.developer.connection>scm:git:https://github.com/${env.GITHUB_REPOSITORY}.git</scm.developer.connection>
+        <scm.url>https://github.com/${env.GITHUB_REPOSITORY}.git</scm.url>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,21 @@
     <module>e2e</module>
   </modules>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/DependencyTrack/hyades.git</connection>
+    <url>https://github.com/DependencyTrack/hyades.git</url>
+    <developerConnection>scm:git:https://github.com/DependencyTrack/hyades.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
   <properties>
     <!-- General Project Properties -->
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
@@ -55,6 +70,7 @@
     <lib.log4j-over-slf4j.version>2.0.7</lib.log4j-over-slf4j.version>
 
     <!-- Plugin Versions -->
+    <plugin.cyclonedx.version>2.7.9</plugin.cyclonedx.version>
     <plugin.jacoco.version>0.8.10</plugin.jacoco.version>
     <plugin.protoc-jar.version>3.11.4</plugin.protoc-jar.version>
 
@@ -379,6 +395,28 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${plugin.cyclonedx.version}</version>
+          <configuration>
+            <outputFormat>json</outputFormat>
+            <outputName>${project.name}-${project.version}.cdx</outputName>
+            <projectType>application</projectType>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.0.1</version>
+          <configuration>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+            <projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
+            <tagNameFormat>v@{project.version}</tagNameFormat>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -10,6 +10,11 @@
     </parent>
     <artifactId>proto</artifactId>
 
+    <properties>
+        <cyclonedx.skip>true</cyclonedx.skip>
+        <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -7,9 +7,7 @@
     <artifactId>hyades</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
-
   <artifactId>repository-meta-analyzer</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
 
   <properties>
     <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>


### PR DESCRIPTION
Releases can now be triggered via GitHub UI, under *Actions* -> *Release* -> *Run Workflow*.

Beside creating a Git tag for the release, this workflow:

* Builds and pushes JVM-based container images (no native images for now)
* Creates a GitHub release with auto generated release notes
* Generates CycloneDX BOMs for all applications and attaches them to the GitHub release

An example execution can be found here: https://github.com/nscuro/hyades/actions/runs/5718792194/job/15495340977

An example release can be found here: https://github.com/nscuro/hyades/releases/tag/v1.11.0

Closes #708 