### PR TITLE
Bump parallel consumer to 0.5.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <lib.checkstyle.version>10.12.2</lib.checkstyle.version>
     <lib.cpe-parser.version>2.0.2</lib.cpe-parser.version>
     <lib.commons-collections4.version>4.4</lib.commons-collections4.version>
-    <lib.confluent-parallel-consumer.version>0.5.2.5</lib.confluent-parallel-consumer.version>
+    <lib.confluent-parallel-consumer.version>0.5.2.6</lib.confluent-parallel-consumer.version>
     <lib.conscrypt.version>2.5.2</lib.conscrypt.version>
     <lib.cvss-calculator.version>1.4.2</lib.cvss-calculator.version>
     <lib.cyclonedx-java.version>7.3.2</lib.cyclonedx-java.version>


### PR DESCRIPTION
See https://github.com/confluentinc/parallel-consumer/releases/tag/0.5.2.6 for release notes