### PR TITLE
Fix container image group not being lower-cased

### DIFF
--- a/.github/workflows/publishJar.yml
+++ b/.github/workflows/publishJar.yml
@@ -37,7 +37,7 @@ jobs:
         run: |-
           mvn clean install -DskipTests \
             -Dquarkus.container-image.registry=ghcr.io \
-            -Dquarkus.container-image.group=${{ github.repository_owner }} \
+            -Dquarkus.container-image.group=${GITHUB_REPOSITORY_OWNER,,} \
             -Dquarkus.container-image.additional-tags=snapshot \
             -Dquarkus.container-image.build=true \
             -Dquarkus.container-image.push=true \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           '-Dcheckstyle.skip'
           '-DskipTests'
           '-Dquarkus.container-image.registry=ghcr.io'
-          "-Dquarkus.container-image.group=${{ github.repository_owner }}"
+          "-Dquarkus.container-image.group=${GITHUB_REPOSITORY_OWNER,,}"
           '-Dquarkus.container-image.additional-tags=latest'
           '-Dquarkus.container-image.build=true'
           '-Dquarkus.container-image.push=true'


### PR DESCRIPTION
Image names are not allowed to contain uppercase characters. #709 introduced a change where the `group` part of the image name would come from the GitHub repository's owner (e.g. `DependencyTrack`), which can contain uppercase characters.

Fixed by using Bash expansion on the `GITHUB_REPOSITORY_OWNER` environment variable, to convert it to lowercase.