### PR TITLE
Fix mapping of CPEs to vers ranges when version is NA (`-`)

### DIFF
--- a/mirror-service/src/main/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
+++ b/mirror-service/src/main/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
@@ -35,6 +35,7 @@ import io.github.jeremylong.openvulnerability.client.nvd.Reference;
 import io.github.jeremylong.openvulnerability.client.nvd.Weakness;
 import io.github.nscuro.versatile.Comparator;
 import io.github.nscuro.versatile.Vers;
+import io.github.nscuro.versatile.VersException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.cyclonedx.proto.v1_4.Bom;
@@ -199,14 +200,6 @@ public final class NvdToCyclonedxParser {
                 continue;
             }
 
-            Vers versForCpeMatch = null;
-            try {
-                versForCpeMatch = versFromNvdRange(cpeMatch.getVersionStartExcluding(), cpeMatch.getVersionStartIncluding(),
-                        cpeMatch.getVersionEndExcluding(), cpeMatch.getVersionEndIncluding(), trimToNull(cpe.getVersion()));
-            } catch (Exception exception) {
-                LOGGER.debug("Exception while parsing NVD version range for Cpe {}", cpe, exception);
-            }
-
             final Component component = componentByCpe.computeIfAbsent(
                     cpeMatch.getCriteria(),
                     cpeStr -> Component.newBuilder()
@@ -217,13 +210,33 @@ public final class NvdToCyclonedxParser {
                             .setCpe(cpeStr)
                             .build());
 
+            final Vers versForCpeMatch;
+            try {
+                final Optional<Vers> optionalVers = versFromNvdRange(
+                        cpeMatch.getVersionStartExcluding(),
+                        cpeMatch.getVersionStartIncluding(),
+                        cpeMatch.getVersionEndExcluding(),
+                        cpeMatch.getVersionEndIncluding(),
+                        trimToNull(cpe.getVersion())
+                );
+                if (optionalVers.isEmpty()) {
+                    // Move to next CPE match.
+                    continue;
+                }
+
+                versForCpeMatch = optionalVers.get();
+            } catch (VersException exception) {
+                LOGGER.warn("Failed to construct vers from CPE {}", cpe, exception);
+                continue;
+            }
+
             final VulnerabilityAffects.Builder affectsBuilder = vulnAffectsBuilderByBomRef.computeIfAbsent(
                     component.getBomRef(),
                     bomRef -> VulnerabilityAffects.newBuilder()
                             .setRef(bomRef));
-            if (versForCpeMatch != null && versForCpeMatch.constraints().size() == 1
-                    && versForCpeMatch.constraints().get(0).comparator().equals(Comparator.EQUAL)) {
-                var versConstraint = versForCpeMatch.constraints().get(0);
+            if (versForCpeMatch.constraints().size() == 1
+                    && versForCpeMatch.constraints().getFirst().comparator().equals(Comparator.EQUAL)) {
+                var versConstraint = versForCpeMatch.constraints().getFirst();
                 // When the only constraint is an exact version match, populate the version field
                 // instead of the range field. We do this despite vers supporting such cases, too,
                 // e.g. via "vers:generic/1.2.3", to be more explicit.
@@ -247,8 +260,8 @@ public final class NvdToCyclonedxParser {
                 final boolean shouldAddRange = affectsBuilder.getVersionsList().stream()
                         .filter(VulnerabilityAffectedVersions::hasRange)
                         .map(VulnerabilityAffectedVersions::getRange)
-                        .noneMatch(versForCpeMatch::equals);
-                if (shouldAddRange && versForCpeMatch != null) {
+                        .noneMatch(versForCpeMatch.toString()::equals);
+                if (shouldAddRange) {
                     affectsBuilder.addVersions(VulnerabilityAffectedVersions.newBuilder().setRange(versForCpeMatch.toString()));
                 }
             }

--- a/mirror-service/src/test/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParserTest.java
+++ b/mirror-service/src/test/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParserTest.java
@@ -57,6 +57,12 @@ class NvdToCyclonedxParserTest {
                              "publisher": "linux",
                              "name": "linux_kernel",
                              "cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*"
+                           }, {
+                             "bomRef": "4ef65adb-bd4c-56bf-9917-2f493c4e127d",
+                             "type": "CLASSIFICATION_OPERATING_SYSTEM",
+                             "publisher": "linux",
+                             "name": "linux_kernel",
+                             "cpe": "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"
                            }],
                            "externalReferences": [{
                              "url": "http://marc.info/?l\\u003dbugtraq\\u0026m\\u003d94061108411308\\u0026w\\u003d2"
@@ -88,6 +94,8 @@ class NvdToCyclonedxParserTest {
                                }, {
                                  "range": "vers:generic/>2.3.0|<2.3.18"
                                }]
+                             }, {
+                               "ref":"4ef65adb-bd4c-56bf-9917-2f493c4e127d"
                              }]
                            }]
                          }

--- a/mirror-service/src/test/resources/datasource/nvd/cve-vuln.json
+++ b/mirror-service/src/test/resources/datasource/nvd/cve-vuln.json
@@ -70,6 +70,11 @@
                 "versionStartExcluding": "2.3.0",
                 "versionEndExcluding": "2.3.18",
                 "matchCriteriaId": "05E1CCDA-7C67-46C5-B6F0-324A5DCE0E47"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*",
+                "matchCriteriaId": "5DFA0A4E-D01F-4E19-A78B-07FD8F839A18"
               }
             ]
           }

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <lib.xercesimpl.version>2.12.2</lib.xercesimpl.version>
     <quarkus.platform.version>3.9.2</quarkus.platform.version>
     <lib.log4j-over-slf4j.version>2.0.7</lib.log4j-over-slf4j.version>
-    <lib.versatile.version>0.6.0</lib.versatile.version>
+    <lib.versatile.version>0.6.1</lib.versatile.version>
 
     <!-- Plugin Versions -->
     <plugin.cyclonedx.version>2.8.0</plugin.cyclonedx.version>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes mapping of CPEs to vers ranges when version is NA (`-`).

* Move creation of Component record with CPE *before* constructing the version range. This way we won't be dropping CPE data even when version range construction fails.
* Handle cases where `versFromNvdRange` doesn't yield a range.
* Log exceptions during vers constructions as warning instead of as debug message, to make it more obvious when things are not working as expected.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #1179

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~