### PR TITLE
Fix false positives in CPE matching due to ambiguous vendor/product relations

### DIFF
--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/repository/VulnerableSoftwareRepository.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/repository/VulnerableSoftwareRepository.java
@@ -71,8 +71,8 @@ public class VulnerableSoftwareRepository implements PanacheRepository<Vulnerabl
                 // | :-- | :------------- | :--------- | :------- |
                 // | 1   | ANY            | ANY        | EQUAL    |
                 // | 5   | NA             | ANY        | SUBSET   |
-                // | 13  | i              | ANY        | SUPERSET |
-                // | 15  | m + wild cards | ANY        | SUPERSET |
+                // | 13  | i              | ANY        | SUBSET   |
+                // | 15  | m + wild cards | ANY        | SUBSET   |
                 cpeQueryFilterParts.add("part is not null");
             }
 

--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/internal/InternalScannerProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/internal/InternalScannerProcessor.java
@@ -10,7 +10,6 @@ import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.cyclonedx.proto.v1_4.Bom;
-import org.dependencytrack.vulnanalyzer.util.ComponentVersion;
 import org.dependencytrack.persistence.model.VulnerableSoftware;
 import org.dependencytrack.persistence.repository.VulnerableSoftwareRepository;
 import org.dependencytrack.proto.vulnanalysis.internal.v1beta1.ScanTask;
@@ -19,15 +18,14 @@ import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
 import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
 import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
+import org.dependencytrack.vulnanalyzer.util.ComponentVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeParsingException;
-import us.springett.parsers.cpe.values.LogicalValue;
+import us.springett.parsers.cpe.util.Relation;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -78,13 +76,10 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
 
         List<VulnerableSoftware> vsList;
         String componentVersion;
-        String componentUpdate;
         if (parsedCpe.isPresent()) {
             componentVersion = parsedCpe.get().getVersion();
-            componentUpdate = parsedCpe.get().getUpdate();
         } else if (parsedPurl.isPresent()) {
             componentVersion = parsedPurl.get().getVersion();
-            componentUpdate = null;
         } else {
             // Catch cases where the CPE couldn't be parsed and no PURL exists.
             // Should be rare, but could lead to NPEs later.
@@ -117,24 +112,21 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
             final Cpe cpe = parsedCpe.get();
             vsList = QuarkusTransaction.joiningExisting().call(() -> vulnerableSoftwareRepository.getAllVulnerableSoftware(cpe.getPart().getAbbreviation(), cpe.getVendor(), cpe.getProduct(), parsedPurl.orElse(null)));
         } else {
-
             vsList = QuarkusTransaction.joiningExisting().call(() -> vulnerableSoftwareRepository.getAllVulnerableSoftware(null, null, null, parsedPurl.orElse(null)));
         }
 
-        final Bom bov = analyzeVersionRange(vsList, componentVersion, componentUpdate);
+        final Bom bov = analyzeVersionRange(vsList, parsedCpe.orElse(null), componentVersion);
         return resultBuilder
                 .setStatus(ScanStatus.SCAN_STATUS_SUCCESSFUL)
                 .setBom(bov)
                 .build();
     }
 
-    Bom analyzeVersionRange(final List<VulnerableSoftware> vsList,
-                            final String targetVersion, final String targetUpdate) {
-        Bom.Builder bov = Bom.newBuilder();
+    Bom analyzeVersionRange(final List<VulnerableSoftware> vsList, final Cpe targetCpe, final String targetVersion) {
         final List<org.cyclonedx.proto.v1_4.Vulnerability> vulnerabilities = new ArrayList<>();
         for (final VulnerableSoftware vs : vsList) {
-            if (compareVersions(vs, targetVersion) && compareUpdate(vs, targetUpdate)) {
-
+            final Boolean isCpeMatch = maybeMatchCpe(vs, targetCpe, targetVersion);
+            if ((isCpeMatch == null || isCpeMatch) && compareVersions(vs, targetVersion)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final org.dependencytrack.persistence.model.Vulnerability vulnerability : vs.getVulnerabilities()) {
                         // Only include vulnerability ID and source in the result. As the vulnerabilities
@@ -148,8 +140,10 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
                 }
             }
         }
-        bov.addAllVulnerabilities(vulnerabilities);
-        return bov.build();
+
+        return Bom.newBuilder()
+                .addAllVulnerabilities(vulnerabilities)
+                .build();
     }
 
     private static Optional<Cpe> parseCpe(final Component component) {
@@ -180,6 +174,43 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
         }
     }
 
+    private Boolean maybeMatchCpe(final VulnerableSoftware vs, final Cpe targetCpe, final String targetVersion) {
+        if (targetCpe == null || vs.getCpe23() == null) {
+            return null;
+        }
+
+        final List<Relation> relations = List.of(
+                Cpe.compareAttribute(vs.getPart(), targetCpe.getPart().getAbbreviation()),
+                Cpe.compareAttribute(vs.getVendor(), targetCpe.getVendor()),
+                Cpe.compareAttribute(vs.getProduct(), targetCpe.getProduct()),
+                Cpe.compareAttribute(vs.getVersion(), targetVersion),
+                Cpe.compareAttribute(vs.getUpdate(), targetCpe.getUpdate()),
+                Cpe.compareAttribute(vs.getEdition(), targetCpe.getEdition()),
+                Cpe.compareAttribute(vs.getLanguage(), targetCpe.getLanguage()),
+                Cpe.compareAttribute(vs.getSwEdition(), targetCpe.getSwEdition()),
+                Cpe.compareAttribute(vs.getTargetSw(), targetCpe.getTargetSw()),
+                Cpe.compareAttribute(vs.getTargetHw(), targetCpe.getTargetHw()),
+                Cpe.compareAttribute(vs.getOther(), targetCpe.getOther())
+        );
+        if (relations.contains(Relation.DISJOINT)) {
+            return false;
+        }
+
+        boolean isMatch = true;
+
+        // Mixed SUBSET / SUPERSET relations in the vendor and product attribute are prone
+        // to false positives: https://github.com/DependencyTrack/dependency-track/issues/3178
+        final Relation vendorRelation = relations.get(1);
+        final Relation productRelation = relations.get(2);
+        isMatch &= !(vendorRelation == Relation.SUBSET && productRelation == Relation.SUPERSET);
+        isMatch &= !(vendorRelation == Relation.SUPERSET && productRelation == Relation.SUBSET);
+        if (!isMatch) {
+            LOGGER.debug("{}: Dropped match with {} due to ambiguous vendor/product relation", targetCpe.toCpe23FS(), vs.getCpe23());
+        }
+
+        return isMatch;
+    }
+
     static boolean compareVersions(VulnerableSoftware vs, String targetVersion) {
         //if any of the four conditions will be evaluated - then true;
         boolean result = (vs.getVersionEndExcluding() != null && !vs.getVersionEndExcluding().isEmpty())
@@ -189,7 +220,7 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
 
         // Modified from original by Steve Springett
         // Added null check: vs.getVersion() != null as purl sources that use version ranges may not have version populated.
-        if (!result && vs.getVersion() != null && compareAttributes(vs.getVersion(), targetVersion)) {
+        if (!result && vs.getVersion() != null && Cpe.compareAttribute(vs.getVersion(), targetVersion) != Relation.DISJOINT) {
             return true;
         }
 
@@ -214,45 +245,6 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
             result &= startIncluding.compareTo(target) <= 0;
         }
         return result;
-    }
-
-    private static final Method COMPARE_ATTRIBUTES_METHOD;
-
-    static {
-        try {
-            // Workaround for the fact that Cpe#compareAttributes has protected visibility.
-            COMPARE_ATTRIBUTES_METHOD = Cpe.class.getDeclaredMethod("compareAttributes", String.class, String.class);
-            COMPARE_ATTRIBUTES_METHOD.setAccessible(true);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("Failed to access compareAttributes method of %s".formatted(Cpe.class.getName()), e);
-        }
-    }
-
-    static boolean compareAttributes(String left, String right) {
-        try {
-            return (Boolean) COMPARE_ATTRIBUTES_METHOD.invoke(null, left, right);
-        } catch (InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static boolean compareUpdate(VulnerableSoftware vs, String targetUpdate) {
-        if (targetUpdate != null && targetUpdate.equals(vs.getUpdate())) {
-            return true;
-        }
-        if (vs.getUpdate() == null && targetUpdate == null) {
-            return true;
-        }
-        // Moving this above the null OR check to reflect method comments (ANY should mean ANY)
-        // This is necessary for fuzz matching when a PURL which assumes null
-        // is matched to a CPE which defaults to ANY
-        if (LogicalValue.ANY.getAbbreviation().equals(targetUpdate) || LogicalValue.ANY.getAbbreviation().equals(vs.getUpdate())) {
-            return true;
-        }
-        if (vs.getUpdate() == null || targetUpdate == null) {
-            return false;
-        }
-        return compareAttributes(vs.getUpdate(), targetUpdate);
     }
 
     private void reportScanResult(final String scanResult) {

--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/internal/InternalScannerProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/internal/InternalScannerProcessor.java
@@ -125,8 +125,8 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
     Bom analyzeVersionRange(final List<VulnerableSoftware> vsList, final Cpe targetCpe, final String targetVersion) {
         final List<org.cyclonedx.proto.v1_4.Vulnerability> vulnerabilities = new ArrayList<>();
         for (final VulnerableSoftware vs : vsList) {
-            final Boolean isCpeMatch = maybeMatchCpe(vs, targetCpe, targetVersion);
-            if ((isCpeMatch == null || isCpeMatch) && compareVersions(vs, targetVersion)) {
+            final Optional<Boolean> isCpeMatch = maybeMatchCpe(vs, targetCpe, targetVersion);
+            if ((isCpeMatch.isEmpty() || isCpeMatch.get()) && compareVersions(vs, targetVersion)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final org.dependencytrack.persistence.model.Vulnerability vulnerability : vs.getVulnerabilities()) {
                         // Only include vulnerability ID and source in the result. As the vulnerabilities
@@ -174,9 +174,9 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
         }
     }
 
-    private Boolean maybeMatchCpe(final VulnerableSoftware vs, final Cpe targetCpe, final String targetVersion) {
+    private Optional<Boolean> maybeMatchCpe(final VulnerableSoftware vs, final Cpe targetCpe, final String targetVersion) {
         if (targetCpe == null || vs.getCpe23() == null) {
-            return null;
+            return Optional.empty();
         }
 
         final List<Relation> relations = List.of(
@@ -193,7 +193,7 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
                 Cpe.compareAttribute(vs.getOther(), targetCpe.getOther())
         );
         if (relations.contains(Relation.DISJOINT)) {
-            return false;
+            return Optional.of(false);
         }
 
         boolean isMatch = true;
@@ -204,11 +204,11 @@ public class InternalScannerProcessor extends ContextualProcessor<String, ScanTa
         final Relation productRelation = relations.get(2);
         isMatch &= !(vendorRelation == Relation.SUBSET && productRelation == Relation.SUPERSET);
         isMatch &= !(vendorRelation == Relation.SUPERSET && productRelation == Relation.SUBSET);
-        if (!isMatch) {
+        if (!isMatch && LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: Dropped match with {} due to ambiguous vendor/product relation", targetCpe.toCpe23FS(), vs.getCpe23());
         }
 
-        return isMatch;
+        return Optional.of(isMatch);
     }
 
     static boolean compareVersions(VulnerableSoftware vs, String targetVersion) {

--- a/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/scanner/internal/InternalScannerProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/scanner/internal/InternalScannerProcessorTest.java
@@ -3,6 +3,8 @@ package org.dependencytrack.vulnanalyzer.processor.scanner.internal;
 import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.TestInputTopic;
@@ -10,7 +12,6 @@ import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.test.TestRecord;
-import org.dependencytrack.vulnanalyzer.VulnerabilityAnalyzerTestProfile;
 import org.dependencytrack.persistence.model.VulnerableSoftware;
 import org.dependencytrack.proto.KafkaProtobufDeserializer;
 import org.dependencytrack.proto.KafkaProtobufSerializer;
@@ -20,6 +21,7 @@ import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
 import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
 import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
+import org.dependencytrack.vulnanalyzer.VulnerabilityAnalyzerTestProfile;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,8 +33,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
 
-import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
 import java.io.Serializable;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -313,18 +313,6 @@ class InternalScannerProcessorTest {
         Assertions.assertFalse(InternalScannerProcessor.compareVersions(vulnerableSoftware, "1.6.6"));
     }
 
-    @Test
-    void testCompareUpdate() {
-        var vulnerableSoftware = new VulnerableSoftware();
-        vulnerableSoftware.setUpdate("*");
-        Assertions.assertTrue(InternalScannerProcessor.compareUpdate(vulnerableSoftware, "*"));
-        vulnerableSoftware.setUpdate(null);
-        Assertions.assertTrue(InternalScannerProcessor.compareUpdate(vulnerableSoftware, null));
-        Assertions.assertFalse(InternalScannerProcessor.compareUpdate(vulnerableSoftware, "-"));
-        vulnerableSoftware.setUpdate("-");
-        Assertions.assertTrue(InternalScannerProcessor.compareUpdate(vulnerableSoftware, "-"));
-    }
-
     enum CpeMatchingExpectation {
         MATCHES,
         DOES_NOT_MATCH
@@ -364,125 +352,274 @@ class InternalScannerProcessorTest {
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 1   | ANY        | ANY        | EQUAL    |
-                arguments("cpe:2.3:*:*:*:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 2   | ANY        | NA         | SUPERSET |
-                arguments("cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:*:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:*:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 3   | ANY        | i          | SUPERSET |
-                arguments("cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:*:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:*:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V | Target A-V     | Relation   |
                 // | :-- | :--------- | :------------- | :--------- |
                 // | 4   | ANY        | m + wild cards | undefined  |
-                // {"cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*", MATCHES, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // arguments("cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*", MATCHES, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                arguments("cpe:2.3:a:*:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:*:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 5   | NA         | ANY        | SUBSET   |
-                arguments("cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:*:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:*:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 6   | NA         | NA         | EQUAL    |
-                arguments("cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 7   | NA         | i          | DISJOINT |
-                arguments("cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V | Target A-V      | Relation   |
                 // | :-- | :--------- | :-------------- | :--------- |
                 // | 8   | NA         | m + wild cards  | undefined  |
-                // {"cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // arguments("cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                arguments("cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 9   | i          | i          | EQUAL    |
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 10  | i          | k          | DISJOINT |
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:o:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:rodnev:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:tcudorp:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.1.1:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:o:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:rodnev:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:tcudorp:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:0.0.1:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:etadpu:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:noitide:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:gnal:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:noitidEws:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:wStegrat:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:wHtegrat:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:rehto"),
                 // | No. | Source A-V | Target A-V      | Relation   |
                 // | :-- | :--------- | :-------------- | :--------- |
                 // | 11  | i          | m + wild cards  | undefined  |
-                // {"cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 12  | i          | NA         | DISJOINT |
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V     | Target A-V | Relation |
                 // | :-- | :------------- | :--------- | :------- |
                 // | 13  | i              | ANY        | SUPERSET |
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:*:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:*:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V      | Target A-V | Relation             |
                 // | :-- | :-------------- | :--------- | :------------------- |
                 // | 14  | m1 + wild cards | m2         | SUPERSET or DISJOINT |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // arguments("cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                arguments("cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:ven:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 //   wildcard expansion in source vendor is currently not supported; *should* be SUPERSET.
-                arguments("cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 //   wildcard expansion in source product is currently not supported; *should* be SUPERSET.
-                arguments("cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V     | Target A-V | Relation |
                 // | :-- | :------------- | :--------- | :------- |
                 // | 15  | m + wild cards | ANY        | SUPERSET |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // arguments("cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                arguments("cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:*:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:*:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V     | Target A-V | Relation |
                 // | :-- | :------------- | :--------- | :------- |
                 // | 16  | m + wild cards | NA         | DISJOINT |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // arguments("cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                arguments("cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V      | Target A-V      | Relation   |
                 // | :-- | :-------------- | :-------------- | :--------- |
                 // | 17  | m1 + wild cards | m2 + wild cards | undefined  |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // arguments("cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                arguments("cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:ven*:product:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
+                arguments("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:v*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:p*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:u*:edition:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:e*:lang:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:l*:swEdition:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:s*:targetSw:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:t*:targetHw:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:t*:other"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:o*"),
+                // ---
+                // Version range evaluation
+                // ---
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("1.0.0"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartExcluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("0.9.9"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartExcluding("0.9.9"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.0"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndExcluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.1"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndExcluding("1.0.1"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                // ---
+                // Required CPE name comparison relations (as per table 6-4 in the spec)
+                // ---
+                // Scenario:  All attributes are EQUAL
+                arguments("cpe:2.3:*:*:*:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:-:-:-:-:-:-:-:-:-:-:-", withoutRange(), MATCHES, "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"),
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                // Scenario:  All attributes of source are SUPERSET of target
+                arguments("cpe:2.3:*:*:*:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                // Scenario:  All attributes of source are SUBSET of target
+                arguments("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", withoutRange(), MATCHES, "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"),
                 // ---
                 // Regression tests
                 // ---
@@ -512,6 +649,7 @@ class InternalScannerProcessorTest {
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/2580
                 // Scenario:  "vendor" of source is "linux", "vendor" of target ANY -> SUBSET.
                 // Table No.: 13
+                arguments("cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:o:*:linux_kernel:*:*:*:*:*:*:*:*"),
                 arguments("cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:o:*:linux_kernel:4.19.139:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/2894
@@ -539,8 +677,18 @@ class InternalScannerProcessorTest {
                 arguments("cpe:2.3:a:busybox:busybox:1.34.1:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:*:busybox:busybox:1.34.1:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/pull/1929#issuecomment-1759411976
+                // Scenario:  "part" and "vendor" of source are i, "part" and "vendor" of target are ANY -> SUBSET
+                // Table No.: 13
+                arguments("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:*:*:nginx:*:*:*:*:*:*:*:*"),
+                arguments("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withRange().havingEndExcluding("1.21.0"), MATCHES, "cpe:2.3:*:*:nginx:*:*:*:*:*:*:*:*"),
                 arguments("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withoutRange(), MATCHES, "cpe:2.3:*:*:nginx:1.20.1:*:*:*:*:*:*:*"),
-                arguments("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withRange().havingEndExcluding("1.21.0"), MATCHES, "cpe:2.3:*:*:nginx:1.20.1:*:*:*:*:*:*:*")
+                arguments("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withRange().havingEndExcluding("1.21.0"), MATCHES, "cpe:2.3:*:*:nginx:1.20.1:*:*:*:*:*:*:*"),
+                // ---
+                // Issue:     https://github.com/DependencyTrack/dependency-track/issues/3178#issuecomment-1812809295
+                // Scenario:  "vendor" of source is i, "product" of source is ANY, "vendor" of target is ANY, "product" of target is i
+                //            We consider mixed SUBSET and SUPERSET relations in "vendor" and "product" attributes to be ambiguous and treat them as no-match
+                // Table No.: 3, 13
+                arguments("cpe:2.3:a:pascom_cloud_phone_system:*:*:*:*:*:*:*:*:*", withoutRange(), DOES_NOT_MATCH, "cpe:2.3:a:*:util-linux-setarch:2.37.4:*:*:*:*:*:*:*")
         );
     }
 


### PR DESCRIPTION
Ports https://github.com/DependencyTrack/dependency-track/pull/3209 from DT v4.10.0

Relates to https://github.com/DependencyTrack/hyades/issues/983