### PR TITLE
Fix random BOM refs in BOVs produced by mirror-service 

### DIFF
--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -70,6 +70,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.uuid</groupId>
+            <artifactId>java-uuid-generator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
         </dependency>
@@ -102,6 +107,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jacoco</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubAdvisoryToCdxParser.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/github/GitHubAdvisoryToCdxParser.java
@@ -1,5 +1,6 @@
 package org.hyades.vulnmirror.datasource.github;
 
+import com.fasterxml.uuid.Generators;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
@@ -37,6 +38,7 @@ import static org.hyades.vulnmirror.datasource.util.ParserUtil.mapSeverity;
 public class GitHubAdvisoryToCdxParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHubAdvisoryToCdxParser.class);
+    private static final UUID UUID_V5_NAMESPACE = UUID.fromString("d13c94df-c6b7-4e5c-9d5b-96d77078eee8");
 
     public static Bom parse(final SecurityAdvisory advisory, boolean aliasSyncEnabled) {
         final Vulnerability.Builder vuln = Vulnerability.newBuilder()
@@ -86,7 +88,7 @@ public class GitHubAdvisoryToCdxParser {
                 VulnerabilityAffects.Builder vulnerabilityAffects = VulnerabilityAffects.newBuilder();
                 String bomRef = getBomRefIfComponentExists(bom.build(), purl.getCoordinates());
                 if (bomRef == null) {
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = Generators.nameBasedGenerator(UUID_V5_NAMESPACE).generate(purl.getCoordinates());
                     Component component = Component.newBuilder()
                             .setBomRef(uuid.toString())
                             .setPurl(purl.getCoordinates())

--- a/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
+++ b/mirror-service/src/main/java/org/hyades/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
@@ -1,5 +1,6 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
+import com.fasterxml.uuid.Generators;
 import com.google.protobuf.Timestamp;
 import io.github.jeremylong.openvulnerability.client.nvd.Config;
 import io.github.jeremylong.openvulnerability.client.nvd.CpeMatch;
@@ -43,6 +44,8 @@ import static org.hyades.vulnmirror.datasource.util.ParserUtil.mapSeverity;
  * Parser and processor of NVD data feeds.
  */
 public final class NvdToCyclonedxParser {
+
+    private static final UUID UUID_V5_NAMESPACE = UUID.fromString("cb83f395-69ff-4b1c-83f9-c461ebd06279");
 
     public static class BovWrapper<T> {
         public final Bom bov;
@@ -152,7 +155,8 @@ public final class NvdToCyclonedxParser {
                 return new BovWrapper(cdxBom, existingComponent.get().getBomRef());
             }
         }
-        UUID uuid = UUID.randomUUID();
+
+        UUID uuid = Generators.nameBasedGenerator(UUID_V5_NAMESPACE).generate(cpe);
         Component component = Component.newBuilder()
                 .setBomRef(uuid.toString())
                 .setCpe(cpe)

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
@@ -154,6 +154,9 @@ class GitHubMirrorTest {
             assertThat(record.value()).isNotNull();
         });
 
+        // FIXME: rating.score should not report 0.0 when neither a vector, nor a pre-calculated score is provided by the source
+        // FIXME: affects should not have duplicate entries for the same ref; Accumulate multiple versions under one affects node instead
+        // FIXME: vers ranges should not include whitespace
         assertThatJson(JsonFormat.printer().print(vulnRecords.get(0).value()))
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
                 .withMatcher("vuln-description", Matchers.allOf(

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/github/GitHubMirrorTest.java
@@ -1,19 +1,21 @@
 package org.hyades.vulnmirror.datasource.github;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
 import io.github.jeremylong.openvulnerability.client.ghsa.GitHubSecurityAdvisoryClient;
 import io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisory;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import jakarta.inject.Inject;
+import net.javacrumbs.jsonunit.core.Option;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.cyclonedx.proto.v1_4.Bom;
-import org.cyclonedx.proto.v1_4.Vulnerability;
+import org.hamcrest.Matchers;
 import org.hyades.common.KafkaTopic;
 import org.hyades.proto.KafkaProtobufSerde;
 import org.hyades.proto.notification.v1.Notification;
@@ -26,6 +28,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -146,17 +149,79 @@ class GitHubMirrorTest {
                 .awaitCompletion()
                 .getRecords();
 
-        assertThat(vulnRecords).satisfiesExactly(
-                record -> {
-                    assertThat(record.key()).isEqualTo("GITHUB/GHSA-fxwm-579q-49qq");
-                    assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+        assertThat(vulnRecords).satisfiesExactly(record -> {
+            assertThat(record.key()).isEqualTo("GITHUB/GHSA-fxwm-579q-49qq");
+            assertThat(record.value()).isNotNull();
+        });
 
-                    final Vulnerability vuln = record.value().getVulnerabilities(0);
-                    assertThat(vuln.getId()).isEqualTo("GHSA-fxwm-579q-49qq");
-                    assertThat(vuln.hasSource()).isTrue();
-                    assertThat(vuln.getSource().getName()).isEqualTo("GITHUB");
-                }
-        );
+        assertThatJson(JsonFormat.printer().print(vulnRecords.get(0).value()))
+                .withOptions(Option.IGNORING_ARRAY_ORDER)
+                .withMatcher("vuln-description", Matchers.allOf(
+                        Matchers.startsWith("In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1,"),
+                        Matchers.hasLength(219)))
+                .isEqualTo("""
+                        {
+                          "components": [
+                            {
+                              "bomRef": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                              "purl": "pkg:nuget/bootstrap"
+                            },
+                            {
+                              "bomRef": "e5dc290a-c649-5f73-b814-c9a47690a48a",
+                              "purl": "pkg:nuget/bootstrap.sass"
+                            },
+                            {
+                              "bomRef": "c8e5d671-0b0d-5fda-a404-730615325a7f",
+                              "purl": "pkg:nuget/Bootstrap.Less"
+                            }
+                          ],
+                          "vulnerabilities": [
+                            {
+                              "id": "GHSA-fxwm-579q-49qq",
+                              "source": { "name": "GITHUB" },
+                              "description": "${json-unit.matches:vuln-description}",
+                              "detail": "Moderate severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass",
+                              "published": "2019-02-22T20:54:40Z",
+                              "updated": "2021-12-03T14:54:43Z",
+                              "ratings": [
+                                {
+                                  "severity": "SEVERITY_MEDIUM",
+                                  "score": 0.0
+                                }
+                              ],
+                              "affects": [
+                                {
+                                  "ref": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                                  "versions": [
+                                    { "range": "vers:nuget/>= 3.0.0|< 3.4.1" }
+                                  ]
+                                },
+                                {
+                                  "ref": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                                  "versions": [
+                                    { "range": "vers:nuget/>= 4.0.0|< 4.3.1" }
+                                  ]
+                                },
+                                {
+                                  "ref": "e5dc290a-c649-5f73-b814-c9a47690a48a",
+                                  "versions": [
+                                    { "range": "vers:nuget/< 4.3.1" }
+                                  ]
+                                },
+                                {
+                                  "ref": "c8e5d671-0b0d-5fda-a404-730615325a7f",
+                                  "versions": [
+                                    { "range": "vers:nuget/>= 3.0.0|< 3.4.1" }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "externalReferences": [
+                            { "url": "https://github.com/advisories/GHSA-fxwm-579q-49qq" }
+                          ]
+                        }
+                        """);
 
         // Trigger a mirror operation one more time.
         // Verify that this time the previously stored "last updated" timestamp is used.

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/nvd/NvdMirrorTest.java
@@ -1,20 +1,23 @@
 package org.hyades.vulnmirror.datasource.nvd;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
 import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
 import io.github.jeremylong.openvulnerability.client.nvd.NvdApiException;
 import io.github.jeremylong.openvulnerability.client.nvd.NvdCveClient;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import jakarta.inject.Inject;
+import net.javacrumbs.jsonunit.core.Option;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.cyclonedx.proto.v1_4.Bom;
 import org.cyclonedx.proto.v1_4.Vulnerability;
+import org.hamcrest.Matchers;
 import org.hyades.common.KafkaTopic;
 import org.hyades.proto.KafkaProtobufSerde;
 import org.hyades.proto.notification.v1.Notification;
@@ -28,6 +31,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -142,7 +146,7 @@ class NvdMirrorTest {
         assertThatNoException().isThrownBy(() -> nvdMirror.mirrorInternal());
         verify(apiClientFactoryMock).createApiClient(eq(0L));
 
-        final List<ConsumerRecord<String, Bom>> vulnRecords = kafkaCompanion
+        final List<ConsumerRecord<String, Bom>> bovRecords = kafkaCompanion
                 .consume(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser()))
                 .withGroupId(TestConstants.CONSUMER_GROUP_ID)
                 .withAutoCommit()
@@ -150,17 +154,55 @@ class NvdMirrorTest {
                 .awaitCompletion()
                 .getRecords();
 
-        assertThat(vulnRecords).satisfiesExactly(
-                record -> {
-                    assertThat(record.key()).isEqualTo("NVD/CVE-2022-40489");
-                    assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+        assertThat(bovRecords).satisfiesExactly(record -> {
+            assertThat(record.key()).isEqualTo("NVD/CVE-2022-40489");
+            assertThat(record.value()).isNotNull();
+        });
 
-                    final Vulnerability vuln = record.value().getVulnerabilities(0);
-                    assertThat(vuln.getId()).isEqualTo("CVE-2022-40489");
-                    assertThat(vuln.hasSource()).isTrue();
-                    assertThat(vuln.getSource().getName()).isEqualTo("NVD");
-                }
-        );
+        assertThatJson(JsonFormat.printer().print(bovRecords.get(0).value()))
+                .withOptions(Option.IGNORING_ARRAY_ORDER)
+                .withMatcher("vuln-description", Matchers.allOf(
+                        Matchers.startsWith("ThinkCMF version 6.0.7 is affected by a"),
+                        Matchers.hasLength(168)))
+                .isEqualTo("""
+                        {
+                          "components": [
+                            {
+                              "bomRef": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                              "cpe": "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*"
+                            }
+                          ],
+                          "vulnerabilities": [
+                            {
+                              "id": "CVE-2022-40489",
+                              "source": { "name": "NVD" },
+                              "description": "${json-unit.matches:vuln-description}",
+                              "cwes": [ 352 ],
+                              "published": "2022-12-01T05:15:11Z",
+                              "updated": "2022-12-02T17:17:02Z",
+                              "ratings": [
+                                {
+                                  "method": "SCORE_METHOD_CVSSV31",
+                                  "score": 8.8,
+                                  "severity": "SEVERITY_HIGH",
+                                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                                }
+                              ],
+                              "affects": [
+                                {
+                                  "ref": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                                  "versions": [
+                                    { "version": "6.0.7" }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "externalReferences": [
+                            { "url": "https://github.com/thinkcmf/thinkcmf/issues/736" }
+                          ]
+                        }
+                        """);
 
         // Trigger a mirror operation one more time.
         // Verify that this time the previously stored "last updated" timestamp is used.

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/osv/OsvMirrorTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/osv/OsvMirrorTest.java
@@ -1,16 +1,18 @@
 package org.hyades.vulnmirror.datasource.osv;
 
+import com.google.protobuf.util.JsonFormat;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import jakarta.inject.Inject;
+import net.javacrumbs.jsonunit.core.Option;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.cyclonedx.proto.v1_4.Bom;
-import org.cyclonedx.proto.v1_4.Vulnerability;
+import org.hamcrest.Matchers;
 import org.hyades.common.KafkaTopic;
 import org.hyades.proto.KafkaProtobufSerde;
 import org.hyades.proto.notification.v1.Notification;
@@ -25,6 +27,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.List;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -152,17 +155,51 @@ class OsvMirrorTest {
                 .awaitCompletion()
                 .getRecords();
 
-        assertThat(vulnRecords).satisfiesExactly(
-                record -> {
-                    assertThat(record.key()).isEqualTo("OSV/GO-2020-0023");
-                    assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+        assertThat(vulnRecords).satisfiesExactly(record -> {
+            assertThat(record.key()).isEqualTo("OSV/GO-2020-0023");
+            assertThat(record.value()).isNotNull();
+        });
 
-                    final Vulnerability vuln = record.value().getVulnerabilities(0);
-                    assertThat(vuln.getId()).isEqualTo("GO-2020-0023");
-                    assertThat(vuln.hasSource()).isTrue();
-                    assertThat(vuln.getSource().getName()).isEqualTo("OSV");
-                }
-        );
+        assertThatJson(JsonFormat.printer().print(vulnRecords.get(0).value()))
+                .withOptions(Option.IGNORING_ARRAY_ORDER)
+                .withMatcher("vuln-description", Matchers.allOf(
+                        Matchers.startsWith("Token validation methods are susceptible to"),
+                        Matchers.hasLength(216)))
+                .isEqualTo("""
+                        {
+                          "components": [
+                            {
+                              "bomRef": "2aa501b7-09d2-5bb7-88cc-41d599869255",
+                              "name": "github.com/robbert229/jwt",
+                              "purl": "pkg:golang/github.com/robbert229/jwt"
+                            }
+                          ],
+                          "vulnerabilities": [
+                            {
+                              "id": "GO-2020-0023",
+                              "source": { "name": "OSV" },
+                              "detail": "${json-unit.matches:vuln-description}",
+                              "published": "2022-06-09T07:01:32Z",
+                              "updated": "2022-06-09T07:01:32Z",
+                              "ratings": [
+                                { "severity": "SEVERITY_UNKNOWN" }
+                              ],
+                              "affects": [
+                                {
+                                  "ref": "2aa501b7-09d2-5bb7-88cc-41d599869255",
+                                  "versions": [
+                                    { "range": "vers:golang/>=0|<0.0.0-20170426191122-ca1404ee6e83" }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "externalReferences": [
+                            { "url": "https://github.com/robbert229/jwt/commit/ca1404ee6e83fcbafb66b09ed0d543850a15b654" },
+                            { "url": "https://github.com/robbert229/jwt/issues/12" }
+                          ]
+                        }
+                        """);
     }
 
     @Test
@@ -182,17 +219,130 @@ class OsvMirrorTest {
                 .awaitCompletion()
                 .getRecords();
 
-        assertThat(vulnRecords).satisfiesExactly(
-                record -> {
-                    assertThat(record.key()).isEqualTo("OSV/GHSA-2cc5-23r7-vc4v");
-                    assertThat(record.value().getVulnerabilitiesCount()).isEqualTo(1);
+        assertThat(vulnRecords).satisfiesExactly(record -> {
+            assertThat(record.key()).isEqualTo("OSV/GHSA-2cc5-23r7-vc4v");
+            assertThat(record.value()).isNotNull();
+        });
 
-                    final Vulnerability vuln = record.value().getVulnerabilities(0);
-                    assertThat(vuln.getId()).isEqualTo("GHSA-2cc5-23r7-vc4v");
-                    assertThat(vuln.hasSource()).isTrue();
-                    assertThat(vuln.getSource().getName()).isEqualTo("GITHUB");
-                }
-        );
+        assertThatJson(JsonFormat.printer().print(vulnRecords.get(0).value()))
+                .withOptions(Option.IGNORING_ARRAY_ORDER)
+                .withMatcher("vuln-description", Matchers.allOf(
+                        Matchers.startsWith("### Impact"),
+                        Matchers.hasLength(952)))
+                .isEqualTo("""
+                        {
+                          "components": [
+                            {
+                              "bomRef": "2a24a29f-9ff3-52b8-bc81-471f326a5b3e",
+                              "name": "io.ratpack:ratpack-session",
+                              "purl": "pkg:maven/io.ratpack/ratpack-session"
+                            }
+                          ],
+                          "vulnerabilities": [
+                            {
+                              "id": "GHSA-2cc5-23r7-vc4v",
+                              "source": { "name": "GITHUB" },
+                              "description": "Ratpack's default client side session signing key is highly predictable",
+                              "detail": "${json-unit.matches:vuln-description}",
+                              "cwes": [ 330, 340 ],
+                              "published": "2021-07-01T17:02:26Z",
+                              "updated": "2023-03-28T05:45:27Z",
+                              "ratings": [
+                                {
+                                  "method": "SCORE_METHOD_CVSSV3",
+                                  "score": 4.4,
+                                  "severity": "SEVERITY_MEDIUM",
+                                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+                                }
+                              ],
+                              "advisories": [
+                                { "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-29480" }
+                              ],
+                              "affects": [
+                                {
+                                  "ref": "2a24a29f-9ff3-52b8-bc81-471f326a5b3e",
+                                  "versions": [
+                                    { "range": "vers:maven/>=0|<1.9.0" },
+                                    { "version": "0.9.0" },
+                                    { "version": "0.9.1" },
+                                    { "version": "0.9.10" },
+                                    { "version": "0.9.11" },
+                                    { "version": "0.9.12" },
+                                    { "version": "0.9.13" },
+                                    { "version": "0.9.14" },
+                                    { "version": "0.9.15" },
+                                    { "version": "0.9.16" },
+                                    { "version": "0.9.17" },
+                                    { "version": "0.9.18" },
+                                    { "version": "0.9.19" },
+                                    { "version": "0.9.2" },
+                                    { "version": "0.9.3" },
+                                    { "version": "0.9.4" },
+                                    { "version": "0.9.5" },
+                                    { "version": "0.9.6" },
+                                    { "version": "0.9.7" },
+                                    { "version": "0.9.8" },
+                                    { "version": "0.9.9" },
+                                    { "version": "1.0.0" },
+                                    { "version": "1.0.0-rc-1" },
+                                    { "version": "1.0.0-rc-2" },
+                                    { "version": "1.0.0-rc-3" },
+                                    { "version": "1.1.0" },
+                                    { "version": "1.1.1" },
+                                    { "version": "1.2.0" },
+                                    { "version": "1.2.0-RC-1" },
+                                    { "version": "1.2.0-rc-2" },
+                                    { "version": "1.3.0" },
+                                    { "version": "1.3.0-rc-1" },
+                                    { "version": "1.3.0-rc-2" },
+                                    { "version": "1.3.1" },
+                                    { "version": "1.3.2" },
+                                    { "version": "1.3.3" },
+                                    { "version": "1.4.0" },
+                                    { "version": "1.4.0-rc-1" },
+                                    { "version": "1.4.0-rc-2" },
+                                    { "version": "1.4.0-rc-3" },
+                                    { "version": "1.4.1" },
+                                    { "version": "1.4.2" },
+                                    { "version": "1.4.3" },
+                                    { "version": "1.4.4" },
+                                    { "version": "1.4.5" },
+                                    { "version": "1.4.6" },
+                                    { "version": "1.5.0" },
+                                    { "version": "1.5.1" },
+                                    { "version": "1.5.2" },
+                                    { "version": "1.5.3" },
+                                    { "version": "1.5.4" },
+                                    { "version": "1.6.0" },
+                                    { "version": "1.6.0-rc-1" },
+                                    { "version": "1.6.0-rc-2" },
+                                    { "version": "1.6.0-rc-3" },
+                                    { "version": "1.6.0-rc-4" },
+                                    { "version": "1.6.1" },
+                                    { "version": "1.7.0" },
+                                    { "version": "1.7.1" },
+                                    { "version": "1.7.2" },
+                                    { "version": "1.7.3" },
+                                    { "version": "1.7.4" },
+                                    { "version": "1.7.5" },
+                                    { "version": "1.7.6" },
+                                    { "version": "1.8.0" },
+                                    { "version": "1.8.1" },
+                                    { "version": "1.8.2" },
+                                    { "version": "1.9.0-rc-1" },
+                                    { "version": "1.9.0-rc-2" }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "externalReferences": [
+                            { "url": "https://github.com/ratpack/ratpack/security/advisories/GHSA-2cc5-23r7-vc4v" },
+                            { "url": "https://github.com/ratpack/ratpack" },
+                            { "url": "https://github.com/ratpack/ratpack/blob/29434f7ac6fd4b36a4495429b70f4c8163100332/ratpack-session/src/main/java/ratpack/session/clientside/ClientSideSessionConfig.java#L29" }
+                          ]
+                        }
+                        """);
     }
 
 

--- a/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/osv/OsvMirrorTest.java
+++ b/mirror-service/src/test/java/org/hyades/vulnmirror/datasource/osv/OsvMirrorTest.java
@@ -224,6 +224,7 @@ class OsvMirrorTest {
             assertThat(record.value()).isNotNull();
         });
 
+        // FIXME: Individual versions should not be listed when a range is provided by the source
         assertThatJson(JsonFormat.printer().print(vulnRecords.get(0).value()))
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
                 .withMatcher("vuln-description", Matchers.allOf(

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <lib.cyclonedx-java.version>7.3.2</lib.cyclonedx-java.version>
     <lib.failsafe.version>3.3.2</lib.failsafe.version>
     <lib.greenmail.version>2.0.0</lib.greenmail.version>
+    <lib.java-uuid-generator.version>4.2.0</lib.java-uuid-generator.version>
     <lib.json-unit.version>3.0.0</lib.json-unit.version>
     <lib.kafka.version>3.5.1</lib.kafka.version>
     <lib.maven-artifact.version>4.0.0-alpha-7</lib.maven-artifact.version>
@@ -146,6 +147,12 @@
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-core-java</artifactId>
         <version>${lib.cyclonedx-java.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.uuid</groupId>
+        <artifactId>java-uuid-generator</artifactId>
+        <version>${lib.java-uuid-generator.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Use UUIDv5 over UUIDv4 in order to have stable BOM refs being generated given the same input.

Fixes #750