### PR TITLE
Fix Hibernate exception due to `null` being assigned to primitive `boolean`

### DIFF
--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationRule.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationRule.java
@@ -111,7 +111,7 @@ public class NotificationRule extends PanacheEntityBase {
      * @since 4.10.0
      */
     @Column(name = "LOG_SUCCESSFUL_PUBLISH")
-    private boolean logSuccessfulPublish;
+    private Boolean logSuccessfulPublish;
 
     public long getId() {
         return id;
@@ -138,7 +138,7 @@ public class NotificationRule extends PanacheEntityBase {
     }
 
     public boolean isLogSuccessfulPublish() {
-        return logSuccessfulPublish;
+        return logSuccessfulPublish != null ? logSuccessfulPublish : false;
     }
 
     public void setLogSuccessfulPublish(final boolean logSuccessfulPublish) {


### PR DESCRIPTION
While DataNucleus can automatically map `null` database values to the primitive value `false`, Hibernate can't, and throws an exception instead.

Because existing deployments will not have a value for the `LOG_SUCCESSFUL_PUBLISH` column, exceptions will be thrown for those records.