### PR TITLE
Add some simple helper scripts

### DIFF
--- a/scripts/change-user-pass.sh
+++ b/scripts/change-user-pass.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAULT_API_URL='http://localhost:8080'
+DEFAULT_USERNAME='admin'
+DEFAULT_OLD_PASSWORD='admin'
+DEFAULT_NEW_PASSWORD='admin123'
+
+function print_help() {
+  echo "Change a user's password"
+  echo ""
+  echo "Usage: $0 [-a <API_URL>] [-u <USERNAME>] [-p <PASSWORD>] [-n <NEW_PASSWORD>]"
+  echo "Options:"
+  echo " -a   Set Dependency-Track API URL (default: ${DEFAULT_API_URL})"
+  echo " -u   Set username                 (default: ${DEFAULT_USERNAME})"
+  echo " -p   Set current password         (default: ${DEFAULT_OLD_PASSWORD})"
+  echo " -n   Set new password             (default: ${DEFAULT_NEW_PASSWORD})"
+  echo ""
+}
+
+while getopts ":h:a:u:p:" opt; do
+  case $opt in
+    a)
+      api_url=$OPTARG
+      ;;
+    u)
+      username=$OPTARG
+      ;;
+    p)
+      old_password=$OPTARG
+      ;;
+    n)
+      new_password=$OPTARG
+      ;;
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help
+      exit
+      ;;
+  esac
+done
+
+echo "[+] Changing password for user ${username:-$DEFAULT_USERNAME}"
+curl "${api_url:-$DEFAULT_API_URL}/api/v1/user/forceChangePassword" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d "username=${username:-$DEFAULT_USERNAME}&password=${old_password:-$DEFAULT_OLD_PASSWORD}&newPassword=${new_password:-$DEFAULT_NEW_PASSWORD}&confirmPassword=${new_password:-$DEFAULT_NEW_PASSWORD}"

--- a/scripts/upload-boms.sh
+++ b/scripts/upload-boms.sh
@@ -79,7 +79,7 @@ done
 
 bearer_token="$(login "${api_url:-$DEFAULT_API_URL}" "${username:-$DEFAULT_USERNAME}" "${password:-$DEFAULT_PASSWORD}")"
 if [[ $bearer_token != ey* ]]; then
-  echo "[x] did not receive bearer token; go this instead: ${bearer_token}" 1>&2
+  echo "[x] did not receive bearer token; got this instead: ${bearer_token}" 1>&2
   exit 1
 fi
 

--- a/scripts/upload-boms.sh
+++ b/scripts/upload-boms.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd -P -- "$(dirname "$0")" && pwd -P)"
+BOM_TESTDATA_DIR="$(cd -P -- "${SCRIPT_DIR}/../testdata/boms" && pwd -P)"
+DEFAULT_API_URL='http://localhost:8080'
+DEFAULT_USERNAME='admin'
+DEFAULT_PASSWORD='admin123'
+
+function print_help() {
+  echo "Upload CycloneDX BOMs to Dependency-Track"
+  echo ""
+  echo "Usage: $0 [-a <API_URL>] [-u <USERNAME>] [-p <PASSWORD>] [-b <BOM_DIR>]"
+  echo "Options:"
+  echo " -a   Set Dependency-Track API URL (default: ${DEFAULT_API_URL})"
+  echo " -u   Set username                 (default: ${DEFAULT_USERNAME})"
+  echo " -p   Set password                 (default: ${DEFAULT_PASSWORD})"
+  echo " -b   Set BOMs directory           (default: ${BOM_TESTDATA_DIR})"
+  echo ""
+  echo "Note: In order for BOM discovery to work, BOM files must be suffixed with .cdx.json"
+  echo ""
+}
+
+function login() {
+  api_url=$1
+  username=$2
+  password=$3
+
+  echo "[+] authenticating as ${username}" 1>&2
+  curl -s "${api_url}/api/v1/user/login" \
+    -H 'Accept: */*' \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -d "username=${username}&password=${password}"
+}
+
+function upload_bom() {
+  api_url=$1
+  bearer_token=$2
+  project_name=$3
+  project_version=$4
+  bom_file=$5
+
+  echo "[+] uploading bom $(basename "${bom_file}") to project ${project_name}:${project_version}" 1>&2
+  curl -s "${api_url}/api/v1/bom" \
+    -H 'Content-Type: multipart/form-data' \
+    -H "Authorization: Bearer ${bearer_token}" \
+    -F 'autoCreate=true' \
+    -F "projectName=${project_name}" \
+    -F "projectVersion=${project_version}" \
+    -F "bom=@${bom_file}"
+}
+
+while getopts ":h:a:u:p:b:" opt; do
+  case $opt in
+    a)
+      api_url=$OPTARG
+      ;;
+    u)
+      username=$OPTARG
+      ;;
+    p)
+      password=$OPTARG
+      ;;
+    b)
+      boms_dir=$OPTARG
+      ;;
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help
+      exit
+      ;;
+  esac
+done
+
+bearer_token="$(login "${api_url:-$DEFAULT_API_URL}" "${username:-$DEFAULT_USERNAME}" "${password:-$DEFAULT_PASSWORD}")"
+if [[ $bearer_token != ey* ]]; then
+  echo "[x] did not receive bearer token; go this instead: ${bearer_token}" 1>&2
+  exit 1
+fi
+
+for bom_file in "${boms_dir:-$BOM_TESTDATA_DIR}"/**/*.cdx.json; do
+  project_name="$(jq -r '.metadata.component.name' "${bom_file}")"
+  project_version="$(jq -r '.metadata.component.version // empty' "${bom_file}")"
+  random_uuid="$(uuidgen)"
+  response="$(upload_bom "${api_url:-$DEFAULT_API_URL}" "${bearer_token}" "${project_name}" "${project_version:-$random_uuid}" "${bom_file}")"
+  upload_token="$(echo "${response}" | jq -r '.token // empty' 2>/dev/null || true)"
+  if [[ -z "${upload_token}" ]]; then
+    echo "[!] upload failed; response: ${response}" 1>&2
+  fi
+done


### PR DESCRIPTION
* `change-user-pass.sh` can be used to perform the initial password change without having to open the frontend
* `upload-boms.sh` automatically authenticates and uploads all BOMs in a specified directory; Very simplistic for now, it literally just dumps all BOMs as quick as it can

Note, `upload-boms.sh` currently fails to authenticate due to https://github.com/stevespringett/Alpine/pull/542.

For quick, local testing, setting up API keys is too much hassle.