### PR TITLE
Reduce verbosity of Maven in CI

### DIFF
--- a/.github/workflows/_build-native-meta.yml
+++ b/.github/workflows/_build-native-meta.yml
@@ -37,6 +37,8 @@ jobs:
         install: true
     - name: Build Native Image
       timeout-minutes: ${{ matrix.arch.build-timeout }}
+      env:
+        MAVEN_ARGS: "-B --no-transfer-progress"
       run: |-
         RESOURCES_INCLUDES=""
         RESOURCES_EXCLUDES=""
@@ -66,6 +68,8 @@ jobs:
           -Dquarkus.native.resources.excludes="$RESOURCES_EXCLUDES"
     - name: Test Native Image
       if: ${{ matrix.arch.name == 'amd64' }}
+      env:
+        MAVEN_ARGS: "-B --no-transfer-progress"
       run: |-
         mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ inputs.module }} test-compile failsafe:integration-test -Dnative
     - name: Upload Build Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Test
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_ARGS: "-B --no-transfer-progress"
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |-
         mvn -pl '!e2e' clean verify \
@@ -69,9 +70,13 @@ jobs:
         components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build Native Image
+      env:
+        MAVEN_ARGS: "-B --no-transfer-progress"
       run: |-
         mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ matrix.module }} clean install -Dnative -DskipTests
     - name: Test Native Image
+      env:
+        MAVEN_ARGS: "-B --no-transfer-progress"
       run: |-
         mvn -pl commons,commons-kstreams,commons-persistence,proto,${{ matrix.module }} \
         test-compile failsafe:integration-test failsafe:verify -Dnative

--- a/.github/workflows/publishJar.yml
+++ b/.github/workflows/publishJar.yml
@@ -34,6 +34,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push container images
+        env:
+          MAVEN_ARGS: "-B --no-transfer-progress"
         run: |-
           mvn clean install -DskipTests \
             -Dquarkus.container-image.registry=ghcr.io \
@@ -61,6 +63,7 @@ jobs:
         cache: maven
     - name: Test
       env:
+        MAVEN_ARGS: "-B --no-transfer-progress"
         OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
         OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
       run: mvn -pl e2e clean verify -Pe2e-all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Perform Release
+      env:
+        MAVEN_ARGS: "-B --no-transfer-progress"
       run: |-
         git config user.name "dependencytrack-bot"
         git config user.email "106437498+dependencytrack-bot@users.noreply.github.com"


### PR DESCRIPTION
By disabling reporting of download status for dependencies. These horribly pollute build logs.