### PR TITLE
Reduce default HTTP client timeouts

### DIFF
--- a/commons/src/main/java/org/hyades/config/HttpClientConfig.java
+++ b/commons/src/main/java/org/hyades/config/HttpClientConfig.java
@@ -17,13 +17,22 @@ public interface HttpClientConfig {
 
     Optional<String> noProxy();
 
-    @WithDefault("30")
+    /**
+     * @return Maximum number of seconds to wait for remote connections to be established.
+     */
+    @WithDefault("3")
     int proxyTimeoutConnection();
 
-    @WithDefault("60")
+    /**
+     * @return Maximum number of seconds to wait for a connection from the connection pool.
+     */
+    @WithDefault("3")
     int proxyTimeoutPool();
 
-    @WithDefault("30")
+    /**
+     * @return Maximum number of seconds to wait for data to be returned after a connection was established.
+     */
+    @WithDefault("3")
     int proxyTimeoutSocket();
 
     @WithDefault("200")


### PR DESCRIPTION
The previous defaults of 30s for connection-, and 30s for socket timeouts are too excessive for a system that needs to maintain high-ish throughput.

These values are aligned with what's configured for the Quarkus REST client in the vulnerability analyzer.