### PR TITLE
Build and publish native images on release

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -108,12 +108,22 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ startsWith(github.repository, 'DependencyTrack/') }}
+    - name: Determine Container Tags
+      id: determine-container-tags
+      run: |-
+        VERSION="$(yq -p=xml '.project.version' pom.xml)"
+        TAGS="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/hyades-${{ inputs.module }}:${VERSION}-native"
+        if [[ $VERSION == *-SNAPSHOT ]]; then
+          TAGS="${TAGS},ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/hyades-${{ inputs.module }}:snapshot-native"
+        else
+          TAGS="${TAGS},ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/hyades-${{ inputs.module }}:latest-native"
+        fi
+        echo "tags=${TAGS}" >> $GITHUB_OUTPUT
     - name: Build Container Image
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # tag=v5.0.0
       with:
         context: ./${{ inputs.module }}
         file: ./${{ inputs.module }}/src/main/docker/Dockerfile.native-multiarch
         platforms: linux/amd64,linux/arm64
-        push: ${{ startsWith(github.repository, 'DependencyTrack/') }}
-        tags: ghcr.io/dependencytrack/hyades-${{ inputs.module }}:snapshot-native
+        push: true
+        tags: ${{ steps.determine-container-tags.outputs.tags }}

--- a/.github/workflows/build-native-mirror-service.yml
+++ b/.github/workflows/build-native-mirror-service.yml
@@ -8,8 +8,13 @@ on:
     - ".github/workflows/_build-native-meta.yml"
     - ".github/workflows/build-native-mirror-service.yml"
     - "commons/**"
+    - "commons-kstreams/**"
     - "mirror-service/**"
     - "pom.xml"
+    - "proto/**"
+  release:
+    types:
+    - released
   workflow_dispatch: { }
 
 permissions: { }

--- a/.github/workflows/build-native-notification-publisher.yml
+++ b/.github/workflows/build-native-notification-publisher.yml
@@ -8,8 +8,13 @@ on:
     - ".github/workflows/_build-native-meta.yml"
     - ".github/workflows/build-native-notification-publisher.yml"
     - "commons/**"
+    - "commons-persistence/**"
     - "notification-publisher/**"
     - "pom.xml"
+    - "proto/**"
+  release:
+    types:
+    - released
   workflow_dispatch: { }
 
 permissions: { }

--- a/.github/workflows/build-native-repository-meta-analyzer.yml
+++ b/.github/workflows/build-native-repository-meta-analyzer.yml
@@ -8,8 +8,14 @@ on:
     - ".github/workflows/_build-native-meta.yml"
     - ".github/workflows/build-native-notification-publisher.yml"
     - "commons/**"
+    - "commons-kstreams/**"
+    - "commons-persistence/**"
     - "repository-meta-analyzer/**"
     - "pom.xml"
+    - "proto/**"
+  release:
+    types:
+    - released
   workflow_dispatch: { }
 
 permissions: { }

--- a/.github/workflows/build-native-vulnerability-analyzer.yml
+++ b/.github/workflows/build-native-vulnerability-analyzer.yml
@@ -8,8 +8,14 @@ on:
     - ".github/workflows/_build-native-meta.yml"
     - ".github/workflows/build-native-notification-publisher.yml"
     - "commons/**"
+    - "commons-kstreams/**"
+    - "commons-persistence/**"
     - "vulnerability-analyzer/**"
     - "pom.xml"
+    - "proto/**"
+  release:
+    types:
+    - released
   workflow_dispatch: { }
 
 permissions: { }


### PR DESCRIPTION
Native images are built upon release now.

They'll be tagged as `<RELEASE_VERSION>-native`.

Additionally, they'll be tagged as `snapshot-native` or `latest-native`, depending on whether the build is happening for a `-SNAPSHOT` version or not. 

Closes #718