### PR TITLE
Add e2e test for vulnerability policies

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -34,6 +34,32 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>minio</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            minio needs a newer version of OkHttp than what's provided via the Quarkus parent POM.
+            Versions are hardcoded here to avoid them being overwritten by accident.
+        -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>3.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>

--- a/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.dependencytrack.apiserver.model.Analysis;
 import org.dependencytrack.apiserver.model.BomProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
 import org.dependencytrack.apiserver.model.BomUploadResponse;
@@ -22,6 +23,7 @@ import org.dependencytrack.apiserver.model.NotificationRule;
 import org.dependencytrack.apiserver.model.Project;
 import org.dependencytrack.apiserver.model.Team;
 import org.dependencytrack.apiserver.model.UpdateNotificationRuleRequest;
+import org.dependencytrack.apiserver.model.VulnerabilityPolicy;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.dependencytrack.apiserver.model.NotificationPublisher;
 
@@ -83,7 +85,7 @@ public interface ApiServerClient {
     @Path("/finding/project/{uuid}")
     @Produces(MediaType.WILDCARD)
     @Consumes(MediaType.APPLICATION_JSON)
-    List<Finding> getFindings(@PathParam("uuid") final UUID projectUuid);
+    List<Finding> getFindings(@PathParam("uuid") final UUID projectUuid, @QueryParam("suppressed") final boolean includeSuppressed);
 
     @GET
     @Path("/project/lookup")
@@ -114,5 +116,18 @@ public interface ApiServerClient {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     ConfigProperty updateConfigProperty(final ConfigProperty configProperty);
+
+    @GET
+    @Path("/policy/vulnerability")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<VulnerabilityPolicy> getAllVulnerabilityPolicies();
+
+    @GET
+    @Path("/analysis")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Analysis getAnalysis(@QueryParam("project") final UUID projectUuid, @QueryParam("component") final UUID componentUuid,
+                         @QueryParam("vulnerability") final UUID vulnUuid);
 
 }

--- a/e2e/src/main/java/org/dependencytrack/apiserver/model/Analysis.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/model/Analysis.java
@@ -1,0 +1,15 @@
+package org.dependencytrack.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Analysis(@JsonProperty("analysisComments") List<Comment> comments) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Comment(String comment, String commenter) {
+    }
+
+}

--- a/e2e/src/main/java/org/dependencytrack/apiserver/model/Finding.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/model/Finding.java
@@ -5,14 +5,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Finding(Component component, Project project, Vulnerability vulnerability, Attribution attribution) {
+public record Finding(Component component, UUID project, Vulnerability vulnerability, Attribution attribution,
+                      Analysis analysis) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Component(UUID uuid, String name, String version) {
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Project(UUID uuid, String name, String version) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,6 +19,10 @@ public record Finding(Component component, Project project, Vulnerability vulner
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Attribution(String analyzerIdentity, String attributedOn, String alternateIdentifier,
                               String referenceUrl) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Analysis(String state, Boolean isSuppressed) {
     }
 
 }

--- a/e2e/src/main/java/org/dependencytrack/apiserver/model/VulnerabilityPolicy.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/model/VulnerabilityPolicy.java
@@ -1,0 +1,7 @@
+package org.dependencytrack.apiserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VulnerabilityPolicy(String name) {
+}

--- a/e2e/src/test/java/org/dependencytrack/e2e/AbstractE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/AbstractE2ET.java
@@ -33,8 +33,8 @@ public class AbstractE2ET {
     protected static String REPO_META_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-repository-meta-analyzer:snapshot";
     protected static String VULN_ANALYZER_IMAGE = "ghcr.io/dependencytrack/hyades-vulnerability-analyzer:snapshot";
 
-    protected Logger logger;
-    private Network internalNetwork;
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final Network internalNetwork = Network.newNetwork();
     protected PostgreSQLContainer<?> postgresContainer;
     protected GenericContainer<?> redpandaContainer;
     protected GenericContainer<?> apiServerContainer;
@@ -45,10 +45,6 @@ public class AbstractE2ET {
 
     @BeforeEach
     void beforeEach() throws Exception {
-        logger = LoggerFactory.getLogger(getClass());
-
-        internalNetwork = Network.newNetwork();
-
         postgresContainer = createPostgresContainer();
         redpandaContainer = createRedpandaContainer();
         deepStart(postgresContainer, redpandaContainer).join();
@@ -202,6 +198,7 @@ public class AbstractE2ET {
         logger.info("Assigning permissions to e2e team");
         for (final String permission : Set.of(
                 "BOM_UPLOAD",
+                "POLICY_MANAGEMENT",
                 "PORTFOLIO_MANAGEMENT",
                 "PROJECT_CREATION_UPLOAD",
                 "SYSTEM_CONFIGURATION",

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadOssIndexAnalysisE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadOssIndexAnalysisE2ET.java
@@ -58,7 +58,7 @@ class BomUploadOssIndexAnalysisE2ET extends AbstractE2ET {
         final Project project = apiServerClient.lookupProject("foo", "bar");
 
         // Ensure that vulnerabilities have been reported correctly.
-        final List<Finding> findings = apiServerClient.getFindings(project.uuid());
+        final List<Finding> findings = apiServerClient.getFindings(project.uuid(), false);
         assertThat(findings)
                 .hasSizeGreaterThan(1)
                 .allSatisfy(

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
@@ -161,7 +161,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
         final Project project = apiServerClient.lookupProject("foo", "bar");
 
         // Ensure the internal vulnerability has been flagged.
-        final List<Finding> findings = apiServerClient.getFindings(project.uuid());
+        final List<Finding> findings = apiServerClient.getFindings(project.uuid(), false);
         assertThat(findings).satisfiesExactly(
                 finding -> {
                     assertThat(finding.component().name()).isEqualTo("jackson-databind");

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadSnykAnalysisE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadSnykAnalysisE2ET.java
@@ -71,7 +71,7 @@ class BomUploadSnykAnalysisE2ET extends AbstractE2ET {
         final Project project = apiServerClient.lookupProject("foo", "bar");
 
         // Ensure that vulnerabilities have been reported correctly.
-        final List<Finding> findings = apiServerClient.getFindings(project.uuid());
+        final List<Finding> findings = apiServerClient.getFindings(project.uuid(), false);
         assertThat(findings)
                 .hasSizeGreaterThan(1)
                 .allSatisfy(

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -1,0 +1,487 @@
+package org.dependencytrack.e2e;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.UploadObjectArgs;
+import jakarta.ws.rs.WebApplicationException;
+import org.apache.commons.io.IOUtils;
+import org.dependencytrack.apiserver.model.Analysis;
+import org.dependencytrack.apiserver.model.BomProcessingResponse;
+import org.dependencytrack.apiserver.model.BomUploadRequest;
+import org.dependencytrack.apiserver.model.BomUploadResponse;
+import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
+import org.dependencytrack.apiserver.model.CreateVulnerabilityRequest;
+import org.dependencytrack.apiserver.model.Finding;
+import org.dependencytrack.apiserver.model.NotificationPublisher;
+import org.dependencytrack.apiserver.model.NotificationRule;
+import org.dependencytrack.apiserver.model.Project;
+import org.dependencytrack.apiserver.model.UpdateNotificationRuleRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MinIOContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+
+class VulnerabilityPolicyE2ET extends AbstractE2ET {
+
+    private static final String BUNDLE_BUCKET_NAME = "dt-vuln-policies";
+    private static final String BUNDLE_FILE_NAME = "bundle.zip";
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    private MinIOContainer minioContainer;
+
+    @Override
+    @BeforeEach
+    void beforeEach() throws Exception {
+        // host.docker.internal may not always be available, so use testcontainer's
+        // solution for host port exposure instead: https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
+        Testcontainers.exposeHostPorts(wireMock.getRuntimeInfo().getHttpPort());
+
+        minioContainer = new MinIOContainer(DockerImageName.parse("minio/minio:RELEASE.2023-12-14T18-51-57Z"))
+                .withNetworkAliases("minio")
+                .withNetwork(internalNetwork);
+        minioContainer.start();
+
+        createAndUploadPolicyBundle();
+
+        super.beforeEach();
+    }
+
+    @Override
+    protected void customizeApiServerContainer(final GenericContainer<?> container) {
+        container
+                // Enable vulnerability policies.
+                .withEnv("VULNERABILITY_POLICY_ANALYSIS_ENABLED", "true")
+                // Configure vulnerability policies to be fetched from bundles in S3.
+                .withEnv("VULNERABILITY_POLICY_BUNDLE_URL", "http://minio:9000")
+                .withEnv("VULNERABILITY_POLICY_BUNDLE_SOURCE_TYPE", "s3")
+                .withEnv("VULNERABILITY_POLICY_S3_ACCESS_KEY", minioContainer.getUserName())
+                .withEnv("VULNERABILITY_POLICY_S3_SECRET_KEY", minioContainer.getPassword())
+                .withEnv("VULNERABILITY_POLICY_S3_BUCKET_NAME", BUNDLE_BUCKET_NAME)
+                .withEnv("VULNERABILITY_POLICY_S3_BUNDLE_NAME", BUNDLE_FILE_NAME)
+                // Configure policy bundle fetching to occur 5s after startup,
+                // and every minute from then on.
+                .withEnv("TASK_SCHEDULER_INITIAL_DELAY", "5000")
+                .withEnv("TASK_CRON_VULNERABILITY_POLICY_BUNDLE_FETCH", "* * * * *");
+    }
+
+    @Override
+    protected void customizeVulnAnalyzerContainer(final GenericContainer<?> container) {
+        // Disable all scanners except the internal one.
+        container
+                .withEnv("SCANNER_INTERNAL_ENABLED", "true")
+                .withEnv("SCANNER_OSSINDEX_ENABLED", "false")
+                .withEnv("SCANNER_SNYK_ENABLED", "false");
+    }
+
+    @Override
+    @AfterEach
+    void afterEach() {
+        Optional.ofNullable(minioContainer).ifPresent(GenericContainer::stop);
+
+        super.afterEach();
+    }
+
+    @Test
+    void test() throws Exception {
+        // Configure NEW_VULNERABLE_DEPENDENCY and NEW_VULNERABILITY webhook notifications.
+        setUpWebhookNotifications();
+
+        // Wait for policies to be reconciled.
+        await("Vulnerability Policy Reconciliation")
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> assertThat(apiServerClient.getAllVulnerabilityPolicies()).hasSize(2));
+
+        // Create a medium severity vulnerability for commons-io.
+        // commons-io is introduced through us.springett:alpine-server and is thus covered by the policy.
+        apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-001", "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L", null, List.of(
+                new CreateVulnerabilityRequest.AffectedComponent("PURL", "pkg:maven/commons-io/commons-io@2.11.0", "EXACT")
+        )));
+        // Create another vulnerability for commons-io, but this time with high severity.
+        // As the policy suppresses findings of severity medium or lower, this finding is not covered by it.
+        apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-002", "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H", null, List.of(
+                new CreateVulnerabilityRequest.AffectedComponent("PURL", "pkg:maven/commons-io/commons-io@2.11.0", "EXACT")
+        )));
+        // Create a critical vulnerability for commons-io.
+        apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-003", "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", null, List.of(
+                new CreateVulnerabilityRequest.AffectedComponent("PURL", "pkg:maven/commons-io/commons-io@2.11.0", "EXACT")
+        )));
+
+        // Parse and base64 encode a BOM.
+        final byte[] bomBytes = IOUtils.resourceToByteArray("/dtrack-apiserver-4.5.0.bom.json");
+        final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
+
+        // Upload the BOM.
+        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        assertThat(response.token()).isNotEmpty();
+
+        // Wait up to 15sec for the BOM processing to complete.
+        await("BOM processing")
+                .atMost(Duration.ofSeconds(15))
+                .pollDelay(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    assertThat(processingResponse.processing()).isFalse();
+                });
+
+        // Lookup the project we just created.
+        final Project project = apiServerClient.lookupProject("foo", "bar");
+
+        // Ensure the policy has been applied.
+        final List<Finding> findings = apiServerClient.getFindings(project.uuid(), true);
+        assertThat(findings).satisfiesExactly(
+                finding -> {
+                    assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-001");
+                    assertThat(finding.analysis().state()).isEqualTo("FALSE_POSITIVE");
+                    assertThat(finding.analysis().isSuppressed()).isTrue();
+
+                    final Analysis analysis = apiServerClient.getAnalysis(finding.project(),
+                            finding.component().uuid(), finding.vulnerability().uuid());
+                    assertThat(analysis).isNotNull();
+                    assertThat(analysis.comments()).extracting(Analysis.Comment::comment).containsExactlyInAnyOrder(
+                            """
+                                    Matched on condition(s):
+                                    - vuln.severity in ["UNASSIGNED", "INFO", "LOW", "MEDIUM"]
+                                    - component.is_dependency_of(org.dependencytrack.policy.v1.Component{group: "us.springett"})\
+                                    """,
+                            "State: NOT_SET → FALSE_POSITIVE",
+                            "Unsuppressed → Suppressed"
+                    );
+                },
+                finding -> {
+                    assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-002");
+                    assertThat(finding.analysis().state()).isNull();
+                    assertThat(finding.analysis().isSuppressed()).isFalse();
+
+                    // No analysis has been applied, so requesting it should yield a 404.
+                    assertThatExceptionOfType(WebApplicationException.class)
+                            .isThrownBy(() -> apiServerClient.getAnalysis(finding.project(),
+                                    finding.component().uuid(), finding.vulnerability().uuid()))
+                            .withMessage("Unknown error, status code 404");
+                },
+                finding -> {
+                    assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-003");
+                    assertThat(finding.analysis().state()).isEqualTo("IN_TRIAGE");
+                    assertThat(finding.analysis().isSuppressed()).isFalse();
+
+                    final Analysis analysis = apiServerClient.getAnalysis(finding.project(),
+                            finding.component().uuid(), finding.vulnerability().uuid());
+                    assertThat(analysis).isNotNull();
+                    assertThat(analysis.comments()).extracting(Analysis.Comment::comment).containsExactlyInAnyOrder(
+                            """
+                                    Matched on condition(s):
+                                    - component.name == "commons-io"
+                                      && vuln.id == "INT-003"
+                                      && !project.depends_on(org.dependencytrack.policy.v1.Component{name: "tomcat-embed-core"})\
+                                    """,
+                            "State: NOT_SET → IN_TRIAGE",
+                            "Severity: CRITICAL → LOW",
+                            "CVSSv2 Score: (None) → 2.6"
+                    );
+                }
+        );
+
+        await("NEW_VULNERABLE_DEPENDENCY notification")
+                .atMost(Duration.ofSeconds(15))
+                .untilAsserted(this::verifyNewVulnerableDependencyNotification);
+
+        await("NEW_VULNERABILITY notifications")
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(this::verifyNewVulnerabilityNotifications);
+    }
+
+    private void createAndUploadPolicyBundle() throws Exception {
+        final Path policyBundlePath = Files.createTempFile("hyades-e2e-", ".zip");
+        logger.info("Packaging policy bundle at %s".formatted(policyBundlePath));
+        try (final OutputStream fileOutputStream = Files.newOutputStream(policyBundlePath);
+             final var zipOutputStream = new ZipOutputStream(fileOutputStream)) {
+            // Create a policy that suppresses findings of severities below HIGH, if the respective
+            // component is a transitive dependency of a component with `us.springett` namespace.
+            zipOutputStream.putNextEntry(new ZipEntry("foo-01.yml"));
+            IOUtils.copy(new StringReader("""
+                    apiVersion: v1.0
+                    type: Vulnerability Policy
+                    name: Foo-01
+                    conditions:
+                    - vuln.severity in ["UNASSIGNED", "INFO", "LOW", "MEDIUM"]
+                    - |-
+                      component.is_dependency_of(org.dependencytrack.policy.v1.Component{group: "us.springett"})
+                    analysis:
+                      state: FALSE_POSITIVE
+                      suppress: true
+                    """), zipOutputStream, StandardCharsets.UTF_8);
+
+            // Create a policy that downgrades occurrences of INT-003 for commons-io to LOW,
+            // as long as tomcat-embed-core is not present in the project (which it isn't in this test).
+            zipOutputStream.putNextEntry(new ZipEntry("foo-02.yml"));
+            IOUtils.copy(new StringReader("""
+                    apiVersion: v1.0
+                    type: Vulnerability Policy
+                    name: Foo-02
+                    conditions:
+                    - |-
+                      component.name == "commons-io"
+                        && vuln.id == "INT-003"
+                        && !project.depends_on(org.dependencytrack.policy.v1.Component{name: "tomcat-embed-core"})
+                    analysis:
+                      state: IN_TRIAGE
+                    ratings:
+                    - method: CVSSV2
+                      severity: LOW
+                      score: 2.6
+                    """), zipOutputStream, StandardCharsets.UTF_8);
+        }
+
+        final var minioClient = MinioClient.builder()
+                .endpoint(minioContainer.getS3URL())
+                .credentials(minioContainer.getUserName(), minioContainer.getPassword())
+                .build();
+
+        logger.info("Creating S3 bucket");
+        minioClient.makeBucket(MakeBucketArgs.builder()
+                .bucket(BUNDLE_BUCKET_NAME)
+                .build());
+
+        logger.info("Uploading policy bundle to S3");
+        minioClient.uploadObject(UploadObjectArgs.builder()
+                .bucket(BUNDLE_BUCKET_NAME)
+                .object(BUNDLE_FILE_NAME)
+                .filename(policyBundlePath.toString())
+                .build());
+    }
+
+    private void setUpWebhookNotifications() {
+        final List<NotificationPublisher> publishers = apiServerClient.getAllNotificationPublishers();
+
+        // Find the webhook notification publisher.
+        final NotificationPublisher webhookPublisher = publishers.stream()
+                .filter(publisher -> publisher.name().equals("Outbound Webhook"))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("Unable to find webhook notification publisher"));
+
+        // Create a webhook alert for NEW_VULNERABILITY
+        final NotificationRule newVulnerabilityRule = apiServerClient.createNotificationRule(new CreateNotificationRuleRequest(
+                "foo", "PORTFOLIO", "INFORMATIONAL", new CreateNotificationRuleRequest.Publisher(webhookPublisher.uuid())));
+        apiServerClient.updateNotificationRule(new UpdateNotificationRuleRequest(newVulnerabilityRule.uuid(), newVulnerabilityRule.name(), true,
+                "INFORMATIONAL", Set.of("NEW_VULNERABILITY"), """
+                {
+                  "destination": "http://host.testcontainers.internal:%d/notification/newVuln"
+                }
+                """.formatted(wireMock.getPort())));
+
+        // ... and NEW_VULNERABLE_DEPENDENCY notifications
+        final NotificationRule newVulnerableDependencyRule = apiServerClient.createNotificationRule(new CreateNotificationRuleRequest(
+                "foo", "PORTFOLIO", "INFORMATIONAL", new CreateNotificationRuleRequest.Publisher(webhookPublisher.uuid())));
+        apiServerClient.updateNotificationRule(new UpdateNotificationRuleRequest(newVulnerableDependencyRule.uuid(), newVulnerableDependencyRule.name(), true,
+                "INFORMATIONAL", Set.of("NEW_VULNERABLE_DEPENDENCY"), """
+                {
+                  "destination": "http://host.testcontainers.internal:%d/notification/newVulnDependency"
+                }
+                """.formatted(wireMock.getPort())));
+
+        // ... and ensure WireMock will acknowledge them.
+        wireMock.stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(201)));
+    }
+
+    private void verifyNewVulnerableDependencyNotification() {
+        wireMock.verify(postRequestedFor(urlPathEqualTo("/notification/newVulnDependency"))
+                .withRequestBody(equalToJson("""
+                        {
+                          "notification": {
+                            "level": "LEVEL_INFORMATIONAL",
+                            "scope": "SCOPE_PORTFOLIO",
+                            "group": "GROUP_NEW_VULNERABLE_DEPENDENCY",
+                            "timestamp": "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]{3}Z$)",
+                            "title" : "Vulnerable Dependency Introduced on Project: [pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war]",
+                            "content" : "A dependency was introduced that contains 2 known vulnerabilities",
+                            "subject": {
+                              "component": {
+                                "uuid": "${json-unit.any-string}",
+                                "group": "commons-io",
+                                "name": "commons-io",
+                                "version": "2.11.0",
+                                "purl": "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+                                "md5": "3b4b7ccfaeceeac240b804839ee1a1ca",
+                                "sha1": "a2503f302b11ebde7ebc3df41daebe0e4eea3689",
+                                "sha256": "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908",
+                                "sha512": "5bd78eed456ede30119319c5bed8e3e4c443b6fd7bdb3a7a5686647bd83094d0c3e2832a7575cfb60e4ef25f08106b93476939d3adcfecf5533cc030b3039e10"
+                              },
+                              "project": {
+                                "uuid": "${json-unit.any-string}",
+                                "name": "foo",
+                                "version": "bar",
+                                "purl": "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war"
+                              },
+                              "vulnerabilities": [
+                                {
+                                  "uuid": "${json-unit.any-string}",
+                                  "vulnId": "INT-002",
+                                  "source": "INTERNAL",
+                                  "cvssv3": 7.1,
+                                  "severity": "HIGH"
+                                },
+                                {
+                                  "uuid": "${json-unit.any-string}",
+                                  "vulnId": "INT-003",
+                                  "source": "INTERNAL",
+                                  "cvssv2": 2.6,
+                                  "severity": "LOW"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                        """, /* ignoreArrayOrder */ true, /* ignoreExtraElements */ false)
+                )
+        );
+    }
+
+    private void verifyNewVulnerabilityNotifications() {
+        // Notification for INT-001.
+        wireMock.verify(postRequestedFor(urlPathEqualTo("/notification/newVuln"))
+                .withRequestBody(equalToJson("""
+                        {
+                          "notification": {
+                            "level": "LEVEL_INFORMATIONAL",
+                            "scope": "SCOPE_PORTFOLIO",
+                            "group": "GROUP_NEW_VULNERABILITY",
+                            "timestamp": "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]{3}Z$)",
+                            "title" : "New Vulnerability Identified on Project: [pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war]",
+                            "content" : "INT-002",
+                            "subject": {
+                              "component": {
+                                "uuid": "${json-unit.any-string}",
+                                "group": "commons-io",
+                                "name": "commons-io",
+                                "version": "2.11.0",
+                                "purl": "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+                                "md5": "3b4b7ccfaeceeac240b804839ee1a1ca",
+                                "sha1": "a2503f302b11ebde7ebc3df41daebe0e4eea3689",
+                                "sha256": "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908",
+                                "sha512": "5bd78eed456ede30119319c5bed8e3e4c443b6fd7bdb3a7a5686647bd83094d0c3e2832a7575cfb60e4ef25f08106b93476939d3adcfecf5533cc030b3039e10"
+                              },
+                              "project": {
+                                "uuid": "${json-unit.any-string}",
+                                "name": "foo",
+                                "version": "bar",
+                                "purl": "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war"
+                              },
+                              "vulnerability": {
+                                "uuid": "${json-unit.any-string}",
+                                "vulnId": "INT-002",
+                                "source": "INTERNAL",
+                                "cvssv3": 7.1,
+                                "severity": "HIGH"
+                              },
+                              "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
+                              "affectedProjects": [
+                                {
+                                  "uuid": "${json-unit.any-string}",
+                                  "name": "foo",
+                                  "version": "bar",
+                                  "purl": "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war"
+                                }
+                              ],
+                              "affectedProjectsReference" : {
+                                "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-002/projects",
+                                "frontendUri": "/vulnerabilities/INTERNAL/INT-002/affectedProjects"
+                              }
+                            }
+                          }
+                        }
+                        """)
+                )
+        );
+
+        // Notification for INT-003, but with downgraded severity.
+        wireMock.verify(postRequestedFor(urlPathEqualTo("/notification/newVuln"))
+                .withRequestBody(equalToJson("""
+                        {
+                          "notification": {
+                            "level": "LEVEL_INFORMATIONAL",
+                            "scope": "SCOPE_PORTFOLIO",
+                            "group": "GROUP_NEW_VULNERABILITY",
+                            "timestamp": "${json-unit.regex}(^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]{3}Z$)",
+                            "title" : "New Vulnerability Identified on Project: [pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war]",
+                            "content" : "INT-003",
+                            "subject": {
+                              "component": {
+                                "uuid": "${json-unit.any-string}",
+                                "group": "commons-io",
+                                "name": "commons-io",
+                                "version": "2.11.0",
+                                "purl": "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+                                "md5": "3b4b7ccfaeceeac240b804839ee1a1ca",
+                                "sha1": "a2503f302b11ebde7ebc3df41daebe0e4eea3689",
+                                "sha256": "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908",
+                                "sha512": "5bd78eed456ede30119319c5bed8e3e4c443b6fd7bdb3a7a5686647bd83094d0c3e2832a7575cfb60e4ef25f08106b93476939d3adcfecf5533cc030b3039e10"
+                              },
+                              "project": {
+                                "uuid": "${json-unit.any-string}",
+                                "name": "foo",
+                                "version": "bar",
+                                "purl": "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war"
+                              },
+                              "vulnerability": {
+                                "uuid": "${json-unit.any-string}",
+                                "vulnId": "INT-003",
+                                "source": "INTERNAL",
+                                "cvssv2": 2.6,
+                                "severity": "LOW"
+                              },
+                              "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
+                              "affectedProjects": [
+                                {
+                                  "uuid": "${json-unit.any-string}",
+                                  "name": "foo",
+                                  "version": "bar",
+                                  "purl": "pkg:maven/org.dependencytrack/dependency-track@4.5.0?type=war"
+                                }
+                              ],
+                              "affectedProjectsReference" : {
+                                "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-003/projects",
+                                "frontendUri": "/vulnerabilities/INTERNAL/INT-003/affectedProjects"
+                              }
+                            }
+                          }
+                        }
+                        """)
+                )
+        );
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <lib.kafka.version>3.6.1</lib.kafka.version>
     <lib.maven-artifact.version>4.0.0-alpha-9</lib.maven-artifact.version>
     <lib.micrometer-jvm-extras.version>0.2.2</lib.micrometer-jvm-extras.version>
+    <lib.minio.version>8.5.7</lib.minio.version>
     <lib.mockserver-netty.version>5.15.0</lib.mockserver-netty.version>
     <lib.org-json.version>20231013</lib.org-json.version>
     <lib.pebble.version>3.2.2</lib.pebble.version>
@@ -65,6 +66,7 @@
     <lib.packageurl-java.version>1.5.0</lib.packageurl-java.version>
     <lib.protobuf-java.version>3.25.1</lib.protobuf-java.version>
     <lib.snappy-java.version>1.1.10.5</lib.snappy-java.version>
+    <lib.testcontainers-minio.version>1.19.3</lib.testcontainers-minio.version>
     <lib.wiremock.version>2.35.1</lib.wiremock.version>
     <lib.xercesimpl.version>2.12.2</lib.xercesimpl.version>
     <quarkus.platform.version>3.5.3</quarkus.platform.version>
@@ -232,6 +234,12 @@
       </dependency>
 
       <dependency>
+        <groupId>io.minio</groupId>
+        <artifactId>minio</artifactId>
+        <version>${lib.minio.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.package-url</groupId>
         <artifactId>packageurl-java</artifactId>
         <version>${lib.packageurl-java.version}</version>
@@ -251,6 +259,12 @@
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
         <version>${lib.snappy-java.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>minio</artifactId>
+        <version>${lib.testcontainers-minio.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The test includes:

* Pulling policies from S3 (MinIO)
* Reconciliation of policies with database
* Application of policies for suppression and rating downgrade
* Verification of notifications sent

Closes #960

> [!NOTE]
> Requires https://github.com/DependencyTrack/hyades-apiserver/pull/493 to succeed.