### PR TITLE
Use custom frontend with CEL and integrity analysis support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: dependencytrack/frontend:4.9.1
+    image: ghcr.io/dependencytrack/hyades-frontend:4.9.1
     container_name: dt-frontend
     environment:
       API_BASE_URL: "http://localhost:8080"

--- a/helm-charts/hyades/README.md
+++ b/helm-charts/hyades/README.md
@@ -70,7 +70,7 @@
 | frontend.extraEnv | object | `{}` |  |
 | frontend.extraEnvFrom | list | `[]` |  |
 | frontend.image.pullPolicy | string | `"Always"` |  |
-| frontend.image.repository | string | `"dependencytrack/frontend"` |  |
+| frontend.image.repository | string | `"dependencytrack/hyades-frontend"` |  |
 | frontend.image.tag | string | `"4.9.1"` |  |
 | frontend.ingress.annotations | object | `{}` |  |
 | frontend.ingress.enabled | bool | `false` |  |

--- a/helm-charts/hyades/templates/_helpers.tpl
+++ b/helm-charts/hyades/templates/_helpers.tpl
@@ -122,7 +122,7 @@ Frontend fully qualified name
 Frontend image
 */}}
 {{- define "hyades.frontendImage" -}}
-{{- printf "%s/%s:%s" "docker.io" .Values.frontend.image.repository (.Values.frontend.image.tag | default .Chart.AppVersion) -}}
+{{- printf "%s/%s:%s" .Values.common.image.registry .Values.frontend.image.repository (.Values.frontend.image.tag | default .Chart.AppVersion) -}}
 {{- end -}}
 
 

--- a/helm-charts/hyades/values.yaml
+++ b/helm-charts/hyades/values.yaml
@@ -72,7 +72,7 @@ frontend:
   replicaCount: 1
   annotations: {}
   image:
-    repository: dependencytrack/frontend
+    repository: dependencytrack/hyades-frontend
     tag: 4.9.1
     pullPolicy: Always
   command: []


### PR DESCRIPTION
We haven't officially forked the frontend yet, and the official frontend doesn't support CEL and integrity analysis yet.

This PR adds a customized v4.9.1 image that includes both functionalities. It was built from https://github.com/sahibamittal/dependency-track-frontend-upstream/commit/33d2b0086241b98c8f4a288caa938fb39362417e.