### PR TITLE
Fix breaking change in `NEW_VULNERABILITY` notification JSON format

### DIFF
--- a/e2e/src/main/java/org/hyades/apiserver/model/CreateVulnerabilityRequest.java
+++ b/e2e/src/main/java/org/hyades/apiserver/model/CreateVulnerabilityRequest.java
@@ -2,7 +2,7 @@ package org.hyades.apiserver.model;
 
 import java.util.List;
 
-public record CreateVulnerabilityRequest(String vulnId, List<AffectedComponent> affectedComponents) {
+public record CreateVulnerabilityRequest(String vulnId, String cvssV3Vector, List<Integer> cwes, List<AffectedComponent> affectedComponents) {
 
     public record AffectedComponent(String identityType, String identity, String versionType) {
     }

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
@@ -200,7 +200,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                             "level": "LEVEL_INFORMATIONAL",
                             "scope": "SCOPE_PORTFOLIO",
                             "group": "GROUP_NEW_VULNERABILITY",
-                            "timestamp": "${json-unit.any-string}",
+                            "timestamp": "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$)",
                             "title": "New Vulnerability Identified on Project: [pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war]",
                             "content": "INT-123",
                             "subject": {
@@ -227,11 +227,19 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                 "source": "INTERNAL",
                                 "severity": "UNASSIGNED"
                               },
-                              "affectedProjects": {
+                              "affectedProjectsReference": {
                                 "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-123/projects",
                                 "frontendUri": "/vulnerabilities/INTERNAL/INT-123/affectedProjects"
                               },
-                              "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS"
+                              "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
+                              "affectedProjects": [
+                                {
+                                  "uuid": "${json-unit.any-string}",
+                                  "name": "foo",
+                                  "version": "bar",
+                                  "purl": "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war"
+                                }
+                              ]
                             }
                           }
                         }

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
@@ -136,7 +136,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                         .withStatus(201)));
 
         // Create a new internal vulnerability for jackson-databind.
-        apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-123", List.of(
+        apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-123", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", List.of(917, 502), List.of(
                 new AffectedComponent("PURL", "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.2", "EXACT")
         )));
 
@@ -225,7 +225,8 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                 "uuid": "${json-unit.any-string}",
                                 "vulnId": "INT-123",
                                 "source": "INTERNAL",
-                                "severity": "UNASSIGNED"
+                                "cvssv3" : 10,
+                                "severity": "CRITICAL"
                               },
                               "affectedProjectsReference": {
                                 "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-123/projects",
@@ -282,7 +283,8 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                    "uuid": "${json-unit.any-string}",
                                    "vulnId" : "INT-123",
                                    "source" : "INTERNAL",
-                                   "severity" : "UNASSIGNED"
+                                   "cvssv3" : 10,
+                                   "severity" : "CRITICAL"
                                  } ]
                                } ],
                                "status" : "PROJECT_VULN_ANALYSIS_STATUS_COMPLETED"

--- a/notification-publisher/src/test/java/org/hyades/notification/NotificationRouterTest.java
+++ b/notification-publisher/src/test/java/org/hyades/notification/NotificationRouterTest.java
@@ -137,9 +137,11 @@ class NotificationRouterTest {
                                 .setUuid(projectUuid.toString()))
                         .setVulnerability(Vulnerability.newBuilder()
                                 .setUuid(UUID.randomUUID().toString()))
-                        .setAffectedProjects(BackReference.newBuilder()
+                        .setAffectedProjectsReference(BackReference.newBuilder()
                                 .setApiUri("foo")
                                 .setFrontendUri("bar"))
+                        .addAffectedProjects(Project.newBuilder()
+                                .setUuid(projectUuid.toString()))
                         .build()))
                 .build();
         // Ok, let's test this
@@ -173,9 +175,11 @@ class NotificationRouterTest {
                                 .setUuid(UUID.randomUUID().toString()))
                         .setVulnerability(Vulnerability.newBuilder()
                                 .setUuid(UUID.randomUUID().toString()))
-                        .setAffectedProjects(BackReference.newBuilder()
+                        .setAffectedProjectsReference(BackReference.newBuilder()
                                 .setApiUri("foo")
                                 .setFrontendUri("bar"))
+                        .addAffectedProjects(Project.newBuilder()
+                                .setUuid(projectUuid.toString()))
                         .build()))
                 .build();
         // Ok, let's test this
@@ -207,9 +211,11 @@ class NotificationRouterTest {
                                 .setUuid(projectUuid.toString()))
                         .setVulnerability(Vulnerability.newBuilder()
                                 .setUuid(UUID.randomUUID().toString()))
-                        .setAffectedProjects(BackReference.newBuilder()
+                        .setAffectedProjectsReference(BackReference.newBuilder()
                                 .setApiUri("foo")
                                 .setFrontendUri("bar"))
+                        .addAffectedProjects(Project.newBuilder()
+                                .setUuid(projectUuid.toString()))
                         .build()))
                 .build();
         // Ok, let's test this
@@ -622,9 +628,11 @@ class NotificationRouterTest {
                                 .setUuid(grandChildUuid.toString()))
                         .setVulnerability(Vulnerability.newBuilder()
                                 .setUuid(UUID.randomUUID().toString()))
-                        .setAffectedProjects(BackReference.newBuilder()
+                        .setAffectedProjectsReference(BackReference.newBuilder()
                                 .setApiUri("foo")
                                 .setFrontendUri("bar"))
+                        .addAffectedProjects(Project.newBuilder()
+                                .setUuid(grandChildUuid.toString()))
                         .build()))
                 .build();
         // Ok, let's test this
@@ -668,9 +676,11 @@ class NotificationRouterTest {
                                 .setUuid(grandChildUuid.toString()))
                         .setVulnerability(Vulnerability.newBuilder()
                                 .setUuid(UUID.randomUUID().toString()))
-                        .setAffectedProjects(BackReference.newBuilder()
+                        .setAffectedProjectsReference(BackReference.newBuilder()
                                 .setApiUri("foo")
                                 .setFrontendUri("bar"))
+                        .addAffectedProjects(Project.newBuilder()
+                                .setUuid(grandChildUuid.toString()))
                         .build()))
                 .build();
         // Ok, let's test this
@@ -712,9 +722,11 @@ class NotificationRouterTest {
                                 .setUuid(grandChildUuid.toString()))
                         .setVulnerability(Vulnerability.newBuilder()
                                 .setUuid(UUID.randomUUID().toString()))
-                        .setAffectedProjects(BackReference.newBuilder()
+                        .setAffectedProjectsReference(BackReference.newBuilder()
                                 .setApiUri("foo")
                                 .setFrontendUri("bar"))
+                        .addAffectedProjects(Project.newBuilder()
+                                .setUuid(grandChildUuid.toString()))
                         .build()))
                 .build();
         // Ok, let's test this
@@ -745,9 +757,11 @@ class NotificationRouterTest {
                                 .setUuid(projectUuid.toString()))
                         .setVulnerability(Vulnerability.newBuilder()
                                 .setUuid(UUID.randomUUID().toString()))
-                        .setAffectedProjects(BackReference.newBuilder()
+                        .setAffectedProjectsReference(BackReference.newBuilder()
                                 .setApiUri("foo")
                                 .setFrontendUri("bar"))
+                        .addAffectedProjects(Project.newBuilder()
+                                .setUuid(projectUuid.toString()))
                         .build()))
                 .build();
         // Ok, let's test this
@@ -764,7 +778,7 @@ class NotificationRouterTest {
     }
 
     private Long createRule(final String name, final NotificationScope scope, final NotificationLevel level,
-                                  final NotificationGroup group, final Long publisherId) {
+                            final NotificationGroup group, final Long publisherId) {
         return (Long) entityManager.createNativeQuery("""            
                         INSERT INTO "NOTIFICATIONRULE" ("ENABLED", "NAME", "PUBLISHER", "NOTIFY_ON", "NOTIFY_CHILDREN", "NOTIFICATION_LEVEL", "SCOPE", "UUID") VALUES
                             (true, :name, :publisherId, :notifyOn, false, :level, :scope, '6b1fee41-4178-4a23-9d1b-e9df79de8e62')

--- a/notification-publisher/src/test/java/org/hyades/notification/publisher/WebhookPublisherTest.java
+++ b/notification-publisher/src/test/java/org/hyades/notification/publisher/WebhookPublisherTest.java
@@ -19,75 +19,271 @@
 package org.hyades.notification.publisher;
 
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.protobuf.Any;
+import com.google.protobuf.util.Timestamps;
 import io.quarkus.test.TestTransaction;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.json.JsonObject;
-import jakarta.persistence.EntityManager;
-import org.apache.http.HttpHeaders;
-import org.hyades.proto.notification.v1.Group;
-import org.hyades.proto.notification.v1.Level;
+import org.hyades.proto.notification.v1.BackReference;
+import org.hyades.proto.notification.v1.Bom;
+import org.hyades.proto.notification.v1.BomConsumedOrProcessedSubject;
+import org.hyades.proto.notification.v1.Component;
+import org.hyades.proto.notification.v1.NewVulnerabilitySubject;
 import org.hyades.proto.notification.v1.Notification;
-import org.hyades.proto.notification.v1.Scope;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.hyades.proto.notification.v1.Project;
+import org.hyades.proto.notification.v1.Vulnerability;
+import org.hyades.util.WireMockTestResource;
+import org.hyades.util.WireMockTestResource.InjectWireMock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockserver.client.MockServerClient;
-import org.mockserver.integration.ClientAndServer;
 
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static org.hyades.notification.publisher.PublisherTestUtil.createPublisherContext;
 import static org.hyades.notification.publisher.PublisherTestUtil.getConfig;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import static org.hyades.proto.notification.v1.Group.GROUP_BOM_PROCESSED;
+import static org.hyades.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
+import static org.hyades.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
+import static org.hyades.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
 
 @QuarkusTest
-public class WebhookPublisherTest {
+@QuarkusTestResource(WireMockTestResource.class)
+class WebhookPublisherTest {
 
     @Inject
     WebhookPublisher publisher;
 
-    @Inject
-    EntityManager entityManager;
+    @InjectWireMock
+    WireMockServer wireMockServer;
 
-    private static ClientAndServer mockServer;
-
-    @BeforeAll
-    public static void beforeClass() {
-        mockServer = startClientAndServer(1080);
-    }
-
-    @AfterAll
-    public static void afterClass() {
-        mockServer.stop();
+    @AfterEach
+    void afterEach() {
+        wireMockServer.resetAll();
     }
 
     @Test
     @TestTransaction
-    public void testPublish() throws Exception {
-        new MockServerClient("localhost", 1080)
-                .when(
-                        request()
-                                .withMethod("POST")
-                                .withPath("/mychannel")
-                )
-                .respond(
-                        response()
-                                .withStatusCode(200)
-                                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                );
-        entityManager.createNativeQuery("""
-                INSERT INTO "CONFIGPROPERTY" ("DESCRIPTION", "GROUPNAME", "PROPERTYTYPE", "PROPERTYNAME", "PROPERTYVALUE") VALUES
-                                    ('slack', 'general', 'STRING', 'base.url', 'http://localhost:1080/mychannel');
-                """).executeUpdate();
-        JsonObject config = getConfig("WEBHOOK","http://localhost:1080/mychannel");
+    void testPublishNewVulnerabilityNotification() throws Exception {
+        wireMockServer.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(202)));
+
         final var notification = Notification.newBuilder()
-                .setScope(Scope.SCOPE_PORTFOLIO)
-                .setLevel(Level.LEVEL_INFORMATIONAL)
-                .setGroup(Group.GROUP_NEW_VULNERABILITY)
+                .setScope(SCOPE_PORTFOLIO)
+                .setLevel(LEVEL_INFORMATIONAL)
+                .setGroup(GROUP_NEW_VULNERABILITY)
                 .setTitle("Test Notification")
                 .setContent("This is only a test")
+                .setTimestamp(Timestamps.fromSeconds(666))
+                .setSubject(Any.pack(NewVulnerabilitySubject.newBuilder()
+                        .setComponent(createComponent())
+                        .setProject(createProject())
+                        .setVulnerability(createVulnerability())
+                        .setAffectedProjectsReference(BackReference.newBuilder()
+                                .setApiUri("apiUriValue")
+                                .setFrontendUri("frontendUriValue"))
+                        .setVulnerabilityAnalysisLevel("BOM_UPLOAD")
+                        .addAffectedProjects(createProject())
+                        .build()))
                 .build();
-        publisher.inform(createPublisherContext(notification), notification, config);
+
+        publisher.inform(createPublisherContext(notification), notification, getPublisherConfig());
+
+        wireMockServer.verify(postRequestedFor(anyUrl())
+                .withRequestBody(equalToJson("""
+                        {
+                          "notification": {
+                            "level": "LEVEL_INFORMATIONAL",
+                            "scope": "SCOPE_PORTFOLIO",
+                            "group": "GROUP_NEW_VULNERABILITY",
+                            "timestamp": "1970-01-01T00:11:06Z",
+                            "title": "Test Notification",
+                            "content": "This is only a test",
+                            "subject": {
+                              "component": {
+                                "uuid": "3c87b90d-d08a-492a-855e-d6e9d8b63a18",
+                                "group": "componentGroup",
+                                "name": "componentName",
+                                "version": "componentVersion",
+                                "purl": "componentPurl",
+                                "md5": "componentMd5",
+                                "sha1": "componentSha1",
+                                "sha256": "componentSha256",
+                                "sha512": "componentSha512"
+                              },
+                              "project": {
+                                "uuid": "0957687b-3482-4891-a836-dad37e9b804a",
+                                "name": "projectName",
+                                "version": "projectVersion",
+                                "description": "projectDescription",
+                                "purl": "projectPurl",
+                                "tags": [
+                                  "tag-a",
+                                  "tag-b"
+                                ]
+                              },
+                              "vulnerability": {
+                                "uuid": "418d9be1-f888-446a-8f03-f3253e5b5361",
+                                "vulnId": "INT-001",
+                                "source": "INTERNAL",
+                                "aliases": [
+                                  {
+                                    "vulnId": "OSV-001",
+                                    "source": "OSV"
+                                  }
+                                ],
+                                "title": "vulnerabilityTitle",
+                                "subtitle": "vulnerabilitySubTitle",
+                                "description": "vulnerabilityDescription",
+                                "recommendation": "vulnerabilityRecommendation",
+                                "cvssv2": 5.5,
+                                "cvssv3": 6.6,
+                                "owaspRRLikelihood": 1.1,
+                                "owaspRRTechnicalImpact": 2.2,
+                                "owaspRRBusinessImpact": 3.3,
+                                "cwes": [
+                                  {
+                                    "cweId": 666,
+                                    "name": "Operation on Resource in Wrong Phase of Lifetime"
+                                  }
+                                ]
+                              },
+                              "affectedProjectsReference": {
+                                "apiUri": "apiUriValue",
+                                "frontendUri": "frontendUriValue"
+                              },
+                              "vulnerabilityAnalysisLevel": "BOM_UPLOAD",
+                              "affectedProjects": [
+                                {
+                                  "uuid": "0957687b-3482-4891-a836-dad37e9b804a",
+                                  "name": "projectName",
+                                  "version": "projectVersion",
+                                  "description": "projectDescription",
+                                  "purl": "projectPurl",
+                                  "tags": [
+                                    "tag-a",
+                                    "tag-b"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                        """)));
     }
+
+    @Test
+    @TestTransaction
+    void testPublishBomProcessedNotification() throws Exception {
+        wireMockServer.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(202)));
+
+        final var notification = Notification.newBuilder()
+                .setScope(SCOPE_PORTFOLIO)
+                .setLevel(LEVEL_INFORMATIONAL)
+                .setGroup(GROUP_BOM_PROCESSED)
+                .setTitle("Test Notification")
+                .setContent("This is only a test")
+                .setTimestamp(Timestamps.fromSeconds(666))
+                .setSubject(Any.pack(BomConsumedOrProcessedSubject.newBuilder()
+                        .setProject(createProject())
+                        .setBom(Bom.newBuilder()
+                                .setContent("bomContent")
+                                .setFormat("bomFormat")
+                                .setSpecVersion("bomSpecVersion"))
+                        .build()))
+                .build();
+
+        publisher.inform(createPublisherContext(notification), notification, getPublisherConfig());
+
+        wireMockServer.verify(postRequestedFor(anyUrl())
+                .withRequestBody(equalToJson("""
+                        {
+                          "notification": {
+                            "level": "LEVEL_INFORMATIONAL",
+                            "scope": "SCOPE_PORTFOLIO",
+                            "group": "GROUP_BOM_PROCESSED",
+                            "timestamp": "1970-01-01T00:11:06Z",
+                            "title": "Test Notification",
+                            "content": "This is only a test",
+                            "subject": {
+                              "project": {
+                                "uuid": "0957687b-3482-4891-a836-dad37e9b804a",
+                                "name": "projectName",
+                                "version": "projectVersion",
+                                "description": "projectDescription",
+                                "purl": "projectPurl",
+                                "tags": [
+                                  "tag-a",
+                                  "tag-b"
+                                ]
+                              },
+                              "bom": {
+                                "content": "bomContent",
+                                "format": "bomFormat",
+                                "specVersion": "bomSpecVersion"
+                              }
+                            }
+                          }
+                        }
+                        """)));
+    }
+
+    private JsonObject getPublisherConfig() {
+        return getConfig("WEBHOOK", wireMockServer.baseUrl());
+    }
+
+    private Component createComponent() {
+        return Component.newBuilder()
+                .setUuid("3c87b90d-d08a-492a-855e-d6e9d8b63a18")
+                .setGroup("componentGroup")
+                .setName("componentName")
+                .setVersion("componentVersion")
+                .setPurl("componentPurl")
+                .setMd5("componentMd5")
+                .setSha1("componentSha1")
+                .setSha256("componentSha256")
+                .setSha512("componentSha512")
+                .build();
+    }
+
+    private Project createProject() {
+        return Project.newBuilder()
+                .setUuid("0957687b-3482-4891-a836-dad37e9b804a")
+                .setName("projectName")
+                .setVersion("projectVersion")
+                .setDescription("projectDescription")
+                .setPurl("projectPurl")
+                .addAllTags(List.of("tag-a", "tag-b"))
+                .build();
+    }
+
+    private Vulnerability createVulnerability() {
+        return Vulnerability.newBuilder()
+                .setUuid("418d9be1-f888-446a-8f03-f3253e5b5361")
+                .setVulnId("INT-001")
+                .setSource("INTERNAL")
+                .addCwes(Vulnerability.Cwe.newBuilder()
+                        .setName("Operation on Resource in Wrong Phase of Lifetime")
+                        .setCweId(666))
+                .addAliases(Vulnerability.Alias.newBuilder()
+                        .setId("OSV-001")
+                        .setSource("OSV"))
+                .setTitle("vulnerabilityTitle")
+                .setSubTitle("vulnerabilitySubTitle")
+                .setDescription("vulnerabilityDescription")
+                .setRecommendation("vulnerabilityRecommendation")
+                .setCvssV2(5.5)
+                .setCvssV3(6.6)
+                .setOwaspRrLikelihood(1.1)
+                .setOwaspRrTechnicalImpact(2.2)
+                .setOwaspRrBusinessImpact(3.3)
+                .build();
+    }
+
 }

--- a/proto/src/main/proto/org/hyades/notification/v1/notification.proto
+++ b/proto/src/main/proto/org/hyades/notification/v1/notification.proto
@@ -177,19 +177,19 @@ message Vulnerability {
   string source = 3;
   repeated Alias aliases = 4;
   optional string title = 5;
-  optional string sub_title = 6;
+  optional string sub_title = 6 [json_name = "subtitle"];
   optional string description = 7;
   optional string recommendation = 8;
-  optional double cvss_v2 = 9;
-  optional double cvss_v3 = 10;
-  optional double owasp_rr_likelihood = 11;
-  optional double owasp_rr_technical_impact = 12;
-  optional double owasp_rr_business_impact = 13;
+  optional double cvss_v2 = 9 [json_name = "cvssv2"];
+  optional double cvss_v3 = 10 [json_name = "cvssv3"];
+  optional double owasp_rr_likelihood = 11 [json_name = "owaspRRLikelihood"];
+  optional double owasp_rr_technical_impact = 12 [json_name = "owaspRRTechnicalImpact"];
+  optional double owasp_rr_business_impact = 13 [json_name = "owaspRRBusinessImpact"];
   optional string severity = 14;
   repeated Cwe cwes = 15;
 
   message Alias {
-    string id = 1;
+    string id = 1 [json_name = "vulnId"];
     string source = 2;
   }
 

--- a/proto/src/main/proto/org/hyades/notification/v1/notification.proto
+++ b/proto/src/main/proto/org/hyades/notification/v1/notification.proto
@@ -86,8 +86,14 @@ message NewVulnerabilitySubject {
   Component component = 1;
   Project project = 2;
   Vulnerability vulnerability = 3;
-  BackReference affected_projects = 4;
+  BackReference affected_projects_reference = 4;
   optional string vulnerability_analysis_level = 5;
+  // List of projects affected by the vulnerability.
+  // DEPRECATED: This list only holds one item, and it is identical to the one in the project field.
+  // The field is kept for backward compatibility of JSON notifications, but consumers should not expect multiple projects here.
+  // Transmitting all affected projects in one notification is not feasible for large portfolios,
+  // see https://github.com/DependencyTrack/hyades/issues/467 for details.
+  repeated Project affected_projects = 6 [deprecated = true];
 }
 
 message NewVulnerableDependencySubject {


### PR DESCRIPTION
Companion change to https://github.com/DependencyTrack/hyades-apiserver/pull/290

Note: Because the original field numbers and types remain untouched, this is not a breaking change schema-wise. The name of the fields has changed, but this is only relevant to the JSON output, which is exactly what we want to fix here.