### PR TITLE
Use `dependencytrack-bot` account to push commits to `main` during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
+      with:
+        persist-credentials: false
     - name: Set up JDK
       uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # tag=v3.12.0
       with:
@@ -37,8 +39,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Perform Release
       run: |-
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "dependencytrack-bot"
+        git config user.email "106437498+dependencytrack-bot@users.noreply.github.com"
         
         BUILD_ARGS=(
           '-Dcheckstyle.skip'
@@ -53,7 +55,14 @@ jobs:
         
         mvn -B release:prepare \
           -DpreparationGoals="clean cyclonedx:makeBom verify" \
-          -Darguments="${BUILD_ARGS[*]}"
+          -Darguments="${BUILD_ARGS[*]}" \
+          -DpushChanges=false
+    - name: Push Changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: ${{ github.ref }}
+        github_token: ${{ secrets.BOT_RELEASE_TOKEN }}
+        tags: true
     - name: Determine Release Tag
       id: determine-release-tag
       run: |-
@@ -61,7 +70,7 @@ jobs:
         echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_OUTPUT
     - name: Create GitHub Release
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        GITHUB_TOKEN: "${{ secrets.BOT_RELEASE_TOKEN }}"
       run: |-
         gh release create "${{ steps.determine-release-tag.outputs.TAG_NAME }}" \
           --target ${{ github.ref_name }} \
@@ -69,7 +78,7 @@ jobs:
           --generate-notes
     - name: Upload BOMs to GitHub Release
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        GITHUB_TOKEN: "${{ secrets.BOT_RELEASE_TOKEN }}"
       run: |-
         gh release upload "${{ steps.determine-release-tag.outputs.TAG_NAME }}" \
           ./*/target/*.cdx.json --clobber


### PR DESCRIPTION
GitHub Actions can't be added to accounts that are allowed by bypass branch protection rules.