### PR TITLE
Ensure consistent formatting of notification timestamps

### DIFF
--- a/e2e/src/test/java/org/hyades/e2e/BomProcessedNotificationDelayedE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomProcessedNotificationDelayedE2ET.java
@@ -115,7 +115,7 @@ public class BomProcessedNotificationDelayedE2ET extends AbstractE2ET {
                             "level" : "LEVEL_INFORMATIONAL",
                             "scope" : "SCOPE_PORTFOLIO",
                             "group" : "GROUP_BOM_PROCESSED",
-                            "timestamp" : "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$)",
+                            "timestamp" : "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]{3}Z$)",
                             "title" : "Bill of Materials Processed",
                             "content" : "A CycloneDX BOM was processed",
                             "subject" : {
@@ -144,7 +144,7 @@ public class BomProcessedNotificationDelayedE2ET extends AbstractE2ET {
                              "level" : "LEVEL_INFORMATIONAL",
                              "scope" : "SCOPE_PORTFOLIO",
                              "group" : "GROUP_PROJECT_VULN_ANALYSIS_COMPLETE",
-                             "timestamp" : "${json-unit.any-string}",
+                             "timestamp" : "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]{3}Z$)",
                              "title" : "Project vulnerability analysis complete",
                              "content" : "${json-unit.any-string}",
                              "subject" : {

--- a/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/hyades/e2e/BomUploadProcessingE2ET.java
@@ -206,7 +206,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                             "level": "LEVEL_INFORMATIONAL",
                             "scope": "SCOPE_PORTFOLIO",
                             "group": "GROUP_NEW_VULNERABILITY",
-                            "timestamp": "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$)",
+                            "timestamp": "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]{3}Z$)",
                             "title": "New Vulnerability Identified on Project: [pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war]",
                             "content": "INT-123",
                             "subject": {
@@ -263,7 +263,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                              "level" : "LEVEL_INFORMATIONAL",
                              "scope" : "SCOPE_PORTFOLIO",
                              "group" : "GROUP_PROJECT_VULN_ANALYSIS_COMPLETE",
-                             "timestamp" : "${json-unit.any-string}",
+                             "timestamp" : "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]{3}Z$)",
                              "title" : "Project vulnerability analysis complete",
                              "content" : "${json-unit.any-string}",
                              "subject" : {

--- a/notification-publisher/src/main/java/org/hyades/notification/publisher/PublishContext.java
+++ b/notification-publisher/src/main/java/org/hyades/notification/publisher/PublishContext.java
@@ -1,9 +1,9 @@
 package org.hyades.notification.publisher;
 
 import com.google.common.base.MoreObjects;
-import com.google.protobuf.util.Timestamps;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.hyades.persistence.model.NotificationRule;
+import org.hyades.proto.ProtobufUtil;
 import org.hyades.proto.notification.v1.BomConsumedOrProcessedSubject;
 import org.hyades.proto.notification.v1.BomProcessingFailedSubject;
 import org.hyades.proto.notification.v1.NewVulnerabilitySubject;
@@ -104,7 +104,7 @@ public class PublishContext {
 
         return new PublishContext(consumerRecord.topic(), consumerRecord.partition(), consumerRecord.offset(),
                 notification.getGroup().name(), notification.getLevel().name(), notification.getScope().name(),
-                Timestamps.toString(notification.getTimestamp()), notificationSubjects);
+                ProtobufUtil.formatTimestamp(notification.getTimestamp()), notificationSubjects);
     }
 
     /**

--- a/notification-publisher/src/main/java/org/hyades/notification/publisher/Publisher.java
+++ b/notification-publisher/src/main/java/org/hyades/notification/publisher/Publisher.java
@@ -20,13 +20,13 @@ package org.hyades.notification.publisher;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import com.google.protobuf.util.Timestamps;
 import io.pebbletemplates.pebble.PebbleEngine;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 import jakarta.json.JsonObject;
 import org.hyades.persistence.model.ConfigProperty;
 import org.hyades.persistence.model.ConfigPropertyConstants;
 import org.hyades.persistence.repository.ConfigPropertyRepository;
+import org.hyades.proto.ProtobufUtil;
 import org.hyades.proto.notification.v1.BomConsumedOrProcessedSubject;
 import org.hyades.proto.notification.v1.NewVulnerabilitySubject;
 import org.hyades.proto.notification.v1.NewVulnerableDependencySubject;
@@ -86,7 +86,7 @@ public interface Publisher {
         final Map<String, Object> context = new HashMap<>();
         final long epochSecond = notification.getTimestamp().getSeconds();
         context.put("timestampEpochSecond", epochSecond);
-        context.put("timestamp", Timestamps.toString(notification.getTimestamp()));
+        context.put("timestamp", ProtobufUtil.formatTimestamp(notification.getTimestamp()));
         context.put("notification", notification);
         if (baseUrlProperty != null && baseUrlProperty.getPropertyValue() != null) {
             context.put("baseUrl", baseUrlProperty.getPropertyValue().replaceAll("/$", ""));

--- a/notification-publisher/src/test/java/org/hyades/notification/NotificationRouterIT.java
+++ b/notification-publisher/src/test/java/org/hyades/notification/NotificationRouterIT.java
@@ -141,7 +141,7 @@ class NotificationRouterIT {
                             "level" : "LEVEL_INFORMATIONAL",
                             "scope" : "SCOPE_PORTFOLIO",
                             "group" : "GROUP_NEW_VULNERABILITY",
-                            "timestamp" : "1970-01-01T00:11:06Z",
+                            "timestamp" : "1970-01-01T00:11:06.000Z",
                             "title" : "Test Notification",
                             "content" : "This is only a test",
                             "subject" : {

--- a/notification-publisher/src/test/java/org/hyades/notification/publisher/ConsolePublisherTest.java
+++ b/notification-publisher/src/test/java/org/hyades/notification/publisher/ConsolePublisherTest.java
@@ -19,7 +19,6 @@
 package org.hyades.notification.publisher;
 
 import com.google.protobuf.Any;
-import com.google.protobuf.util.Timestamps;
 import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -37,12 +36,12 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyades.notification.publisher.PublisherTestUtil.createPublisherContext;
 import static org.hyades.notification.publisher.PublisherTestUtil.getConfig;
 import static org.hyades.proto.notification.v1.Group.GROUP_FILE_SYSTEM;
 import static org.hyades.proto.notification.v1.Level.LEVEL_ERROR;
 import static org.hyades.proto.notification.v1.Scope.SCOPE_SYSTEM;
-import static org.junit.Assert.assertTrue;
 
 @QuarkusTest
 public class ConsolePublisherTest {
@@ -88,7 +87,7 @@ public class ConsolePublisherTest {
                 .build();
         publisher.inform(createPublisherContext(notification), notification, getConfig("CONSOLE", ""));
         System.out.println("outContent: " + outContent);
-        assertTrue(outContent.toString().contains(expectedResult(notification)));
+        assertThat(outContent.toString()).contains(expectedResult(notification));
     }
 
     @Test
@@ -114,7 +113,7 @@ public class ConsolePublisherTest {
                 .build();
         publisher.inform(createPublisherContext(notification), notification, getConfig("CONSOLE", ""));
         System.out.println("outContent: " + outContent);
-        assertTrue(outContent.toString().contains(expectedResult(notification)));
+        assertThat(outContent.toString()).contains(expectedResult(notification));
     }
 
     @Test
@@ -138,7 +137,7 @@ public class ConsolePublisherTest {
     private String expectedResult(Notification notification) {
         return "--------------------------------------------------------------------------------" + System.lineSeparator() +
                 "Notification" + System.lineSeparator() +
-                "  -- timestamp: " + Timestamps.toString(notification.getTimestamp()) + System.lineSeparator() +
+                "  -- timestamp: 1970-01-01T00:00:00.000Z" + System.lineSeparator() +
                 "  -- level:     " + notification.getLevel() + System.lineSeparator() +
                 "  -- scope:     " + notification.getScope() + System.lineSeparator() +
                 "  -- group:     " + notification.getGroup() + System.lineSeparator() +

--- a/notification-publisher/src/test/java/org/hyades/notification/publisher/PublishContextTest.java
+++ b/notification-publisher/src/test/java/org/hyades/notification/publisher/PublishContextTest.java
@@ -63,7 +63,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_BOM_CONSUMED");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects()).hasEntrySatisfying("project", projectObj -> {
                 assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
                 final var project = (PublishContext.Project) projectObj;
@@ -95,7 +95,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_BOM_PROCESSED");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects()).hasEntrySatisfying("project", projectObj -> {
                 assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
                 final var project = (PublishContext.Project) projectObj;
@@ -127,7 +127,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_BOM_PROCESSING_FAILED");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects()).hasEntrySatisfying("project", projectObj -> {
                 assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
                 final var project = (PublishContext.Project) projectObj;
@@ -164,7 +164,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_NEW_VULNERABILITY");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects())
                     .hasEntrySatisfying("project", projectObj -> {
                         assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
@@ -210,7 +210,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_NEW_VULNERABLE_DEPENDENCY");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects())
                     .hasEntrySatisfying("project", projectObj -> {
                         assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
@@ -250,7 +250,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_PROJECT_CREATED");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects()).hasEntrySatisfying("project", projectObj -> {
                 assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
                 final var project = (PublishContext.Project) projectObj;
@@ -282,7 +282,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_PROJECT_VULN_ANALYSIS_COMPLETE");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects()).hasEntrySatisfying("project", projectObj -> {
                 assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
                 final var project = (PublishContext.Project) projectObj;
@@ -319,7 +319,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_POLICY_VIOLATION");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects())
                     .hasEntrySatisfying("project", projectObj -> {
                         assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
@@ -365,7 +365,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_PROJECT_AUDIT_CHANGE");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects())
                     .hasEntrySatisfying("project", projectObj -> {
                         assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
@@ -411,7 +411,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_PROJECT_AUDIT_CHANGE");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects())
                     .hasEntrySatisfying("project", projectObj -> {
                         assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
@@ -452,7 +452,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_VEX_CONSUMED");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects()).hasEntrySatisfying("project", projectObj -> {
                 assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
                 final var project = (PublishContext.Project) projectObj;
@@ -484,7 +484,7 @@ class PublishContextTest {
             assertThat(ctx.notificationGroup()).isEqualTo("GROUP_VEX_PROCESSED");
             assertThat(ctx.notificationLevel()).isEqualTo("LEVEL_INFORMATIONAL");
             assertThat(ctx.notificationScope()).isEqualTo("SCOPE_PORTFOLIO");
-            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06Z");
+            assertThat(ctx.notificationTimestamp()).isEqualTo("1970-01-01T00:11:06.000Z");
             assertThat(ctx.notificationSubjects()).hasEntrySatisfying("project", projectObj -> {
                 assertThat(projectObj).isInstanceOf(PublishContext.Project.class);
                 final var project = (PublishContext.Project) projectObj;

--- a/notification-publisher/src/test/java/org/hyades/notification/publisher/WebhookPublisherTest.java
+++ b/notification-publisher/src/test/java/org/hyades/notification/publisher/WebhookPublisherTest.java
@@ -102,7 +102,7 @@ class WebhookPublisherTest {
                             "level": "LEVEL_INFORMATIONAL",
                             "scope": "SCOPE_PORTFOLIO",
                             "group": "GROUP_NEW_VULNERABILITY",
-                            "timestamp": "1970-01-01T00:11:06Z",
+                            "timestamp": "1970-01-01T00:11:06.000Z",
                             "title": "Test Notification",
                             "content": "This is only a test",
                             "subject": {
@@ -208,7 +208,7 @@ class WebhookPublisherTest {
                             "level": "LEVEL_INFORMATIONAL",
                             "scope": "SCOPE_PORTFOLIO",
                             "group": "GROUP_BOM_PROCESSED",
-                            "timestamp": "1970-01-01T00:11:06Z",
+                            "timestamp": "1970-01-01T00:11:06.000Z",
                             "title": "Test Notification",
                             "content": "This is only a test",
                             "subject": {

--- a/proto/src/main/java/org/hyades/proto/ProtobufUtil.java
+++ b/proto/src/main/java/org/hyades/proto/ProtobufUtil.java
@@ -1,0 +1,30 @@
+package org.hyades.proto;
+
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+public final class ProtobufUtil {
+
+    /**
+     * Customized version of {@link DateTimeFormatter#ISO_INSTANT}, which will <em>always</em>
+     * include three digits of the fractional second when formatting.
+     * <p>
+     * Per default {@link DateTimeFormatter#ISO_INSTANT} includes as many fractional digits as necessary,
+     * which can result in different formats being produced, depending on how precise the given timestamp is.
+     * <p>
+     * Because we want output to be reliable, we chose to stay with a fixed format of: {@code yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}.
+     */
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendInstant(3)
+            .toFormatter();
+
+    public static String formatTimestamp(final Timestamp timestamp) {
+        return DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(Timestamps.toMillis(timestamp)));
+    }
+
+}

--- a/proto/src/test/java/org/hyades/proto/ProtobufUtilTest.java
+++ b/proto/src/test/java/org/hyades/proto/ProtobufUtilTest.java
@@ -1,0 +1,24 @@
+package org.hyades.proto;
+
+import com.google.protobuf.util.Timestamps;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProtobufUtilTest {
+
+    @Test
+    void testFormatTimestamp() {
+        assertThat(ProtobufUtil.formatTimestamp(Timestamps.fromDate(new Date())))
+                .matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$");
+
+        // Just to be super-sure: When the timestamp has no fractional part,
+        // we still include the fraction for consistency's sake.
+        assertThat(ProtobufUtil.formatTimestamp(Timestamps.fromDate(Date.from(Instant.ofEpochSecond(666)))))
+                .matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.000Z$");
+    }
+
+}


### PR DESCRIPTION
Adds a custom method for formatting Protobuf `Timestamp`s.

With the default `Timestamps#toString` method, the format could change slightly, depending on how precise the provided `Timestamp` was. The number of fractional digit could either be of length 0, 3, 6, or 9. To prevent any complications in timestamp parsing, we settle for a fixed length of 3.