### PR TITLE
Fix mirror task rejection causing KStreams to fail

### DIFF
--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorConfiguration.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorConfiguration.java
@@ -6,6 +6,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.hyades.vulnmirror.datasource.util.LoggingRejectedExecutionHandler;
+import org.hyades.vulnmirror.datasource.util.LoggingUncaughtExceptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -18,12 +22,15 @@ class GitHubMirrorConfiguration {
     @ApplicationScoped
     @Named("githubExecutorService")
     ExecutorService executorService() {
+        final Logger githubMirrorLogger = LoggerFactory.getLogger(GitHubMirror.class);
+
         final var threadFactory = new BasicThreadFactory.Builder()
                 .namingPattern("hyades-mirror-github-%d")
+                .uncaughtExceptionHandler(new LoggingUncaughtExceptionHandler(githubMirrorLogger))
                 .build();
 
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(1), threadFactory);
+                new LinkedBlockingQueue<>(1), threadFactory, new LoggingRejectedExecutionHandler(githubMirrorLogger));
     }
 
     @Produces

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/util/LoggingRejectedExecutionHandler.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/util/LoggingRejectedExecutionHandler.java
@@ -1,0 +1,21 @@
+package org.hyades.vulnmirror.datasource.util;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class LoggingRejectedExecutionHandler implements RejectedExecutionHandler {
+
+    private final Logger logger;
+
+    public LoggingRejectedExecutionHandler(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void rejectedExecution(final Runnable r, final ThreadPoolExecutor executor) {
+        logger.warn("A task execution was rejected; Likely because the executor's task queue is already saturated");
+    }
+
+}

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/util/LoggingUncaughtExceptionHandler.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/util/LoggingUncaughtExceptionHandler.java
@@ -1,0 +1,20 @@
+package org.hyades.vulnmirror.datasource.util;
+
+import org.slf4j.Logger;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+
+public class LoggingUncaughtExceptionHandler implements UncaughtExceptionHandler {
+
+    private final Logger logger;
+
+    public LoggingUncaughtExceptionHandler(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void uncaughtException(final Thread t, final Throwable e) {
+        logger.error("An uncaught exception occurred while processing a task", e);
+    }
+
+}

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/util/LoggingRejectedExecutionHandlerTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/util/LoggingRejectedExecutionHandlerTest.java
@@ -1,0 +1,29 @@
+package org.hyades.vulnmirror.datasource.util;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LoggingRejectedExecutionHandlerTest {
+
+    @Test
+    void testRejectedExecution() {
+        final Logger loggerMock = mock(Logger.class);
+        final var handler = new LoggingRejectedExecutionHandler(loggerMock);
+
+        handler.rejectedExecution(() -> {
+        }, null);
+
+        final ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(loggerMock).warn(messageCaptor.capture());
+
+        assertThat(messageCaptor.getValue()).isEqualTo("""
+                A task execution was rejected; Likely because the executor's \
+                task queue is already saturated""");
+    }
+
+}

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/util/LoggingUncaughtExceptionHandlerTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/util/LoggingUncaughtExceptionHandlerTest.java
@@ -1,0 +1,28 @@
+package org.hyades.vulnmirror.datasource.util;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LoggingUncaughtExceptionHandlerTest {
+
+    @Test
+    void testUncaughtException() {
+        final Logger loggerMock = mock(Logger.class);
+        final var exception = new IllegalArgumentException();
+
+        new LoggingUncaughtExceptionHandler(loggerMock).uncaughtException(null, exception);
+
+        final ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(loggerMock).error(messageCaptor.capture(), exceptionCaptor.capture());
+
+        assertThat(messageCaptor.getValue()).isEqualTo("An uncaught exception occurred while processing a task");
+        assertThat(exceptionCaptor.getValue()).isEqualTo(exception);
+    }
+
+}


### PR DESCRIPTION
Task execution rejections and otherwise uncaught exceptions are now logged, using the logger of the respective `DatasourceMirror` class.