### PR TITLE
Make replicaCount configurable for mirror-service

### DIFF
--- a/helm-charts/hyades/README.md
+++ b/helm-charts/hyades/README.md
@@ -104,6 +104,7 @@
 | mirrorService.probes.readiness.periodSeconds | int | `15` |  |
 | mirrorService.probes.readiness.successThreshold | int | `1` |  |
 | mirrorService.probes.readiness.timeoutSeconds | int | `5` |  |
+| mirrorService.replicaCount | int | `1` | Number of replicas. Should be <= 1. |
 | mirrorService.resources.limits.cpu | string | `"2"` |  |
 | mirrorService.resources.limits.memory | string | `"2Gi"` |  |
 | mirrorService.resources.requests.cpu | string | `"500m"` |  |

--- a/helm-charts/hyades/templates/mirror-service/deployment.yaml
+++ b/helm-charts/hyades/templates/mirror-service/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.mirrorServiceLabels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.mirrorService.replicaCount }}
   selector:
     matchLabels: {{- include "hyades.mirrorServiceSelectorLabels" . | nindent 6 }}
   template:

--- a/helm-charts/hyades/values.yaml
+++ b/helm-charts/hyades/values.yaml
@@ -97,6 +97,8 @@ frontend:
 
 mirrorService:
   enabled: true
+  # -- Number of replicas. Should be <= 1.
+  replicaCount: 1
   annotations: {}
   image:
     repository: dependencytrack/hyades-mirror-service


### PR DESCRIPTION
Allows the deployment to be scaled down to zero pods, which was not possible with the hardcoded replicaCount of `1`.