### PR TITLE
Fix inconsistent `source` identifier for GitHub Advisories

### DIFF
--- a/mirror-service/src/test/java/org/dependencytrack/vulnmirror/datasource/github/GitHubAdvisoryToCdxParserTest.java
+++ b/mirror-service/src/test/java/org/dependencytrack/vulnmirror/datasource/github/GitHubAdvisoryToCdxParserTest.java
@@ -72,14 +72,9 @@ class GitHubAdvisoryToCdxParserTest {
                                "name": "GITHUB"
                              },
                              "references": [{
-                               "id": "GHSA-fxwm-579q-49qq",
-                               "source": {
-                                 "name": "GHSA"
-                               }
-                             }, {
                                "id": "CVE-2019-8331",
                                "source": {
-                                 "name": "CVE"
+                                 "name": "NVD"
                                }
                              }],
                              "ratings": [{
@@ -164,14 +159,9 @@ class GitHubAdvisoryToCdxParserTest {
                                "name": "GITHUB"
                              },
                              "references": [{
-                               "id": "GHSA-p82g-2xpp-m5r3",
-                               "source": {
-                                 "name": "GHSA"
-                               }
-                             }, {
                                "id": "CVE-2015-5654",
                                "source": {
-                                 "name": "CVE"
+                                 "name": "NVD"
                                }
                              }],
                              "ratings": [{


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes inconsistent `source` identifier for GitHub Advisories.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #1295

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~