### PR TITLE
porting issue-3511 adding cargo analyzer

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -51,6 +51,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jaxb</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.github.mweirauch</groupId>

--- a/commons/src/main/java/org/dependencytrack/commonutil/DateUtil.java
+++ b/commons/src/main/java/org/dependencytrack/commonutil/DateUtil.java
@@ -57,4 +57,11 @@ public final class DateUtil {
         df.setTimeZone(tz);
         return df.format(date);
     }
+
+    public static Date fromISO8601(final String dateString) {
+        if (dateString == null) {
+            return null;
+        }
+        return javax.xml.bind.DatatypeConverter.parseDateTime(dateString).getTime();
+    }
 }

--- a/commons/src/main/java/org/dependencytrack/commonutil/DateUtil.java
+++ b/commons/src/main/java/org/dependencytrack/commonutil/DateUtil.java
@@ -62,6 +62,6 @@ public final class DateUtil {
         if (dateString == null) {
             return null;
         }
-        return javax.xml.bind.DatatypeConverter.parseDateTime(dateString).getTime();
+        return jakarta.xml.bind.DatatypeConverter.parseDateTime(dateString).getTime();
     }
 }

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/CargoMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/CargoMetaAnalyzer.java
@@ -35,9 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 
 /**
  * An IMetaAnalyzer implementation that supports Cargo via crates.io compatible repos

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/CargoMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/CargoMetaAnalyzer.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+
+package org.dependencytrack.repometaanalyzer.repositories;
+
+import com.github.packageurl.PackageURL;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.dependencytrack.persistence.model.Component;
+import org.dependencytrack.persistence.model.RepositoryType;
+import org.dependencytrack.repometaanalyzer.model.MetaAnalyzerException;
+import org.dependencytrack.repometaanalyzer.model.MetaModel;
+import org.dependencytrack.commonutil.DateUtil;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+/**
+ * An IMetaAnalyzer implementation that supports Cargo via crates.io compatible repos
+ *
+ * @author Steve Springett
+ * @since 4.1.0
+ */
+
+public class CargoMetaAnalyzer extends AbstractMetaAnalyzer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CargoMetaAnalyzer.class);
+    private static final String DEFAULT_BASE_URL = "https://crates.io";
+    private static final String API_URL = "/api/v1/crates/%s";
+
+    CargoMetaAnalyzer() {
+        this.baseUrl = DEFAULT_BASE_URL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RepositoryType supportedRepositoryType() {
+        return RepositoryType.CARGO;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isApplicable(final Component component) {
+        return component.getPurl() != null && PackageURL.StandardTypes.CARGO.equals(component.getPurl().getType());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public MetaModel analyze(final Component component) {
+        final MetaModel meta = new MetaModel(component);
+        if (component.getPurl() != null) {
+            final String url = String.format(baseUrl + API_URL, component.getPurl().getName());
+            try (final CloseableHttpResponse response = processHttpRequest(url)) {
+                if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                    final HttpEntity entity = response.getEntity();
+                    if (entity != null) {
+                        String responseString = EntityUtils.toString(entity);
+                        var jsonObject = new JSONObject(responseString);
+                        final JSONObject crate = jsonObject.optJSONObject("crate");
+                        if (crate != null) {
+                            final String latest = crate.getString("newest_version");
+                            meta.setLatestVersion(latest);
+                        }
+                        final JSONArray versions = jsonObject.optJSONArray("versions");
+                        if (versions != null) {
+                            for (int i = 0; i < versions.length(); i++) {
+                                final JSONObject version = versions.getJSONObject(i);
+                                final String versionString = version.optString("num");
+                                if (meta.getLatestVersion() != null && meta.getLatestVersion().equals(versionString)) {
+                                    final String publishedTimestamp = version.optString("created_at");
+                                    try {
+                                        meta.setPublishedTimestamp(DateUtil.fromISO8601(publishedTimestamp));
+                                    } catch (IllegalArgumentException e) {
+                                        LOGGER.warn("An error occurred while parsing published time", e);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    handleUnexpectedHttpResponse(LOGGER, url, response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase(), component);
+                }
+            } catch (IOException ex) {
+                handleRequestException(LOGGER, ex);
+            } catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
+            }
+        }
+        return meta;
+    }
+
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/RepositoryAnalyzerFactory.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/RepositoryAnalyzerFactory.java
@@ -39,6 +39,7 @@ public class RepositoryAnalyzerFactory {
             PackageURL.StandardTypes.NPM, NpmMetaAnalyzer::new,
             PackageURL.StandardTypes.NUGET, NugetMetaAnalyzer::new,
             PackageURL.StandardTypes.PYPI, PypiMetaAnalyzer::new,
+            PackageURL.StandardTypes.CARGO, CargoMetaAnalyzer::new,
             "cpan", CpanMetaAnalyzer::new
     );
 

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/CargoMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/CargoMetaAnalyzerTest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+
+package org.dependencytrack.repometaanalyzer.repositories;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.persistence.model.Component;
+import org.dependencytrack.persistence.model.RepositoryType;
+import org.dependencytrack.repometaanalyzer.model.MetaModel;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CargoMetaAnalyzerTest {
+    @Test
+    public void testAnalyzer() throws Exception {
+        Component component = new Component();
+        component.setPurl(new PackageURL("pkg:cargo/rand@0.7.2"));
+
+        CargoMetaAnalyzer analyzer = new CargoMetaAnalyzer();
+        Assert.assertTrue(analyzer.isApplicable(component));
+        Assert.assertEquals(RepositoryType.CARGO, analyzer.supportedRepositoryType());
+        MetaModel metaModel = analyzer.analyze(component);
+        Assert.assertNotNull(metaModel.getLatestVersion());
+        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+    }    
+}

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/RepositoryAnalyzerFactoryTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/RepositoryAnalyzerFactoryTest.java
@@ -38,7 +38,7 @@ class RepositoryAnalyzerFactoryTest {
     @ParameterizedTest
     @CsvSource(value = {
             "pkg:foo/bar, false",
-            "pkg:cargo/foo, false",
+            "pkg:cargo/foo, true",
             "pkg:cocoapods/foo, false",
             "pkg:composer/foo, true",
             "pkg:deb/foo, false",
@@ -63,6 +63,7 @@ class RepositoryAnalyzerFactoryTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "pkg:cargo/foo",
             "pkg:composer/foo/bar",
             "pkg:gem/foo/bar",
             "pkg:golang/foo/bar",


### PR DESCRIPTION
### Description

- Porting issue to add Cargo analyzer: https://github.com/DependencyTrack/dependency-track/pull/3511
- Added the `CargoMetaAnalyzer.java`, which was not there. Made changes to the file to fit hyades changes
- Added `fromISO8601` function to `DateUtil.java`. ~~Note: my IDE says that `javax.xml.bind` cannot be resolved, but maybe I don't have the environment configured. Is this dependency added to this project able to be used?~~
- switched from javax to jakarta https://jakarta.ee/specifications/platform/9/apidocs/jakarta/xml/bind/datatypeconverter 
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Porting changes from 4.11: https://github.com/DependencyTrack/hyades/issues/1190
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

I haven't run any manual tests for this feature either. I can look into doing so if needed
<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly