### PR TITLE
Fix `repartition.purge.interval.ms` not being configurable via environment variables

### DIFF
--- a/mirror-service/src/main/resources/application.properties
+++ b/mirror-service/src/main/resources/application.properties
@@ -45,6 +45,12 @@ quarkus.kafka-streams.topics=\
 %dev.quarkus.kafka.devservices.enabled=false
 kafka-streams.num.stream.threads=3
 kafka-streams.commit.interval.ms=1000
+# Using the default value of 30s in order to make the property configurable via environment variables.
+# Without this, Quarkus will interpret "KAFKA_STREAMS" as "kafka.streams", which fails its internal property
+# prefix check, which is expecting a "kafka-streams" prefix.
+# Overriding this property is required in cases where the Delete topic permission can not be granted to
+# Kafka clients (e.g. in multi-tenant Kafka clusters).
+kafka-streams.repartition.purge.interval.ms=30000
 
 ## Kafka Streams Exception Handling
 #

--- a/repository-meta-analyzer/src/main/resources/application.properties
+++ b/repository-meta-analyzer/src/main/resources/application.properties
@@ -26,6 +26,12 @@ kafka-streams.metrics.recording.level=DEBUG
 kafka-streams.num.stream.threads=3
 kafka-streams.compression.type=snappy
 quarkus.kafka.snappy.enabled=true
+# Using the default value of 30s in order to make the property configurable via environment variables.
+# Without this, Quarkus will interpret "KAFKA_STREAMS" as "kafka.streams", which fails its internal property
+# prefix check, which is expecting a "kafka-streams" prefix.
+# Overriding this property is required in cases where the Delete topic permission can not be granted to
+# Kafka clients (e.g. in multi-tenant Kafka clusters).
+kafka-streams.repartition.purge.interval.ms=30000
 
 ## Kafka Streams Exception Handling
 #

--- a/vulnerability-analyzer/src/main/resources/application.properties
+++ b/vulnerability-analyzer/src/main/resources/application.properties
@@ -2,10 +2,12 @@
 #
 quarkus.application.name=hyades-vulnerability-analyzer
 quarkus.http.port=8092
+
 ## Logging
 #
 quarkus.log.console.json=false
 quarkus.log.category."org.apache.kafka".level=WARN
+
 ## Kafka
 #
 %dev.kafka.bootstrap.servers=localhost:9092
@@ -28,6 +30,13 @@ kafka-streams.metrics.recording.level=DEBUG
 kafka-streams.num.stream.threads=3
 kafka-streams.max.task.idle.ms=1000
 kafka-streams.compression.type=snappy
+# Using the default value of 30s in order to make the property configurable via environment variables.
+# Without this, Quarkus will interpret "KAFKA_STREAMS" as "kafka.streams", which fails its internal property
+# prefix check, which is expecting a "kafka-streams" prefix.
+# Overriding this property is required in cases where the Delete topic permission can not be granted to
+# Kafka clients (e.g. in multi-tenant Kafka clusters).
+kafka-streams.repartition.purge.interval.ms=30000
+
 ## Kafka Streams Exception Handling
 #
 kafka-streams.default.deserialization.exception.handler=org.hyades.kstreams.exception.DeserializationExceptionHandler
@@ -38,21 +47,25 @@ kafka-streams.exception.thresholds.processing.count=50
 kafka-streams.exception.thresholds.processing.interval=PT30M
 kafka-streams.exception.thresholds.production.count=5
 kafka-streams.exception.thresholds.production.interval=PT30M
+
 ## Kafka Streams State Stores
 #
 state-store.type=in_memory
 # state-store.rocks-db.compaction-style=
 # state-store.rocks-db.compression-type=
+
 ## Dev Services for Kafka
 #
 quarkus.kafka.devservices.image-name=docker.redpanda.com/vectorized/redpanda:v23.2.8
 quarkus.kafka.devservices.topic-partitions."dtrack.vuln-analysis.component"=3
 quarkus.kafka.devservices.topic-partitions."dtrack.vuln-analysis.scanner.result"=3
 quarkus.kafka.devservices.topic-partitions."dtrack.vuln-analysis.result"=3
+
 ## Internal Scanner
 #
 scanner.internal.enabled=true
 scanner.internal.topic-partitions=3
+
 ## OSS Index Scanner
 #
 scanner.ossindex.enabled=true
@@ -80,6 +93,7 @@ scanner.ossindex.custom-package-urls-supported=conan,conda,swift,cocoapods,cran
 quarkus.rest-client."org.hyades.client.ossindex.OssIndexClient".url=${scanner.ossindex.api.baseurl}
 quarkus.rest-client."org.hyades.client.ossindex.OssIndexClient".connect-timeout=3000
 quarkus.rest-client."org.hyades.client.ossindex.OssIndexClient".read-timeout=3000
+
 ## Snyk Scanner
 #
 scanner.snyk.enabled=false
@@ -110,6 +124,7 @@ scanner.snyk.alias-sync-enabled=false
 quarkus.rest-client."org.hyades.client.snyk.SnykClient".url=${scanner.snyk.api.baseurl}
 quarkus.rest-client."org.hyades.client.snyk.SnykClient".connect-timeout=3000
 quarkus.rest-client."org.hyades.client.snyk.SnykClient".read-timeout=3000
+
 ## Cache
 #
 quarkus.cache.enabled=true
@@ -120,6 +135,7 @@ quarkus.cache.caffeine."snyk".initial-capacity=5
 quarkus.cache.caffeine."ossindex".expire-after-write=4H
 quarkus.cache.caffeine."ossindex".metrics-enabled=true
 quarkus.cache.caffeine."ossindex".initial-capacity=5
+
 quarkus.datasource.db-kind=postgresql
 # Always use quotes for keywords, column- and table names.
 # e.g. SELECT "FOO"."BAR" FROM "BAZ". This matches what the API server does,
@@ -137,6 +153,7 @@ quarkus.hibernate-orm.database.generation=validate
 quarkus.datasource.devservices.init-script-path=migrations/postgres/V0.0.1__API-Server-4.8.2.sql
 #%dev.quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.active=true
+
 ## Container Image
 #
 quarkus.container-image.registry=ghcr.io


### PR DESCRIPTION
See comments in `application.properties` for an explanation why. Will likely raise an issue with Quarkus for this.