### PR TITLE
Emit logs as `WARN` when encountering retryable exceptions

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/retry/RetryableRecord.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/retry/RetryableRecord.java
@@ -3,6 +3,9 @@ package org.dependencytrack.vulnanalyzer.processor.retry;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.util.JsonFormat;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -171,14 +174,42 @@ public class RetryableRecord<K, V> extends Record<K, V> {
 
     @Override
     public String toString() {
+        final String keyString;
+        if (key() == null) {
+            keyString = null;
+        } else if (key() instanceof final Message protoKey) {
+            keyString = tryFormatAsJson(protoKey);
+        } else {
+            keyString = key().toString();
+        }
+
+        final String valueString;
+        if (value() == null) {
+            valueString = null;
+        } else if (value() instanceof final Message protoValue) {
+            valueString = tryFormatAsJson(protoValue);
+        } else {
+            valueString = value().toString();
+        }
+
         return "RetryableRecord{" +
-                "key=" + key() +
-                ", value=" + value() +
+                "key=" + keyString +
+                ", value=" + valueString +
                 ", timestamp=" + timestamp() +
                 ", headers=" + headers() +
                 ", nextRetryAt=" + nextRetryAt +
                 ", retryAttempts=" + retryAttempts +
                 '}';
+    }
+
+    private static String tryFormatAsJson(final Message message) {
+        try {
+            return JsonFormat.printer()
+                    .omittingInsignificantWhitespace()
+                    .print(message);
+        } catch (InvalidProtocolBufferException e) {
+            return message.toString();
+        }
     }
 
 }

--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/retry/RetryableRecord.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/retry/RetryableRecord.java
@@ -180,7 +180,7 @@ public class RetryableRecord<K, V> extends Record<K, V> {
         } else if (key() instanceof final Message protoKey) {
             keyString = tryFormatAsJson(protoKey);
         } else {
-            keyString = key().toString();
+            keyString = String.valueOf(key());
         }
 
         final String valueString;
@@ -189,7 +189,7 @@ public class RetryableRecord<K, V> extends Record<K, V> {
         } else if (value() instanceof final Message protoValue) {
             valueString = tryFormatAsJson(protoValue);
         } else {
-            valueString = value().toString();
+            valueString = String.valueOf(value());
         }
 
         return "RetryableRecord{" +

--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/ossindex/OssIndexProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/ossindex/OssIndexProcessor.java
@@ -121,7 +121,7 @@ public class OssIndexProcessor extends RetryingBatchProcessor<String, ScanTask, 
         } catch (Throwable e) {
             if (ProcessorUtils.isRetryable(e)) {
                 batch.forEach(record -> {
-                    LOGGER.debug("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
+                    LOGGER.warn("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
                     scheduleForRetry(record);
                 });
             } else {

--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessor.java
@@ -6,6 +6,12 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.cache.Cache;
 import jakarta.ws.rs.core.MultivaluedMap;
 import org.cyclonedx.proto.v1_4.Bom;
+import org.dependencytrack.common.cwe.CweResolver;
+import org.dependencytrack.proto.vulnanalysis.internal.v1beta1.ScanTask;
+import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
+import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
+import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
+import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
 import org.dependencytrack.vulnanalyzer.client.snyk.Issue;
 import org.dependencytrack.vulnanalyzer.client.snyk.MetaError;
 import org.dependencytrack.vulnanalyzer.client.snyk.ModelConverterToCdx;
@@ -21,12 +27,6 @@ import org.dependencytrack.vulnanalyzer.processor.retry.RetryStatus;
 import org.dependencytrack.vulnanalyzer.processor.retry.RetryableRecord;
 import org.dependencytrack.vulnanalyzer.processor.retry.RetryingBatchProcessor;
 import org.dependencytrack.vulnanalyzer.util.ProcessorUtils;
-import org.dependencytrack.common.cwe.CweResolver;
-import org.dependencytrack.proto.vulnanalysis.internal.v1beta1.ScanTask;
-import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
-import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
-import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
-import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
 import org.jboss.resteasy.specimpl.MultivaluedTreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,7 +134,7 @@ public class SnykProcessor extends RetryingBatchProcessor<String, ScanTask, Scan
         } catch (Throwable e) {
             if (ProcessorUtils.isRetryable(e)) {
                 batch.forEach(record -> {
-                    LOGGER.debug("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
+                    LOGGER.warn("Encountered retryable exception while analyzing {}: {}", record, e.getMessage());
                     scheduleForRetry(record);
                 });
             } else {

--- a/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/retry/RetryableRecordTest.java
+++ b/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/retry/RetryableRecordTest.java
@@ -3,7 +3,10 @@ package org.dependencytrack.vulnanalyzer.processor.retry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.dependencytrack.vulnanalyzer.processor.retry.RetryableRecord;
+import org.dependencytrack.proto.vulnanalysis.internal.v1beta1.ScanTask;
+import org.dependencytrack.proto.vulnanalysis.v1.Component;
+import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
+import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -75,6 +78,62 @@ class RetryableRecordTest {
         assertThat(record.headers().lastHeader("baz").value()).isEqualTo("qux".getBytes(StandardCharsets.UTF_8));
         assertThat(record.nextRetryAt()).isEqualTo(123);
         assertThat(record.retryAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    void testToStringWithPrimitiveKeyAndValue() {
+        final var record = new RetryableRecord<>("foo", "bar", 123456789,
+                new RecordHeaders()
+                        .add("foo", "bar".getBytes(StandardCharsets.UTF_8))
+                        .add("baz", "qux".getBytes(StandardCharsets.UTF_8)),
+                123, 3);
+
+        assertThat(record).hasToString("""
+                RetryableRecord{key=foo, value=bar, timestamp=123456789, \
+                headers=RecordHeaders(headers = [RecordHeader(key = foo, value = [98, 97, 114]), \
+                RecordHeader(key = baz, value = [113, 117, 120])], isReadOnly = false), nextRetryAt=123, retryAttempts=3}""");
+    }
+
+    @Test
+    void testToStringWithProtoKeyAndValue() {
+        final ScanKey scanKey = ScanKey.newBuilder()
+                .setComponentUuid("a7ec737d-4785-4558-beb6-6d37d09e4f6a")
+                .setScanToken("13f3cb78-6ac8-4d4e-97b2-b9ff245a74c2")
+                .build();
+
+        final ScanTask scanTask = ScanTask.newBuilder()
+                .setKey(scanKey)
+                .setScanner(Scanner.SCANNER_INTERNAL)
+                .setComponent(Component.newBuilder()
+                        .setUuid("a7ec737d-4785-4558-beb6-6d37d09e4f6a")
+                        .build())
+                .build();
+
+        final var record = new RetryableRecord<>(scanKey, scanTask, 123456789,
+                new RecordHeaders()
+                        .add("foo", "bar".getBytes(StandardCharsets.UTF_8))
+                        .add("baz", "qux".getBytes(StandardCharsets.UTF_8)),
+                123, 3);
+
+        assertThat(record).hasToString("""
+                RetryableRecord{key={"scanToken":"13f3cb78-6ac8-4d4e-97b2-b9ff245a74c2","componentUuid":"a7ec737d-4785-4558-beb6-6d37d09e4f6a"}, \
+                value={"key":{"scanToken":"13f3cb78-6ac8-4d4e-97b2-b9ff245a74c2","componentUuid":"a7ec737d-4785-4558-beb6-6d37d09e4f6a"},\
+                "scanner":"SCANNER_INTERNAL","component":{"uuid":"a7ec737d-4785-4558-beb6-6d37d09e4f6a"}}, timestamp=123456789, \
+                headers=RecordHeaders(headers = [RecordHeader(key = foo, value = [98, 97, 114]), RecordHeader(key = baz, value = [113, 117, 120])], \
+                isReadOnly = false), nextRetryAt=123, retryAttempts=3}""");
+    }
+
+    @Test
+    void testToStringWithNullKeyAndValue() {
+        final var record = new RetryableRecord<>(null, null, 123456789,
+                new RecordHeaders()
+                        .add("foo", "bar".getBytes(StandardCharsets.UTF_8))
+                        .add("baz", "qux".getBytes(StandardCharsets.UTF_8)),
+                123, 3);
+
+        assertThat(record).hasToString("""
+                RetryableRecord{key=null, value=null, timestamp=123456789, headers=RecordHeaders(headers = [RecordHeader(key = foo, value = [98, 97, 114]), \
+                RecordHeader(key = baz, value = [113, 117, 120])], isReadOnly = false), nextRetryAt=123, retryAttempts=3}""");
     }
 
 }


### PR DESCRIPTION
Also format Protobuf record keys and values as JSON when logging them; The default `toString()` output of Protobuf messages contains lots of unnecessary whitespace.

Example output:

```
Encountered retryable exception while analyzing RetryableRecord{key=pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.49, value={"key":{"scanToken":"dee932c1-fe98-4197-9bcd-21646f910727","componentUuid":"e310ebc2-904e-45e6-ac82-49e8081e3db0"},"scanner":"SCANNER_SNYK","component":{"uuid":"e310ebc2-904e-45e6-ac82-49e8081e3db0","purl":"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.49?foo\u003dbar\u0026type\u003djar"}}, timestamp=1709127126459, headers=RecordHeaders(headers = [], isReadOnly = false), nextRetryAt=1709127131153, retryAttempts=1}: HTTP 500 Internal Server Error
```