### PR TITLE
Fix native image integration tests

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -59,7 +59,7 @@ jobs:
         echo "Including resources: ${RESOURCES_INCLUDES:-None}"
         echo "Excluding resources: ${RESOURCES_EXCLUDES:-None}"
         mvn clean package -Pnative -pl commons,commons-kstreams,commons-persistence,proto,${{ inputs.module }} -DskipTests \
-          -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17 \
+          -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java17 \
           -Dquarkus.native.container-build=true \
           -Dquarkus.native.container-runtime-options='--platform=linux/${{ matrix.arch.name }}' \
           -Dquarkus.native.resources.includes="$RESOURCES_INCLUDES" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,15 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Set up GraalVM
-      uses: graalvm/setup-graalvm@v1
+      uses: graalvm/setup-graalvm@d1891786152ae96fee67f86c3a1eae596291bbed # tag=v1.1.2
       with:
-        version: 'latest'
+        # NOTE: Do NOT use the Oracle GraalVM distribution, as that is causing issues
+        # with Protobuf serialization. GraalVM Community 17.0.8 and Mandrel 23.0 have
+        # both been tested to work. We're using GraalVM CE for now because installing
+        # Mandrel via this action doesn't work quite right.
+        #   https://github.com/DependencyTrack/hyades/issues/641
+        #   https://github.com/quarkusio/quarkus/issues/35125
+        distribution: 'graalvm-community'
         java-version: '17'
         components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,5 +74,5 @@ jobs:
         mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ matrix.module }} clean install -Pnative -DskipTests
     - name: Test Native Image
       run: |-
-        mvn -pl commons,commons-persistence,proto,${{ matrix.module }} \
+        mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ matrix.module }} \
         test-compile failsafe:integration-test failsafe:verify -Pnative

--- a/mirror-service/src/main/resources/application.properties
+++ b/mirror-service/src/main/resources/application.properties
@@ -10,7 +10,11 @@ quarkus.log.category."org.apache.kafka".level=WARN
 
 ## Native Image
 #
-quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl
+quarkus.native.additional-build-args=\
+  --initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl,\
+  -H:IncludeResources=securityAdvisories.mustache,\
+  -H:IncludeResources=securityAdvisoryVulnerabilities.mustache,\
+  -H:IncludeResources=securityAdvisoryCwes.mustache
 
 ## Kafka
 #


### PR DESCRIPTION
The `graalvm/setup-graalvm` action defaults to using the new Oracle GraalVM distribution, which causes failures with Protobuf serialization.

Trying to install Mandrel using the action doesn't work; It still installs Oracle GraalVM on top of it, see for example https://github.com/DependencyTrack/hyades/actions/runs/5724111667/job/15509962852

```
Run graalvm/setup-graalvm@v1
  with:
    distribution: mandrel
    version: mandrel-latest
    java-version: 17
    components: native-image
    github-token: ***
    set-java-home: true
    check-for-updates: true
    native-image-musl: false
    native-image-job-reports: false
    native-image-pr-reports: false
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.7-7/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.7-7/x64
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/3297c16a-6e0c-4d7f-85f3-8aea9897056d -f /home/runner/work/_temp/9a492745-e727-4331-a37f-0a5e6fbdd33e
Adding mandrel-java17-linux 23.0.1.2-Final to tool-cache ...
This build is using the new Oracle GraalVM. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/a3b4128c-fd4c-4154-ac03-666871ca017c -f /home/runner/work/_temp/f19211d5-e943-476b-960a-ccc00e42e5c2
Adding graalvm-jdk-17_linux-x64_bin 17 to tool-cache ...
Warning: Mandrel does not support GraalVM components: native-image
```

Fixes https://github.com/DependencyTrack/hyades/issues/641

Relates to https://github.com/quarkusio/quarkus/issues/35125