### PR TITLE
Build and publish docs upon release

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,9 @@ on:
       - mkdocs.yml
     branches:
       - main
+  release:
+    types:
+    - released
 
 permissions: { }
 


### PR DESCRIPTION
This makes the docs' versioning functionality work properly. Users will be able to switch between doc versions.