### PR TITLE
Fix line break issues when cloning repository on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+*       text=auto
+*.sh	text eol=lf


### PR DESCRIPTION
When checking out the repository, bash scripts would use the platform's native line breaks, which when done on Windows would break the scripts for Linux containers. One of them being the `create-topics.sh` script we mount into the `redpanda-init` container.