### PR TITLE
Fix confusion of IDs when `SNYK-` vulnerabilities are reported in `problems` array

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/client/snyk/ModelConverterToCdx.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/client/snyk/ModelConverterToCdx.java
@@ -13,6 +13,8 @@ import org.cyclonedx.proto.v1_4.VulnerabilityReference;
 import org.dependencytrack.common.cwe.Cwe;
 import org.dependencytrack.common.cwe.CweResolver;
 import org.dependencytrack.commonutil.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import us.springett.cvss.Cvss;
 import us.springett.cvss.CvssV2;
 
@@ -23,7 +25,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.regex.Pattern;
 
 import static org.cyclonedx.proto.v1_4.ScoreMethod.SCORE_METHOD_CVSSV2;
 import static org.cyclonedx.proto.v1_4.ScoreMethod.SCORE_METHOD_CVSSV3;
@@ -38,6 +40,8 @@ import static org.dependencytrack.commonutil.VulnerabilityUtil.trimSummary;
 
 public final class ModelConverterToCdx {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModelConverterToCdx.class);
+    private static final Pattern VULN_ID_PATTERN = Pattern.compile("^SNYK-.+$");
     static final String TITLE_PROPERTY_NAME = "dependency-track:vuln:title";
 
     private ModelConverterToCdx() {
@@ -63,12 +67,22 @@ public final class ModelConverterToCdx {
 
         Vulnerability.Builder vulnerability = Vulnerability.newBuilder();
 
-        //If it is a legacy vulnerability from SNYK, we want the id from the problem where source is SNYK
-        //This id will take precedence over id of page data itself
-        Stream.of(getNewIdForLegacySnykVulnIfExists(pageData), Optional.ofNullable(pageData.id()))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .findFirst().ifPresent(vulnerability::setId);
+        // If it is a legacy vulnerability from SNYK, we want the id from the problem where source is SNYK.
+        // This id will take precedence over id of page data itself, BUT ONLY IF the page data ID is not already
+        // in the "current" format.
+        String vulnId = pageData.id();
+        if (!VULN_ID_PATTERN.matcher(vulnId).matches()) {
+            final Optional<String> optionalId = getNewIdForLegacySnykVulnIfExists(pageData);
+            if (optionalId.isPresent()) {
+                vulnId = optionalId.get();
+            } else {
+                LOGGER.warn("""
+                        Vulnerability %s does not match the expected ID pattern, and does not specify
+                        an alternative ID in the "problems" array. Received "problems": %s""".formatted(vulnId,
+                        pageData.attributes().problems() != null ? pageData.attributes().problems() : null));
+            }
+        }
+        vulnerability.setId(vulnId);
 
         vulnerability.setSource(Source.newBuilder().setName("SNYK"));
         Optional.ofNullable(pageData.attributes().title()).ifPresent(title -> vulnerability.addProperties(
@@ -255,12 +269,13 @@ public final class ModelConverterToCdx {
 
     private static Optional<String> getNewIdForLegacySnykVulnIfExists(final PageData<Issue> pageData) {
         String vulnId = null;
-        if(pageData.attributes().problems() != null) {
+        if (pageData.attributes().problems() != null) {
             Optional<Problem> sourceProblem = pageData.attributes().problems()
                     .stream()
                     .filter(problem -> problem.source().equals("SNYK"))
+                    .filter(problem -> problem.id() != null && VULN_ID_PATTERN.matcher(problem.id()).matches())
                     .findFirst();
-            if(sourceProblem.isPresent()) {
+            if (sourceProblem.isPresent()) {
                 vulnId = sourceProblem.get().id();
             }
         }

--- a/vulnerability-analyzer/src/test/java/org/dependencytrack/client/snyk/ModelConverterToCdxTest.java
+++ b/vulnerability-analyzer/src/test/java/org/dependencytrack/client/snyk/ModelConverterToCdxTest.java
@@ -2,8 +2,9 @@ package org.dependencytrack.client.snyk;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.dependencytrack.serde.ObjectMapperCustomizer;
+import org.cyclonedx.proto.v1_4.VulnerabilityReference;
 import org.dependencytrack.common.cwe.CweResolver;
+import org.dependencytrack.serde.ObjectMapperCustomizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.cyclonedx.proto.v1_4.ScoreMethod.SCORE_METHOD_CVSSV31;
 import static org.cyclonedx.proto.v1_4.Severity.SEVERITY_CRITICAL;
 import static org.cyclonedx.proto.v1_4.Severity.SEVERITY_HIGH;
-import static org.dependencytrack.client.snyk.ModelConverterToCdx.convert;
 
 class ModelConverterToCdxTest {
 
@@ -259,7 +259,7 @@ class ModelConverterToCdxTest {
     }
 
     @Test
-    public void shouldSetIdFromProblemForSnykSource() throws Exception {
+    void shouldSetIdFromProblemForSnykSource() throws Exception {
         final PageData<Issue> issue = objectMapper.readValue("""
                 {
                   "id": "npm:js/some/old/id",
@@ -296,6 +296,116 @@ class ModelConverterToCdxTest {
         final var severitySourcePriority = List.of(SeveritySource.NVD, SeveritySource.REDHAT, SeveritySource.SNYK);
         final var vuln = ModelConverterToCdx.convert(CweResolver.getInstance(), severitySourcePriority, issue, false);
         assertThat(vuln.getId()).isEqualTo("SNYK-JAVA-COMFASTERXMLWOODSTOX-2928754");
+    }
+
+    @Test
+    void testConvertWithNonLegacyIdAndOtherNonLegacyIdsInProblems() throws Exception {
+        final PageData<Issue> issue = objectMapper.readValue("""
+                {
+                  "id": "SNYK-JS-MINIMIST-2429795",
+                  "type": "issue",
+                  "attributes": {
+                    "title": "Prototype Pollution",
+                    "type": "package_vulnerability",
+                    "created_at": "2022-03-18T13:02:08.840039Z",
+                    "updated_at": "2023-11-08T09:43:26.766318Z",
+                    "description": "## Overview\\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module...",
+                    "problems": [
+                      {
+                        "id": "CVE-2021-44906",
+                        "source": "CVE"
+                      },
+                      {
+                        "id": "CWE-1321",
+                        "source": "CWE"
+                      },
+                      {
+                        "id": "SNYK-JS-MINIMIST-559764",
+                        "source": "SNYK"
+                      }
+                    ],
+                    "coordinates": [
+                      {
+                        "representations": [
+                          {
+                            "resource_path": "<0.2.4,>=1.2.0 <1.2.6"
+                          },
+                          {
+                            "package": {
+                              "name": "minimist",
+                              "version": "1.2.0",
+                              "type": "npm",
+                              "url": "pkg:npm/minimist@1.2.0"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "severities": [],
+                    "effective_severity_level": "low",
+                    "slots": {}
+                  }
+                }
+                """, new TypeReference<>() {
+        });
+
+        final var severitySourcePriority = List.of(SeveritySource.NVD, SeveritySource.REDHAT, SeveritySource.SNYK);
+        final var vuln = ModelConverterToCdx.convert(CweResolver.getInstance(), severitySourcePriority, issue, true);
+        assertThat(vuln.getId()).isEqualTo("SNYK-JS-MINIMIST-2429795");
+        assertThat(vuln.getReferencesList()).extracting(VulnerabilityReference::getId).containsExactly("CVE-2021-44906");
+    }
+
+    @Test
+    void testConvertWithLegacyIdAndWithoutNonLegacyIdsInProblems() throws Exception {
+        final PageData<Issue> issue = objectMapper.readValue("""
+                {
+                  "id": "npm:js/some/old/id",
+                  "type": "issue",
+                  "attributes": {
+                    "title": "Prototype Pollution",
+                    "type": "package_vulnerability",
+                    "created_at": "2022-03-18T13:02:08.840039Z",
+                    "updated_at": "2023-11-08T09:43:26.766318Z",
+                    "description": "## Overview\\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module...",
+                    "problems": [
+                      {
+                        "id": "CVE-2021-44906",
+                        "source": "CVE"
+                      },
+                      {
+                        "id": "CWE-1321",
+                        "source": "CWE"
+                      }
+                    ],
+                    "coordinates": [
+                      {
+                        "representations": [
+                          {
+                            "resource_path": "<0.2.4,>=1.2.0 <1.2.6"
+                          },
+                          {
+                            "package": {
+                              "name": "minimist",
+                              "version": "1.2.0",
+                              "type": "npm",
+                              "url": "pkg:npm/minimist@1.2.0"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "severities": [],
+                    "effective_severity_level": "low",
+                    "slots": {}
+                  }
+                }
+                """, new TypeReference<>() {
+        });
+
+        final var severitySourcePriority = List.of(SeveritySource.NVD, SeveritySource.REDHAT, SeveritySource.SNYK);
+        final var vuln = ModelConverterToCdx.convert(CweResolver.getInstance(), severitySourcePriority, issue, true);
+        assertThat(vuln.getId()).isEqualTo("npm:js/some/old/id");
+        assertThat(vuln.getReferencesList()).extracting(VulnerabilityReference::getId).containsExactly("CVE-2021-44906");
     }
 
 }


### PR DESCRIPTION
Originally this should only happen when the main ID of a vulnerability followed a legacy format. Now, it seems like `SNYK-` vulnerabilities can also reference other `SNYK-` vulnerabilities.