### PR TITLE
Fix broken e2e tests due to Quarkus RestClient requiring CDI context

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -35,9 +35,18 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jackson</artifactId>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jaxrs3</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerAuthInterceptor.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerAuthInterceptor.java
@@ -18,38 +18,34 @@
  */
 package org.dependencytrack.apiserver;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 
-public class ApiServerClientHeaderFactory implements ClientHeadersFactory {
+public class ApiServerAuthInterceptor implements RequestInterceptor {
 
     private static String bearerToken;
     private static String apiKey;
 
     @Override
-    public MultivaluedMap<String, String> update(final MultivaluedMap<String, String> incomingHeaders,
-                                                 final MultivaluedMap<String, String> clientOutgoingHeaders) {
-        final var headers = new MultivaluedHashMap<String, String>();
+    public void apply(final RequestTemplate requestTemplate) {
         if (apiKey != null) {
-            headers.putSingle("X-Api-Key", apiKey);
+            requestTemplate.header("X-Api-Key", apiKey);
         } else if (bearerToken != null) {
-            headers.putSingle("Authorization", "Bearer " + bearerToken);
+            requestTemplate.header("Authorization", "Bearer " + bearerToken);
         }
-        return headers;
     }
 
     public static void setBearerToken(final String bearerToken) {
-        ApiServerClientHeaderFactory.bearerToken = bearerToken;
+        ApiServerAuthInterceptor.bearerToken = bearerToken;
     }
 
     public static void setApiKey(final String apiKey) {
-        ApiServerClientHeaderFactory.apiKey = apiKey;
+        ApiServerAuthInterceptor.apiKey = apiKey;
     }
 
     public static void reset() {
-        ApiServerClientHeaderFactory.bearerToken = null;
-        ApiServerClientHeaderFactory.apiKey = null;
+        ApiServerAuthInterceptor.bearerToken = null;
+        ApiServerAuthInterceptor.apiKey = null;
     }
 
 }

--- a/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
@@ -44,13 +44,11 @@ import org.dependencytrack.apiserver.model.UpdateNotificationRuleRequest;
 import org.dependencytrack.apiserver.model.VulnerabilityPolicy;
 import org.dependencytrack.apiserver.model.WorkflowState;
 import org.dependencytrack.apiserver.model.WorkflowTokenResponse;
-import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 
 import java.util.List;
 import java.util.UUID;
 
 @Path("/api/v1")
-@RegisterClientHeaders(ApiServerClientHeaderFactory.class)
 public interface ApiServerClient {
 
     @POST

--- a/e2e/src/main/java/org/dependencytrack/apiserver/CompositeDecoder.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/CompositeDecoder.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.apiserver;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.Decoder;
+import feign.jackson.JacksonDecoder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+public class CompositeDecoder implements Decoder {
+
+    private final Decoder jsonDecoder = new JacksonDecoder();
+
+    @Override
+    public Object decode(final Response response, final Type type) throws IOException, FeignException {
+        final String contentType = response.headers().getOrDefault("Content-Type", Collections.emptyList()).stream()
+                .findFirst()
+                .orElse(null);
+
+        if ("application/json".equals(contentType)) {
+            return jsonDecoder.decode(response, type);
+        }
+
+        try (final var reader = new BufferedReader(response.body().asReader(StandardCharsets.UTF_8))) {
+            return reader.lines().collect(Collectors.joining());
+        }
+    }
+
+}

--- a/e2e/src/main/java/org/dependencytrack/apiserver/CompositeEncoder.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/CompositeEncoder.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.apiserver;
+
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import feign.jackson.JacksonEncoder;
+
+import java.lang.reflect.Type;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CompositeEncoder implements Encoder {
+
+    private final Encoder jsonEncoder = new JacksonEncoder();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void encode(final Object object, final Type bodyType, final RequestTemplate template) throws EncodeException {
+        if (bodyType == Encoder.MAP_STRING_WILDCARD) {
+            final Map<String, ?> body = (Map<String, ?>) object;
+            template.body(body.entrySet().stream()
+                    .map(entry -> "%s=%s".formatted(
+                            URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8),
+                            URLEncoder.encode(String.valueOf(entry.getValue()), StandardCharsets.UTF_8)
+                    ))
+                    .collect(Collectors.joining("&")));
+        } else {
+            jsonEncoder.encode(object, bodyType, template);
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <lib.micrometer-jvm-extras.version>0.2.2</lib.micrometer-jvm-extras.version>
     <lib.minio.version>8.5.9</lib.minio.version>
     <lib.mockserver-netty.version>5.15.0</lib.mockserver-netty.version>
+    <lib.open-feign.version>13.2.1</lib.open-feign.version>
     <lib.org-json.version>20240303</lib.org-json.version>
     <lib.pebble.version>3.2.2</lib.pebble.version>
     <lib.resilience4j.version>2.2.0</lib.resilience4j.version>
@@ -317,6 +318,22 @@
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver-netty</artifactId>
         <version>${lib.mockserver-netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-core</artifactId>
+        <version>${lib.open-feign.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jackson</artifactId>
+        <version>${lib.open-feign.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jaxrs3</artifactId>
+        <version>${lib.open-feign.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
As of Quarkus 3.9.x(?), the RestClient can no longer be used without an CDI context being present. This is causing test failures, e.g. https://github.com/DependencyTrack/hyades/actions/runs/8535995179/job/23383687429

```
java.lang.IllegalStateException: The Reactive REST Client needs to be built within the context of a Quarkus application with a valid ArC (CDI) context running.
```

This replaces the Quarkus RestClient with OpenFeign (https://github.com/OpenFeign/feign), which is largely compatible, although requiring a few customizations when it comes to encoding and decoding.