### PR TITLE
Run e2e tests against `snapshot` tags

### DIFF
--- a/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/AbstractE2ET.java
@@ -29,9 +29,9 @@ public class AbstractE2ET {
     protected static String POSTGRES_IMAGE = "postgres:15-alpine";
     protected static String REDPANDA_IMAGE = "docker.redpanda.com/vectorized/redpanda:v23.2.2";
     protected static String API_SERVER_IMAGE = "ghcr.io/dependencytrack/hyades-apiserver:snapshot";
-    protected static String NOTIFICATION_PUBLISHER_IMAGE = "ghcr.io/dependencytrack/hyades-notification-publisher:latest";
-    protected static String REPO_META_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-repository-meta-analyzer:latest";
-    protected static String VULN_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-vulnerability-analyzer:latest";
+    protected static String NOTIFICATION_PUBLISHER_IMAGE = "ghcr.io/dependencytrack/hyades-notification-publisher:snapshot";
+    protected static String REPO_META_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-repository-meta-analyzer:snapshot";
+    protected static String VULN_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-vulnerability-analyzer:snapshot";
 
     protected Logger logger;
     private Network internalNetwork;


### PR DESCRIPTION
As of https://github.com/DependencyTrack/hyades/pull/709, unreleased `main` builds are no longer tagged as `latest`, but `snapshot` instead.