### PR TITLE
Fix broken native build caused by Cloud SQL socket factory

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -58,7 +58,7 @@ jobs:
         fi
         echo "Including resources: ${RESOURCES_INCLUDES:-None}"
         echo "Excluding resources: ${RESOURCES_EXCLUDES:-None}"
-        mvn clean package -Pnative -pl commons,commons-kstreams,commons-persistence,proto,${{ inputs.module }} -DskipTests \
+        mvn clean package -Dnative -pl commons,commons-kstreams,commons-persistence,proto,${{ inputs.module }} -DskipTests \
           -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.1-java21 \
           -Dquarkus.native.container-build=true \
           -Dquarkus.native.container-runtime-options='--platform=linux/${{ matrix.arch.name }}' \
@@ -67,7 +67,7 @@ jobs:
     - name: Test Native Image
       if: ${{ matrix.arch.name == 'amd64' }}
       run: |-
-        mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ inputs.module }} test-compile failsafe:integration-test -Pnative
+        mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ inputs.module }} test-compile failsafe:integration-test -Dnative
     - name: Upload Build Artifact
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # tag=v4.3.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build Native Image
       run: |-
-        mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ matrix.module }} clean install -Pnative -DskipTests
+        mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ matrix.module }} clean install -Dnative -DskipTests
     - name: Test Native Image
       run: |-
         mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ matrix.module }} \
-        test-compile failsafe:integration-test failsafe:verify -Pnative
+        test-compile failsafe:integration-test failsafe:verify -Dnative

--- a/.idea/runConfigurations/Build_Native.xml
+++ b/.idea/runConfigurations/Build_Native.xml
@@ -11,6 +11,7 @@
           <option name="jreName" value="#USE_PROJECT_JDK" />
           <option name="mavenProperties">
             <map>
+              <entry key="native" value="true" />
               <entry key="skipTests" value="true" />
             </map>
           </option>
@@ -32,11 +33,10 @@
               <option value="package" />
             </list>
           </option>
+          <option name="multimoduleDir" />
           <option name="pomFileName" />
           <option name="profilesMap">
-            <map>
-              <entry key="native" value="true" />
-            </map>
+            <map />
           </option>
           <option name="projectsCmdOptionValues">
             <list />

--- a/.idea/runConfigurations/Run_Native_Integration_Tests.xml
+++ b/.idea/runConfigurations/Run_Native_Integration_Tests.xml
@@ -2,7 +2,24 @@
   <configuration default="false" name="Run Native Integration Tests" type="MavenRunConfiguration" factoryName="Maven">
     <MavenSettings>
       <option name="myGeneralSettings" />
-      <option name="myRunnerSettings" />
+      <option name="myRunnerSettings">
+        <MavenRunnerSettings>
+          <option name="delegateBuildToMaven" value="false" />
+          <option name="environmentProperties">
+            <map />
+          </option>
+          <option name="jreName" value="#USE_PROJECT_JDK" />
+          <option name="mavenProperties">
+            <map>
+              <entry key="native" value="true" />
+            </map>
+          </option>
+          <option name="passParentEnv" value="true" />
+          <option name="runMavenInBackground" value="true" />
+          <option name="skipTests" value="false" />
+          <option name="vmOptions" value="" />
+        </MavenRunnerSettings>
+      </option>
       <option name="myRunnerParameters">
         <MavenRunnerParameters>
           <option name="cmdOptions" />
@@ -19,11 +36,10 @@
               <option value="-DskipITs=false" />
             </list>
           </option>
+          <option name="multimoduleDir" />
           <option name="pomFileName" />
           <option name="profilesMap">
-            <map>
-              <entry key="native" value="true" />
-            </map>
+            <map />
           </option>
           <option name="projectsCmdOptionValues">
             <list />

--- a/commons-persistence/pom.xml
+++ b/commons-persistence/pom.xml
@@ -43,11 +43,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.cloud.sql</groupId>
-            <artifactId>postgres-socket-factory</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -136,6 +136,11 @@
     <profiles>
         <profile>
             <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
             <dependencies>
                 <!--
                     Required for Apache httpclient5.
@@ -151,6 +156,10 @@
                     <version>${lib.conscrypt.version}</version>
                 </dependency>
             </dependencies>
+            <properties>
+                <skipITs>false</skipITs>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
         </profile>
     </profiles>
 

--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -99,6 +99,36 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <skipITs>false</skipITs>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>non-native</id>
+      <activation>
+        <property>
+          <name>!native</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.google.cloud.sql</groupId>
+          <artifactId>postgres-socket-factory</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -489,19 +489,6 @@
 
   <profiles>
     <profile>
-      <id>native</id>
-      <activation>
-        <property>
-          <name>native</name>
-        </property>
-      </activation>
-      <properties>
-        <skipITs>false</skipITs>
-        <quarkus.package.type>native</quarkus.package.type>
-      </properties>
-    </profile>
-
-    <profile>
       <!--
         When running in GitHub Actions, the SCM connection must be via HTTPS
         so that the GITHUB_TOKEN injected by Actions can be used to authenticate.

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -130,6 +130,36 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <skipITs>false</skipITs>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>non-native</id>
+      <activation>
+        <property>
+          <name>!native</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.google.cloud.sql</groupId>
+          <artifactId>postgres-socket-factory</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>

--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -119,6 +119,37 @@
           <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>false</skipITs>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>non-native</id>
+            <activation>
+                <property>
+                    <name>!native</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.cloud.sql</groupId>
+                    <artifactId>postgres-socket-factory</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -131,12 +162,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>native</id>
-            <properties>
-                <quarkus.package.type>native</quarkus.package.type>
-            </properties>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
As per Mandrel 23.1, the native image build fails when modules depend on `com.google.cloud.sql:postgres-socket-factory`: https://github.com/DependencyTrack/hyades/actions/runs/7686438316/job/20945288653. Apparently it uses a special way to call native libraries, which is not supported.

This change only includes the dependency when explicitly *not* building in native mode.

Also added an IntelliJ run profile to build native executables using containers, removing the requirement of having Graal / Mandrel installed.