### PR TITLE
Don't assert order of findings returned by REST API in e2e test

### DIFF
--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -207,7 +207,7 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
 
         // Ensure the policy has been applied.
         List<Finding> findings = apiServerClient.getFindings(project.uuid(), true);
-        assertThat(findings).satisfiesExactly(
+        assertThat(findings).satisfiesExactlyInAnyOrder(
                 finding -> {
                     assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-001");
                     assertThat(finding.analysis().state()).isEqualTo("FALSE_POSITIVE");


### PR DESCRIPTION
Unless explicit sorting is applied, it's up to the database to decide in which order records are being returned.

This fixes the e2e test failure observed in https://github.com/DependencyTrack/hyades/actions/runs/8077647349/job/22068521065