### PR TITLE
Handle duplicate issues reported by Snyk

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/client/snyk/ModelConverterToCdx.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/client/snyk/ModelConverterToCdx.java
@@ -75,6 +75,7 @@ public final class ModelConverterToCdx {
                             return issuePurl.isPresent() && issuePurl.get().equals(purl);
                         })
                         .map(issuePageData -> convert(cweResolver, severitySourcePriorities, issuePageData, isAliasSyncEnabled))
+                        .distinct()
                         .toList())
                 .build();
     }

--- a/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessorTest.java
@@ -418,6 +418,25 @@ class SnykProcessorTest {
         verify(snykClientMock, Mockito.times(100)).getIssues(anyString(), anyString(), any(ReportRequest.class));
     }
 
+    @Test
+    void testDuplicateIssues() throws Exception {
+        when(snykClientMock.getIssues(anyString(), anyString(), any(ReportRequest.class)))
+                .thenReturn(getSnykResponseTestData("duplicate-issues-response.json"));
+
+        final TestRecord<String, ScanTask> inputRecord = createTestRecord("pkg:npm/qs@0.4.2");
+        inputTopic.pipeInput(inputRecord);
+
+        testDriver.advanceWallClockTime(Duration.ofSeconds(6));
+
+        assertThat(outputTopic.getQueueSize()).isEqualTo(1);
+        TestRecord<ScanKey, ScannerResult> outputRecord = outputTopic.readRecord();
+        assertThat(outputRecord.key()).isEqualTo(inputRecord.getValue().getKey());
+        assertThat(outputRecord.getValue().getStatus()).isEqualTo(ScanStatus.SCAN_STATUS_SUCCESSFUL);
+        assertThat(outputRecord.getValue().hasFailureReason()).isFalse();
+        assertThat(outputRecord.getValue().getScanner()).isEqualTo(Scanner.SCANNER_SNYK);
+        assertThat(outputRecord.getValue().getBom().getVulnerabilitiesCount()).isOne();
+    }
+
     private TestRecord<String, ScanTask> createTestRecord(final String purl) throws MalformedPackageURLException {
         final PackageURL packageURL = new PackageURL(purl);
         final String key = packageURL.getCoordinates();

--- a/vulnerability-analyzer/src/test/resources/snyk/duplicate-issues-response.json
+++ b/vulnerability-analyzer/src/test/resources/snyk/duplicate-issues-response.json
@@ -1,0 +1,203 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "id": "npm:qs:20170213",
+      "type": "issue",
+      "attributes": {
+        "title": "Prototype Override Protection Bypass",
+        "type": "package_vulnerability",
+        "created_at": "2017-02-14T11:44:54.163000Z",
+        "updated_at": "2024-03-11T09:48:53.414157Z",
+        "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Override Protection Bypass. By default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\n## Remediation\nUpgrade `qs` to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.\n## References\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\n- [GitHub Issue](https://github.com/ljharb/qs/issues/200)\n",
+        "problems": [
+          {
+            "id": "CVE-2017-1000048",
+            "source": "CVE"
+          },
+          {
+            "id": "CWE-20",
+            "source": "CWE"
+          },
+          {
+            "id": "GHSA-gqgv-6jq5-jjj9",
+            "source": "GHSA"
+          },
+          {
+            "id": "SNYK-JS-QS-10407",
+            "source": "ALTERNATIVE"
+          },
+          {
+            "id": "SNYK-JS-QS-10407",
+            "source": "SNYK"
+          }
+        ],
+        "coordinates": [
+          {
+            "remedies": [
+              {
+                "type": "indeterminate",
+                "description": "Upgrade the package version to 6.0.4,6.1.2,6.2.3,6.3.2 to fix this vulnerability",
+                "details": {
+                  "upgrade_package": "6.0.4,6.1.2,6.2.3,6.3.2"
+                }
+              }
+            ],
+            "representations": [
+              {
+                "resource_path": "<6.0.4,>=6.1.0 <6.1.2,>=6.2.0 <6.2.3,>=6.3.0 <6.3.2"
+              },
+              {
+                "package": {
+                  "name": "qs",
+                  "version": "0.4.2",
+                  "type": "npm",
+                  "url": "pkg:npm/qs@0.4.2"
+                }
+              }
+            ]
+          }
+        ],
+        "severities": [
+          {
+            "source": "Snyk",
+            "level": "high",
+            "score": 7.5,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          {
+            "source": "NVD",
+            "level": "high",
+            "score": 7.5,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          {
+            "source": "Red Hat",
+            "level": "medium",
+            "score": 5.3,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+          }
+        ],
+        "effective_severity_level": "high",
+        "slots": {
+          "disclosure_time": "2017-02-13T00:00:00Z",
+          "exploit": "Not Defined",
+          "publication_time": "2017-03-01T10:00:54Z",
+          "references": [
+            {
+              "url": "https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d",
+              "title": "GitHub Commit"
+            },
+            {
+              "url": "https://github.com/ljharb/qs/issues/200",
+              "title": "GitHub Issue"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "npm:qs:20170213",
+      "type": "issue",
+      "attributes": {
+        "title": "Prototype Override Protection Bypass",
+        "type": "package_vulnerability",
+        "created_at": "2017-02-14T11:44:54.163000Z",
+        "updated_at": "2024-03-11T09:48:53.414157Z",
+        "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Override Protection Bypass. By default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\n## Remediation\nUpgrade `qs` to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.\n## References\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\n- [GitHub Issue](https://github.com/ljharb/qs/issues/200)\n",
+        "problems": [
+          {
+            "id": "CVE-2017-1000048",
+            "source": "CVE"
+          },
+          {
+            "id": "CWE-20",
+            "source": "CWE"
+          },
+          {
+            "id": "GHSA-gqgv-6jq5-jjj9",
+            "source": "GHSA"
+          },
+          {
+            "id": "SNYK-JS-QS-10407",
+            "source": "ALTERNATIVE"
+          },
+          {
+            "id": "SNYK-JS-QS-10407",
+            "source": "SNYK"
+          }
+        ],
+        "coordinates": [
+          {
+            "remedies": [
+              {
+                "type": "indeterminate",
+                "description": "Upgrade the package version to 6.0.4,6.1.2,6.2.3,6.3.2 to fix this vulnerability",
+                "details": {
+                  "upgrade_package": "6.0.4,6.1.2,6.2.3,6.3.2"
+                }
+              }
+            ],
+            "representations": [
+              {
+                "resource_path": "<6.0.4,>=6.1.0 <6.1.2,>=6.2.0 <6.2.3,>=6.3.0 <6.3.2"
+              },
+              {
+                "package": {
+                  "name": "qs",
+                  "version": "0.4.2",
+                  "type": "npm",
+                  "url": "pkg:npm/qs@0.4.2"
+                }
+              }
+            ]
+          }
+        ],
+        "severities": [
+          {
+            "source": "Snyk",
+            "level": "high",
+            "score": 7.5,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          {
+            "source": "NVD",
+            "level": "high",
+            "score": 7.5,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          {
+            "source": "Red Hat",
+            "level": "medium",
+            "score": 5.3,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+          }
+        ],
+        "effective_severity_level": "high",
+        "slots": {
+          "disclosure_time": "2017-02-13T00:00:00Z",
+          "exploit": "Not Defined",
+          "publication_time": "2017-03-01T10:00:54Z",
+          "references": [
+            {
+              "url": "https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d",
+              "title": "GitHub Commit"
+            },
+            {
+              "url": "https://github.com/ljharb/qs/issues/200",
+              "title": "GitHub Issue"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "meta": {
+    "errors": []
+  },
+  "links": {
+    "self": "/orgs/<ORG_ID>/packages/issues?version=2024-03-12"
+  }
+}


### PR DESCRIPTION
We're occasionally seeing responses from Snyk that contain the exact same issue multiple times. It is unclear where those are coming from, but in any case we shouldn't forward obvious duplicates to the API server.