### PR TITLE
Fix CVSS vectors missing from e2e notification asserts

### DIFF
--- a/e2e/src/test/java/org/dependencytrack/e2e/BomProcessedNotificationDelayedE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomProcessedNotificationDelayedE2ET.java
@@ -191,7 +191,8 @@ public class BomProcessedNotificationDelayedE2ET extends AbstractE2ET {
                                    "vulnId" : "INT-123",
                                    "source" : "INTERNAL",
                                    "severity" : "CRITICAL",
-                                   "cvssv3": 10.0
+                                   "cvssv3": 10.0,
+                                   "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
                                  } ]
                                } ],
                                "status" : "PROJECT_VULN_ANALYSIS_STATUS_COMPLETED"

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
@@ -245,7 +245,8 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                 "vulnId": "INT-123",
                                 "source": "INTERNAL",
                                 "cvssv3" : "${json-unit.any-number}",
-                                "severity": "CRITICAL"
+                                "severity": "CRITICAL",
+                                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
                               },
                               "affectedProjectsReference": {
                                 "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-123/projects",
@@ -304,7 +305,8 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                    "vulnId" : "INT-123",
                                    "source" : "INTERNAL",
                                    "severity" : "CRITICAL",
-                                   "cvssv3": 10.0
+                                   "cvssv3": 10.0,
+                                   "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
                                  } ]
                                } ],
                                "status" : "PROJECT_VULN_ANALYSIS_STATUS_COMPLETED"

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -487,7 +487,8 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                   "vulnId": "INT-002",
                                   "source": "INTERNAL",
                                   "cvssv3": 7.1,
-                                  "severity": "HIGH"
+                                  "severity": "HIGH",
+                                  "cvssV3Vector" : "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
                                 },
                                 {
                                   "uuid": "${json-unit.any-string}",
@@ -540,7 +541,8 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                 "vulnId": "INT-002",
                                 "source": "INTERNAL",
                                 "cvssv3": 7.1,
-                                "severity": "HIGH"
+                                "severity": "HIGH",
+                                "cvssV3Vector" : "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
                               },
                               "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
                               "affectedProjects": [


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes CVSS vectors missing from e2e notification asserts.

Vectors were added to notification subjects in https://github.com/DependencyTrack/hyades-apiserver/pull/696.

Depends on https://github.com/DependencyTrack/hyades-apiserver/pull/699

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~