### PR TITLE
Fix broken assertion in e2e test

### DIFF
--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -19,11 +19,11 @@
 package org.dependencytrack.e2e;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import feign.FeignException;
 import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.UploadObjectArgs;
-import jakarta.ws.rs.WebApplicationException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.dependencytrack.apiserver.model.Analysis;
@@ -251,10 +251,9 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                     assertThat(finding.analysis().isSuppressed()).isFalse();
 
                     // No analysis has been applied, so requesting it should yield a 404.
-                    assertThatExceptionOfType(WebApplicationException.class)
+                    assertThatExceptionOfType(FeignException.NotFound.class)
                             .isThrownBy(() -> apiServerClient.getAnalysis(finding.project(),
-                                    finding.component().uuid(), finding.vulnerability().uuid()))
-                            .withMessage("Unknown error, status code 404");
+                                    finding.component().uuid(), finding.vulnerability().uuid()));
                 },
                 finding -> {
                     assertThat(finding.vulnerability().vulnId()).isEqualTo("INT-003");


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes the currently broken `VulnerabilityPolicyE2ET` e2e test, caused by an assertion for an invalid exception.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

As of https://github.com/DependencyTrack/hyades/pull/1170, `apiServerClient` no longer throws `WebApplicationException`s.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~