### PR TITLE
Don't label docs for `SNAPSHOT` versions as `latest`

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -51,10 +51,20 @@ jobs:
         id: determine_version
         run: |-
           VERSION=`yq -p=xml '.project.version' pom.xml`
+          ALIASES=""
+          
+          if [[ $VERSION != *-SNAPSHOT ]]; then
+            ALIASES="latest"
+          fi
+          
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "aliases=${ALIASES}" >> $GITHUB_OUTPUT
       - name: Configure Git User
         run: |-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Deploy
-        run: mike deploy --push --update-aliases ${{ steps.determine_version.outputs.version }} latest
+        run: >-
+          mike deploy --push --update-aliases 
+              ${{ steps.determine_version.outputs.version }}
+              ${{ steps.determine_version.outputs.aliases }}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Currently the documentation for `0.5.0-SNAPSHOT` is aliased as `latest`, which results in users seeing docs that are not applicable to the current stable version.

With this change, the `latest` alias will only be applied when building for a non-`SNAPSHOT` version.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~