### PR TITLE
Port: Configurable email subject prefix 

### DIFF
--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -113,6 +113,15 @@ public class SendMailPublisher implements Publisher {
             return;
         }
 
+        String emailSubjectPrefix;
+        // emailSubjectPrefix = qm.getConfigProperty(EMAIL_PREFIX.getGroupName(), EMAIL_PREFIX.getPropertyName()).getPropertyValue();
+        //emailSubjectPrefix = emailSubjectPrefix == null ? " " : emailSubjectPrefix;
+        emailSubjectPrefix = publisherConfig.emailPrefix().orElse(" ");
+        if (emailSubjectPrefix == null) {
+            LOGGER.warn("Email prefix is not configured; Skipping notification (%s)".formatted(ctx));
+            return;
+        }
+
         final String fromAddress = publisherConfig.fromAddress().orElse(null);
         if (fromAddress == null) {
             LOGGER.warn("From address is not configured; Skipping notification (%s)".formatted(ctx));
@@ -132,7 +141,7 @@ public class SendMailPublisher implements Publisher {
                 final var message = new MailMessage();
                 message.setFrom(fromAddress);
                 message.setTo(destination);
-                message.setSubject("[Dependency-Track] " + notification.getTitle());
+                message.setSubject(emailSubjectPrefix + " " + notification.getTitle());
                 message.setText(content);
 
                 mailClient.sendMailAndAwait(message);

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -114,8 +114,6 @@ public class SendMailPublisher implements Publisher {
         }
 
         String emailSubjectPrefix;
-        // emailSubjectPrefix = qm.getConfigProperty(EMAIL_PREFIX.getGroupName(), EMAIL_PREFIX.getPropertyName()).getPropertyValue();
-        //emailSubjectPrefix = emailSubjectPrefix == null ? " " : emailSubjectPrefix;
         emailSubjectPrefix = publisherConfig.emailPrefix().orElse(" ");
         if (emailSubjectPrefix == null) {
             LOGGER.warn("Email prefix is not configured; Skipping notification (%s)".formatted(ctx));

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -115,10 +115,6 @@ public class SendMailPublisher implements Publisher {
 
         String emailSubjectPrefix;
         emailSubjectPrefix = publisherConfig.emailPrefix().orElse(" ");
-        if (emailSubjectPrefix == null) {
-            LOGGER.warn("Email prefix is not configured; Skipping notification (%s)".formatted(ctx));
-            return;
-        }
 
         final String fromAddress = publisherConfig.fromAddress().orElse(null);
         if (fromAddress == null) {

--- a/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisherConfig.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisherConfig.java
@@ -44,6 +44,7 @@ class SendMailPublisherConfig {
     private final Provider<Optional<String>> passwordProvider;
     private final Provider<Optional<Boolean>> tlsEnabledProvider;
     private final Provider<Optional<Boolean>> trustCertificateProvider;
+    private final Provider<Optional<String>> emailPrefixProvider;
 
     SendMailPublisherConfig(
             @ConfigProperty(name = "dtrack.email.smtp.enabled") final Provider<Optional<Boolean>> smtpEnabledProvider,
@@ -53,7 +54,8 @@ class SendMailPublisherConfig {
             @ConfigProperty(name = "dtrack.email.smtp.username") final Provider<Optional<String>> usernameProvider,
             @ConfigProperty(name = "dtrack.email.smtp.password") final Provider<Optional<String>> passwordProvider,
             @ConfigProperty(name = "dtrack.email.smtp.ssltls") final Provider<Optional<Boolean>> tlsEnabledProvider,
-            @ConfigProperty(name = "dtrack.email.smtp.trustcert") final Provider<Optional<Boolean>> trustCertificateProvider
+            @ConfigProperty(name = "dtrack.email.smtp.trustcert") final Provider<Optional<Boolean>> trustCertificateProvider,
+            @ConfigProperty(name = "dtrack.email.subject.prefix") final Provider<Optional<String>> emailPrefixProvider
     ) {
         this.smtpEnabledProvider = smtpEnabledProvider;
         this.fromAddressProvider = fromAddressProvider;
@@ -63,10 +65,15 @@ class SendMailPublisherConfig {
         this.passwordProvider = passwordProvider;
         this.tlsEnabledProvider = tlsEnabledProvider;
         this.trustCertificateProvider = trustCertificateProvider;
+        this.emailPrefixProvider = emailPrefixProvider;
     }
 
     Optional<Boolean> isSmtpEnabled() {
         return smtpEnabledProvider.get();
+    }
+
+    Optional<String> emailPrefix() {
+        return emailPrefixProvider.get();
     }
 
     Optional<String> fromAddress() {

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -55,7 +55,8 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
                     Map.entry("dtrack.email.smtp.enabled", "true"),
                     Map.entry("dtrack.email.smtp.server.hostname", "localhost"),
                     Map.entry("dtrack.email.smtp.server.port", "${mailpit.smtp.port}"),
-                    Map.entry("dtrack.email.smtp.from.address", "dtrack@example.com")
+                    Map.entry("dtrack.email.smtp.from.address", "dtrack@example.com"),
+                    Map.entry("dtrack.email.subject.prefix", "[Dependency-Track]")
             );
         }
 


### PR DESCRIPTION
### Description

porting issue https://github.com/DependencyTrack/dependency-track/pull/3422 

### Addressed Issue
for porting issues https://github.com/DependencyTrack/hyades/issues/1190 

### Additional Details

need to port corresponding front end issue too https://github.com/DependencyTrack/frontend/pull/720

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly