### PR TITLE
Fix grammatical number of `vulnerabilities` in `ProjectVulnAnalysisCompleteSubject`

### DIFF
--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
@@ -286,7 +286,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                    "sha256" : "efb86b148712a838b94b3cfc95769785a116b3461f709b4cc510055a58b804b2",
                                    "sha512" : "0e9398591d86f80f16fc2d6ff0dda3e7821033e2c59472981eaab61443be3d77198655682905b85260fb2186a2cf0f33988aff689a49bb54e56c07e02f607e8a"
                                  },
-                                 "vulnerability" : [ {
+                                 "vulnerabilities" : [ {
                                    "uuid": "${json-unit.any-string}",
                                    "vulnId" : "INT-123",
                                    "source" : "INTERNAL",

--- a/proto/src/main/proto/org/hyades/notification/v1/notification.proto
+++ b/proto/src/main/proto/org/hyades/notification/v1/notification.proto
@@ -214,12 +214,13 @@ message PolicyViolationAnalysis {
   optional string state = 4;
   optional bool suppressed = 5;
 }
-message ComponentVulnAnalysisCompleteSubject{
+
+message ComponentVulnAnalysisCompleteSubject {
   Component component = 1;
-  repeated Vulnerability vulnerability = 2;
+  repeated Vulnerability vulnerabilities = 2;
 }
 
-message ProjectVulnAnalysisCompleteSubject{
+message ProjectVulnAnalysisCompleteSubject {
   Project project = 1;
   repeated ComponentVulnAnalysisCompleteSubject findings = 2;
   ProjectVulnAnalysisStatus status = 3;


### PR DESCRIPTION
The field contains multiple vulnerabilities, yet its name says `vulnerability`, which is confusing.

Companion PR to https://github.com/DependencyTrack/hyades-apiserver/pull/294