### PR TITLE
Use `/dev/urandom` instead of `openssl rand` to generate secret key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,7 +316,7 @@ services:
 
   secret-init:
     image: alpine:latest
-    command: "/bin/sh -c 'if [ ! -f /tmp/secret/secret.key ]; then apk add --no-cache openssl && openssl rand 32 > /tmp/secret/secret.key; fi'"
+    command: "/bin/sh -c 'if [ ! -f /tmp/secret/secret.key ]; then head -c 32 /dev/urandom > /tmp/secret/secret.key; fi'"
     profiles:
       - demo
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       POSTGRES_PASSWORD: "dtrack"
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready", "-d", "dtrack" ]
-      interval: 15s
+      interval: 5s
       timeout: 3s
       retries: 3
     ports:
@@ -207,7 +207,7 @@ services:
       - PLAINTEXT://dt-redpanda:28082,OUTSIDE://localhost:8082
     healthcheck:
       test: [ "CMD-SHELL", "rpk", "cluster", "health", "--exit-when-healthy" ]
-      interval: 15s
+      interval: 5s
       timeout: 3s
       retries: 3
     ports:


### PR DESCRIPTION
This is mostly for local development purposes and / or demo setups. Installing OpenSSL can be problematic for folks behind corporate proxies. Using `/dev/urandom` should be sufficient considering that's what `openssl rand` is using behind the scenes anyway.