### PR TITLE
Incorporate manual sync trigger in vuln policy e2e test

### DIFF
--- a/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
@@ -13,7 +13,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.dependencytrack.apiserver.model.Analysis;
 import org.dependencytrack.apiserver.model.BomProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
-import org.dependencytrack.apiserver.model.BomUploadResponse;
+import org.dependencytrack.apiserver.model.WorkflowTokenResponse;
 import org.dependencytrack.apiserver.model.ConfigProperty;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
 import org.dependencytrack.apiserver.model.CreateTeamRequest;
@@ -68,7 +68,7 @@ public interface ApiServerClient {
     @Path("/bom")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    BomUploadResponse uploadBom(final BomUploadRequest request);
+    WorkflowTokenResponse uploadBom(final BomUploadRequest request);
 
     @GET
     @Path("/bom/token/{token}")
@@ -124,6 +124,12 @@ public interface ApiServerClient {
     @Consumes(MediaType.APPLICATION_JSON)
     List<VulnerabilityPolicy> getAllVulnerabilityPolicies();
 
+    @POST
+    @Path("/policy/vulnerability/bundle/sync")
+    @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
+    WorkflowTokenResponse triggerVulnerabilityPolicyBundleSync();
+
     @GET
     @Path("/analysis")
     @Produces(MediaType.WILDCARD)
@@ -135,7 +141,7 @@ public interface ApiServerClient {
     @Path("/finding/project/{uuid}/analyze")
     @Produces(MediaType.WILDCARD)
     @Consumes(MediaType.APPLICATION_JSON)
-    BomUploadResponse analyzeProject(@PathParam("uuid") final UUID projectUuid);
+    WorkflowTokenResponse analyzeProject(@PathParam("uuid") final UUID projectUuid);
 
     @GET
     @Path("/workflow/token/{token}/status")

--- a/e2e/src/main/java/org/dependencytrack/apiserver/model/WorkflowTokenResponse.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/model/WorkflowTokenResponse.java
@@ -3,5 +3,5 @@ package org.dependencytrack.apiserver.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record BomUploadResponse(String token) {
+public record WorkflowTokenResponse(String token) {
 }

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomProcessedNotificationDelayedE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomProcessedNotificationDelayedE2ET.java
@@ -2,7 +2,7 @@ package org.dependencytrack.e2e;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
-import org.dependencytrack.apiserver.model.BomUploadResponse;
+import org.dependencytrack.apiserver.model.WorkflowTokenResponse;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
 import org.dependencytrack.apiserver.model.CreateVulnerabilityRequest;
 import org.dependencytrack.apiserver.model.NotificationPublisher;
@@ -94,7 +94,7 @@ public class BomProcessedNotificationDelayedE2ET extends AbstractE2ET {
         final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
 
         // Upload the BOM
-        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        final WorkflowTokenResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
         assertThat(response.token()).isNotEmpty();
 
         // Wait up to 15sec for the BOM processing to complete.

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadOssIndexAnalysisE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadOssIndexAnalysisE2ET.java
@@ -2,7 +2,7 @@ package org.dependencytrack.e2e;
 
 import org.dependencytrack.apiserver.model.BomProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
-import org.dependencytrack.apiserver.model.BomUploadResponse;
+import org.dependencytrack.apiserver.model.WorkflowTokenResponse;
 import org.dependencytrack.apiserver.model.Finding;
 import org.dependencytrack.apiserver.model.Project;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ class BomUploadOssIndexAnalysisE2ET extends AbstractE2ET {
         final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
 
         // Upload the BOM
-        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        final WorkflowTokenResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
         assertThat(response.token()).isNotEmpty();
 
         // Wait up to 15sec for the BOM processing to complete.

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
@@ -6,7 +6,7 @@ import com.icegreen.greenmail.util.ServerSetup;
 import jakarta.mail.internet.MimeMessage;
 import org.dependencytrack.apiserver.model.BomProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
-import org.dependencytrack.apiserver.model.BomUploadResponse;
+import org.dependencytrack.apiserver.model.WorkflowTokenResponse;
 import org.dependencytrack.apiserver.model.ConfigProperty;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest.Publisher;
@@ -145,7 +145,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
         final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
 
         // Upload the BOM
-        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        final WorkflowTokenResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
         assertThat(response.token()).isNotEmpty();
 
         // Wait up to 15sec for the BOM processing to complete.

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadSnykAnalysisE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadSnykAnalysisE2ET.java
@@ -2,7 +2,7 @@ package org.dependencytrack.e2e;
 
 import org.dependencytrack.apiserver.model.BomProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
-import org.dependencytrack.apiserver.model.BomUploadResponse;
+import org.dependencytrack.apiserver.model.WorkflowTokenResponse;
 import org.dependencytrack.apiserver.model.Finding;
 import org.dependencytrack.apiserver.model.Project;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +55,7 @@ class BomUploadSnykAnalysisE2ET extends AbstractE2ET {
         final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
 
         // Upload the BOM
-        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        final WorkflowTokenResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
         assertThat(response.token()).isNotEmpty();
 
         // Wait up to 15sec for the BOM processing to complete.

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.dependencytrack.apiserver.model.Analysis;
 import org.dependencytrack.apiserver.model.BomProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
-import org.dependencytrack.apiserver.model.BomUploadResponse;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
 import org.dependencytrack.apiserver.model.CreateVulnerabilityRequest;
 import org.dependencytrack.apiserver.model.Finding;
@@ -20,6 +19,7 @@ import org.dependencytrack.apiserver.model.NotificationRule;
 import org.dependencytrack.apiserver.model.Project;
 import org.dependencytrack.apiserver.model.UpdateNotificationRuleRequest;
 import org.dependencytrack.apiserver.model.WorkflowState;
+import org.dependencytrack.apiserver.model.WorkflowTokenResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -167,6 +167,9 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                 .atMost(Duration.ofMinutes(1))
                 .untilAsserted(() -> assertThat(apiServerClient.getAllVulnerabilityPolicies()).hasSize(2));
 
+        // Ensure a workflow was created and properly marked as completed.
+        verifyWorkflowStatusComplete("bc106cf4-3993-4e38-952d-d2f5f11412ed");
+
         // Create a medium severity vulnerability for commons-io.
         // commons-io is introduced through us.springett:alpine-server and is thus covered by the policy.
         apiServerClient.createVulnerability(new CreateVulnerabilityRequest("INT-001", "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L", null, List.of(
@@ -187,7 +190,7 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
         final String bomBase64 = Base64.getEncoder().encodeToString(bomBytes);
 
         // Upload the BOM.
-        final BomUploadResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
+        final WorkflowTokenResponse response = apiServerClient.uploadBom(new BomUploadRequest("foo", "bar", true, bomBase64));
         assertThat(response.token()).isNotEmpty();
 
         // Wait up to 15sec for the BOM processing to complete.
@@ -269,10 +272,17 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
         // Update the policy bundle by modifying POLICY_A (Foo-01), and removing POLICY_B (Foo-02).
         createAndUploadPolicyBundle(List.of(POLICY_A_MODIFIED));
 
+        // Trigger bundle synchronization manually.
+        final WorkflowTokenResponse bundleSyncResponse = apiServerClient.triggerVulnerabilityPolicyBundleSync();
+        assertThat(bundleSyncResponse.token()).isEqualTo("bc106cf4-3993-4e38-952d-d2f5f11412ed");
+
         // Wait for policies to be reconciled.
         await("Vulnerability Policy Reconciliation")
-                .atMost(Duration.ofMinutes(2))
-                .untilAsserted(() -> assertThat(apiServerClient.getAllVulnerabilityPolicies()).hasSize(1));
+                .atMost(Duration.ofSeconds(15))
+                .untilAsserted(() -> {
+                    assertThat(apiServerClient.getAllVulnerabilityPolicies()).hasSize(1);
+                    verifyWorkflowStatusComplete(bundleSyncResponse.token());
+                });
 
         // Fetch findings again and verify that the analysis applied via the (now deleted)
         // policy FOO-002 has been reversed.
@@ -414,6 +424,12 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
         wireMock.stubFor(post(anyUrl())
                 .willReturn(aResponse()
                         .withStatus(201)));
+    }
+
+    private void verifyWorkflowStatusComplete(final String token) {
+        final List<WorkflowState> workflowStates = apiServerClient.getWorkflowStatus(token);
+        assertThat(workflowStates).hasSize(1);
+        assertThat(workflowStates.get(0).status()).isEqualTo("COMPLETED");
     }
 
     private void verifyNewVulnerableDependencyNotification() {


### PR DESCRIPTION
Incorporates manual sync trigger in vulnerability policy e2e test.

Requires https://github.com/DependencyTrack/hyades-apiserver/pull/528

Relates to #1008 