### PR TITLE
Transfer copyright from Steve Springett to OWASP Foundation

### DIFF
--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/converter/CollectionIntegerConverter.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/converter/CollectionIntegerConverter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.converter;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Classifier.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Classifier.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Component.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Component.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/ConfigProperty.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/ConfigProperty.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/ConfigPropertyConstants.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/ConfigPropertyConstants.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/IConfigProperty.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/IConfigProperty.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/ICpe.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/ICpe.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationGroup.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationGroup.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationRule.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationRule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationScope.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/NotificationScope.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Project.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Project.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Repository.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Repository.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/RepositoryType.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/RepositoryType.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Tag.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Tag.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Vulnerability.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/Vulnerability.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/VulnerabilityAlias.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/VulnerabilityAlias.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/main/java/org/dependencytrack/persistence/model/VulnerableSoftware.java
+++ b/commons-persistence/src/main/java/org/dependencytrack/persistence/model/VulnerableSoftware.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/ClassifierTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/ClassifierTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/ComponentTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/ComponentTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationGroupTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationGroupTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationPublisherTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationPublisherTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationRuleTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationRuleTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationScopeTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/NotificationScopeTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/RepositoryTypeTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/RepositoryTypeTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/SeverityTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/SeverityTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/TagTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/TagTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/VulnerabilityTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/VulnerabilityTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons-persistence/src/test/java/org/dependencytrack/persistence/model/VulnerableSoftwareTest.java
+++ b/commons-persistence/src/test/java/org/dependencytrack/persistence/model/VulnerableSoftwareTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.persistence.model;
 

--- a/commons/src/main/java/org/dependencytrack/common/HttpClientConfiguration.java
+++ b/commons/src/main/java/org/dependencytrack/common/HttpClientConfiguration.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.common;
 

--- a/commons/src/main/java/org/dependencytrack/common/cwe/Cwe.java
+++ b/commons/src/main/java/org/dependencytrack/common/cwe/Cwe.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.common.cwe;
 

--- a/commons/src/main/java/org/dependencytrack/common/cwe/CweResolver.java
+++ b/commons/src/main/java/org/dependencytrack/common/cwe/CweResolver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.common.cwe;
 

--- a/commons/src/main/java/org/dependencytrack/common/model/Severity.java
+++ b/commons/src/main/java/org/dependencytrack/common/model/Severity.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.common.model;
 

--- a/commons/src/main/java/org/dependencytrack/commonutil/DateUtil.java
+++ b/commons/src/main/java/org/dependencytrack/commonutil/DateUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.commonutil;
 

--- a/commons/src/main/java/org/dependencytrack/commonutil/HttpUtil.java
+++ b/commons/src/main/java/org/dependencytrack/commonutil/HttpUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.commonutil;
 

--- a/commons/src/main/java/org/dependencytrack/commonutil/JsonUtil.java
+++ b/commons/src/main/java/org/dependencytrack/commonutil/JsonUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.commonutil;
 

--- a/commons/src/main/java/org/dependencytrack/commonutil/VulnerabilityUtil.java
+++ b/commons/src/main/java/org/dependencytrack/commonutil/VulnerabilityUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.commonutil;
 

--- a/commons/src/main/java/org/dependencytrack/commonutil/XmlUtil.java
+++ b/commons/src/main/java/org/dependencytrack/commonutil/XmlUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.commonutil;
 

--- a/commons/src/test/java/org/dependencytrack/common/cwe/CweResolverTest.java
+++ b/commons/src/test/java/org/dependencytrack/common/cwe/CweResolverTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.common.cwe;
 

--- a/commons/src/test/java/org/dependencytrack/common/cwe/CweTest.java
+++ b/commons/src/test/java/org/dependencytrack/common/cwe/CweTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.common.cwe;
 

--- a/commons/src/test/java/org/dependencytrack/commonutil/DateUtilTest.java
+++ b/commons/src/test/java/org/dependencytrack/commonutil/DateUtilTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.commonutil;
 

--- a/commons/src/test/java/org/dependencytrack/commonutil/HttpUtilTest.java
+++ b/commons/src/test/java/org/dependencytrack/commonutil/HttpUtilTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.commonutil;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/NotificationConstants.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/NotificationConstants.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/ConsolePublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/ConsolePublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/CsWebexPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/CsWebexPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/MattermostPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/MattermostPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/MsTeamsPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/MsTeamsPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/WebhookPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/WebhookPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification;
 

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.notification.publisher;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/model/MetaAnalyzerException.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/model/MetaAnalyzerException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.model;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/model/MetaModel.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/model/MetaModel.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.model;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/AbstractMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/AbstractMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/ComposerMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/ComposerMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/GemMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/GemMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/GithubMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/GithubMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 
 package org.dependencytrack.repometaanalyzer.repositories;

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/GoModulesMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/GoModulesMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/HexMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/HexMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/IMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/IMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/MavenMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/MavenMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/PypiMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/PypiMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/ComposerMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/ComposerMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/CpanMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/CpanMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/GemMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/GemMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/GitHubMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/GitHubMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/GoModulesMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/GoModulesMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/HexMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/HexMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/MavenMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/MavenMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/PypiMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/PypiMetaAnalyzerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.repositories;
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/util/ComponentVersion.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/util/ComponentVersion.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.repometaanalyzer.util;
 

--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/util/ComponentVersion.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/util/ComponentVersion.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.vulnanalyzer.util;
 

--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/util/RoundRobinAccessor.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/util/RoundRobinAccessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.vulnanalyzer.util;
 

--- a/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/util/RoundRobinAccessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/util/RoundRobinAccessorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.vulnanalyzer.util;
 


### PR DESCRIPTION
As per [internal discussion](https://owasp.slack.com/archives/C04FL64RPK9/p1710942680826329), this PR transfers copyright from Steve Springett to the OWASP Foundation.

The change is reflected in the copyright statement of all source files in this project, that were copied from the original Dependency-Track project.

Files that were authored since the fork do not currently have a license / copyright header. It will be added and enforced with Checkstyle, once this PR is merged.