### PR TITLE
Fix potential `TopologyException` when running multiple vulnerability-analyzer instances

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
+++ b/vulnerability-analyzer/src/main/java/org/hyades/VulnerabilityAnalyzerTopology.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
@@ -115,7 +116,15 @@ public class VulnerabilityAnalyzerTopology {
         // parallelism in Kafka, and scanners work at different paces, utilizing the same
         // input topic for all scanners is not practical. Scanner topics are managed by
         // Kafka Streams and will be automatically created if they don't exist yet.
-        for (final ScanProcessorSupplier scanProcessorSupplier : scanProcessorSuppliers) {
+        //
+        // The order in which the scanners are registered with the topology is important.
+        // It has to be consistent across all instances of the vulnerability analyzer service,
+        // otherwise Kafka Streams will assume that instances run on different topologies entirely
+        // and refuse to start.
+        final List<ScanProcessorSupplier> sortedScanProcessorSuppliers = scanProcessorSuppliers.stream()
+                .sorted(Comparator.comparing(ScanProcessorSupplier::scannerIdentity))
+                .toList();
+        for (final ScanProcessorSupplier scanProcessorSupplier : sortedScanProcessorSuppliers) {
             final Scanner scannerIdentity = scanProcessorSupplier.scannerIdentity();
             final String scannerShortName = shortName(scannerIdentity);
 


### PR DESCRIPTION
Kafka Streams works based on topologies. It relies on the fact that the *exact* same topology is present on all instances of a KS app. This means that the order of topology nodes must be identical.

For the vulnerability-analyzer, users can enable or disable individual scanners. Only enabled scanners will be added to the topology on startup.

Scanners are CDI beans, and we inject all of them via [`Instance`](https://jakarta.ee/specifications/cdi/3.0/apidocs/jakarta/enterprise/inject/instance). `Instance` can contain zero or more beans.

Scanners are added to the topology by iterating over the `Instance` bean. The problem here is that the order of the beans in `Instance` is not guaranteed. It could happen that instance A of the service added scanners in the order 123, whereas instance B added them in order 213.

A symptom of this problem is the following exception, followed by a shutdown of Kafka Streams:

```
org.apache.kafka.streams.errors.TopologyException: Invalid topology: Topic hyades-vulnerability-analyzer-scan-task-ossindex-repartition is unknown to the topology. This may happen if different KafkaStreams instances of the same application execute different Topologies. Note that Topologies are only identical if all operators are added in the same order.
```

Sorting the beans before adding them to the topology resolved the issue.