### PR TITLE
Add test to double check NPE when OSV package is not defined

### DIFF
--- a/mirror-service/src/test/java/org/dependencytrack/vulnmirror/datasource/osv/OsvToCyclonedxParserTest.java
+++ b/mirror-service/src/test/java/org/dependencytrack/vulnmirror/datasource/osv/OsvToCyclonedxParserTest.java
@@ -631,6 +631,15 @@ class OsvToCyclonedxParserTest {
                         """);
     }
 
+    @Test // https://github.com/DependencyTrack/dependency-track/issues/3185
+    public void testIssue3185() throws Exception {
+        String jsonFile = "src/test/resources/datasource/osv/osv-CVE-2016-10012.json";
+        String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
+        JSONObject jsonObject = new JSONObject(jsonString);
+        var bov = new OsvToCyclonedxParser(mapper).parse(jsonObject, false);
+        assertNotNull(bov);
+    }
+
     private static JSONObject getOsvForTestingFromFile(String jsonFile) throws IOException {
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
         return new JSONObject(jsonString);

--- a/mirror-service/src/test/resources/datasource/osv/osv-CVE-2016-10012.json
+++ b/mirror-service/src/test/resources/datasource/osv/osv-CVE-2016-10012.json
@@ -1,0 +1,408 @@
+{
+  "id": "CVE-2016-10012",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "details": "The shared memory manager (associated with pre-authentication compression) in sshd in OpenSSH before 7.4 does not ensure that a bounds check is enforced by all compilers, which might allows local users to gain privileges by leveraging access to a sandboxed privilege-separation process, related to the m_zback and m_zlib data structures.",
+  "affected": [
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.10",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.11",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.12",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.13",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.14",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.15",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.16",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.17",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.18",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.3",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.2_p2-r3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.4",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.2_p2-r4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.5",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.6",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.7",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.5_p1-r8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.8",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "openssh",
+        "ecosystem": "Alpine:v3.9",
+        "purl": "pkg:apk/alpine/openssh?arch=source"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.4_p1-r0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ranges": [
+        {
+          "type": "GIT",
+          "repo": "https://github.com/openbsd/src",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3095060f479b86288e31c79ecbc5131a66bcd2f9"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/openbsd/src/commit/3095060f479b86288e31c79ecbc5131a66bcd2f9"
+    },
+    {
+      "type": "FIX",
+      "url": "https://github.com/openbsd/src/commit/3095060f479b86288e31c79ecbc5131a66bcd2f9"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "http://www.openwall.com/lists/oss-security/2016/12/19/2"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2016/12/19/2"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.openssh.com/txt/release-7.4"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.slackware.com/security/viewer.php?l=slackware-security\u0026y=2016\u0026m=slackware-security.647637"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securitytracker.com/id/1037490"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securityfocus.com/bid/94975"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://security.netapp.com/advisory/ntap-20171130-0002/"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://access.redhat.com/errata/RHSA-2017:2029"
+    },
+    {
+      "type": "WEB",
+      "url": "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US\u0026docId=emr_na-hpesbux03818en_us"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2018/09/msg00010.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-412672.pdf"
+    },
+    {
+      "type": "WEB",
+      "url": "https://support.f5.com/csp/article/K62201745?utm_source=f5support\u0026amp%3Butm_medium=RSS"
+    }
+  ],
+  "modified": "2023-11-07T02:29:00Z",
+  "published": "2017-01-05T02:59:00Z"
+}


### PR DESCRIPTION
Backport issue: https://github.com/DependencyTrack/hyades/issues/983
