### PR TITLE
Add date format to support offset in nuget analyser

### DIFF
--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzer.java
@@ -47,7 +47,8 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
 
     public static final DateFormat[] SUPPORTED_DATE_FORMATS = new DateFormat[]{
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
     };
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NugetMetaAnalyzer.class);

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzerTest.java
@@ -36,12 +36,15 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.dependencytrack.repometaanalyzer.repositories.NugetMetaAnalyzer.SUPPORTED_DATE_FORMATS;
 
 class NugetMetaAnalyzerTest {
     private IMetaAnalyzer analyzer;
@@ -169,6 +172,17 @@ class NugetMetaAnalyzerTest {
         Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 
+    @Test
+    void testPublishedDateTimeFormat() throws ParseException {
+        Date dateParsed = null;
+        for (DateFormat dateFormat : SUPPORTED_DATE_FORMATS) {
+            try {
+                dateParsed = dateFormat.parse("1900-01-01T00:00:00+00:00");
+            } catch (ParseException e) {}
+        }
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Assertions.assertEquals(dateFormat.parse("1900-01-01T00:00:00+00:00"), dateParsed);
+    }
 
     private String readResourceFileToString(String fileName) throws Exception {
         return Files.readString(Paths.get(getClass().getResource(fileName).toURI()));


### PR DESCRIPTION
### Description

Nuget Analyzer has list of two supported SimpleDateFormat which are allowed for parsing the dates being received from the repository, based on limited test data.

Now, as seen in logs, below date format is also received from the nugget repo. This date has offset dateTime and needs to be added to the list of supported formats in order to avoid the ParseException.

Date example: 1900-01-01T00:00:00+00:00
Format needed: yyyy-MM-dd'T'HH:mm:ss

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1263

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly