### PR TITLE
Fix batches not being submitted even though `batchStore` contains records

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregator.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/misc/ScannerResultAggregator.java
@@ -1,6 +1,7 @@
 package org.hyades.processor.misc;
 
-import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
@@ -11,6 +12,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.hyades.proto.vulnanalysis.internal.v1beta1.ScannerResultAggregate;
 import org.hyades.proto.vulnanalysis.v1.ScanKey;
+import org.hyades.proto.vulnanalysis.v1.ScanStatus;
 import org.hyades.proto.vulnanalysis.v1.ScannerResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +22,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_PENDING;
 
@@ -89,8 +92,29 @@ public class ScannerResultAggregator extends ContextualFixedKeyProcessor<ScanKey
                 final KeyValue<ScanKey, ScannerResultAggregate> record = all.next();
                 final Instant lastUpdated = Instant.ofEpochSecond(record.value.getLastUpdated().getSeconds());
 
-                if (isComplete(record.value) || lastUpdated.isBefore(cutoffTimestamp)) {
-                    LOGGER.debug("Deleting expired aggregate for {}", record.key);
+                if (isComplete(record.value)) {
+                    LOGGER.debug("Deleting completed aggregate; This is a normal housekeeping activity (token={}, component={})",
+                            record.key.getScanToken(), record.key.getComponentUuid());
+                    store.delete(record.key);
+                } else if (lastUpdated.isBefore(cutoffTimestamp)) {
+                    // To give more useful context in the log message, figure out for which scanner we received results,
+                    // and for which we did not. This map will have the form of:
+                    //   {
+                    //     SCANNER_OSSINDEX: SCAN_STATUS_SUCCESSFUL,
+                    //     SCANNER_SNYK: SCAN_STATUS_PENDING
+                    //   }
+                    //
+                    // Normally, scanners should always send results, no matter if they succeed or fail.
+                    // If this scenario happens, then likely an unhandled error occurred in a scanner, causing
+                    // it to drop records, OR the batching logic is faulty.
+                    final Map<String, ScanStatus> scanStatusByScanner = record.value.getResultsMap().entrySet().stream()
+                            .map(entry -> Pair.of(entry.getKey(), entry.getValue().getStatus()))
+                            .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+
+                    LOGGER.warn("""
+                            Deleting incomplete aggregate from store; At least one applicable scanner failed to send \
+                            results in time (token={}, component={}, statuses={}, lastUpdated={}, cutoff={})
+                            """, record.key.getScanToken(), record.key.getComponentUuid(), scanStatusByScanner, lastUpdated, cutoffTimestamp);
                     store.delete(record.key);
                 }
             }
@@ -117,14 +141,8 @@ public class ScannerResultAggregator extends ContextualFixedKeyProcessor<ScanKey
         }
 
         return resultAggregateBuilder
-                .setLastUpdated(currentStreamTimestamp())
+                .setLastUpdated(Timestamps.fromMillis(context().currentStreamTimeMs()))
                 .putAllResults(scannerResults)
-                .build();
-    }
-
-    private Timestamp currentStreamTimestamp() {
-        return Timestamp.newBuilder()
-                .setSeconds(context().currentStreamTimeMs() / 1000)
                 .build();
     }
 

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/retry/RetryingBatchProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/retry/RetryingBatchProcessor.java
@@ -35,7 +35,7 @@ public abstract class RetryingBatchProcessor<KI, VI, KO, VO, KR> extends Retryin
     private DistributionSummary batchSizeDistribution;
     private Counter.Builder componentsScannedCounterBuilder;
     private Instant lastBatchAnalysis;
-    private int batchSize;
+    private final int batchSize;
     private final Logger logger;
 
     protected RetryingBatchProcessor(final String storeName, final IntervalFunction intervalFunction,
@@ -102,16 +102,21 @@ public abstract class RetryingBatchProcessor<KI, VI, KO, VO, KR> extends Retryin
     }
 
     private void punctuateBatch(final long timestamp) {
-        if (batchStore.approximateNumEntries() == 0) {
+        if (Instant.ofEpochMilli(timestamp).isBefore(lastBatchAnalysis.plusSeconds(5))) {
+            logger.debug("Current batch is not yet due for analysis (lastBatchAnalysis={})", lastBatchAnalysis);
+            return;
+        }
+
+        final var batch = currentBatch();
+        if (batch.isEmpty()) {
+            // Note: DO NOT use batchStore#approximateNumEntries to check the batch store size,
+            // it will report 0 even though there are entries in the store when RocksDB is used.
+            // It is NOT reliable, the only reliable way to determine the store size is to actually
+            // read from it.
             logger.debug("Current batch is empty");
             return;
         }
 
-        if (Instant.ofEpochMilli(timestamp).isBefore(lastBatchAnalysis.plusSeconds(5))) {
-            logger.debug("Current batch is not yet due for submission");
-            return;
-        }
-        final var batch = currentBatch();
         analyzeBatch(batch);
     }
 

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/ossindex/OssIndexProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/ossindex/OssIndexProcessor.java
@@ -93,6 +93,11 @@ public class OssIndexProcessor extends RetryingBatchProcessor<String, ScanTask, 
             return;
         }
 
+        // Note: approximateNumEntries may over-report or under-report when RocksDB is used.
+        // It is possible that this condition will be true, even though the store contains
+        // more or less entries than config.batchSize.
+        // This is an acceptable trade-off here, because it's still a better option than reading
+        // entries from the store too often (as it involves de-serializing all of them).
         if (batchStore.approximateNumEntries() >= config.batchSize()) {
             final List<RetryableRecord<String, ScanTask>> batch = currentBatch();
             analyzeBatch(batch);

--- a/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/snyk/SnykProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/processor/scanner/snyk/SnykProcessor.java
@@ -99,6 +99,11 @@ public class SnykProcessor extends RetryingBatchProcessor<String, ScanTask, Scan
             return;
         }
 
+        // Note: approximateNumEntries may over-report or under-report when RocksDB is used.
+        // It is possible that this condition will be true, even though the store contains
+        // more or less entries than config.batchSize.
+        // This is an acceptable trade-off here, because it's still a better option than reading
+        // entries from the store too often (as it involves de-serializing all of them).
         if (batchStore.approximateNumEntries() >= config.batchSize()) {
             final List<RetryableRecord<String, ScanTask>> batch = currentBatch();
             analyzeBatch(batch);


### PR DESCRIPTION
When RocksDB state stores are enabled (`STATE_STORE_TYPE=rocks_db`), there was a possibility that under low-traffic circumstances, records in a scanner's `batchStore` were not submitted for analysis.

This is because the `approximateNumEntries` method can differ vastly from the *actual* number of entries in the store.

We use `approximateNumEntries` to short-circuit the punctuator responsible for submitting incomplete batches on a schedule

I temporarily modified the respective code to log both the result of `approximateNumEntries`, as well as the *actual* number of entries:

```java
final long batchStoreSize = batchStore.approximateNumEntries();
if (batchStoreSize == 0) {
    final long actual = Iterators.size(batchStore.all());
    logger.info("Current batch is empty (rocks={}, actual={})", batchStoreSize, actual);
    return;
}
```

On multiple occasions, I saw logs like the following:
```
Current batch is empty (rocks=0, actual=75)
```

In the worst case, this could cause batch entries to be "stuck" until the next wave of records comes in (which can take several hours, depending on BOM upload volume).