### PR TITLE
Port fix for npm purls with special characters

### DIFF
--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/AbstractMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/AbstractMetaAnalyzer.java
@@ -28,12 +28,14 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.dependencytrack.commonutil.DateUtil;
 import org.dependencytrack.commonutil.HttpUtil;
-import org.dependencytrack.repometaanalyzer.model.IntegrityMeta;
 import org.dependencytrack.persistence.model.Component;
+import org.dependencytrack.repometaanalyzer.model.IntegrityMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Base abstract class that all IMetaAnalyzer implementations should likely extend.
@@ -82,6 +84,10 @@ public abstract class AbstractMetaAnalyzer implements IMetaAnalyzer {
     public void setRepositoryUsernameAndPassword(String username, String password) {
         this.username = StringUtils.trimToNull(username);
         this.password = StringUtils.trimToNull(password);
+    }
+
+    protected String urlEncode(final String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     @Override

--- a/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzer.java
@@ -21,11 +21,11 @@ package org.dependencytrack.repometaanalyzer.repositories;
 import com.github.packageurl.PackageURL;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.dependencytrack.persistence.model.Component;
+import org.dependencytrack.persistence.model.RepositoryType;
 import org.dependencytrack.repometaanalyzer.model.IntegrityMeta;
 import org.dependencytrack.repometaanalyzer.model.MetaAnalyzerException;
 import org.dependencytrack.repometaanalyzer.model.MetaModel;
-import org.dependencytrack.persistence.model.Component;
-import org.dependencytrack.persistence.model.RepositoryType;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,12 +71,12 @@ public class NpmMetaAnalyzer extends AbstractMetaAnalyzer {
 
             final String packageName;
             if (component.getPurl().getNamespace() != null) {
-                packageName = component.getPurl().getNamespace().replace("@", "%40") + "%2F" + component.getPurl().getName();
+                packageName = "%s/%s".formatted(component.getPurl().getNamespace(), component.getPurl().getName());
             } else {
                 packageName = component.getPurl().getName();
             }
 
-            final String url = String.format(baseUrl + API_URL, packageName);
+            final String url = String.format(baseUrl + API_URL, urlEncode(packageName));
             try (final CloseableHttpResponse response = processHttpRequest(url)) {
                 if (response.getStatusLine().getStatusCode() == org.apache.http.HttpStatus.SC_OK) {
                     String responseString = EntityUtils.toString(response.getEntity());

--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NpmMetaAnalyzerTest.java
@@ -190,4 +190,53 @@ class NpmMetaAnalyzerTest {
         Assertions.assertNull(integrityMeta.getSha512());
         Assertions.assertNull(integrityMeta.getCurrentVersionLastModified());
     }
+
+    @Test
+    public void testWithScopedPackage() {
+        wireMockServer.stubFor(get(urlPathEqualTo("/-/package/%40angular%2Fcli/dist-tags"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                {
+                                  "latest": "17.1.2",
+                                  "next": "17.2.0-next.1",
+                                  "v6-lts": "6.2.9",
+                                  "v8-lts": "8.3.29",
+                                  "v7-lts": "7.3.10",
+                                  "v9-lts": "9.1.15",
+                                  "v10-lts": "10.2.4",
+                                  "v11-lts": "11.2.19",
+                                  "v12-lts": "12.2.18",
+                                  "v13-lts": "13.3.11",
+                                  "v14-lts": "14.2.13",
+                                  "v15-lts": "15.2.10",
+                                  "v16-lts": "16.2.12"
+                                }
+                                """)));
+
+        final var component = new Component();
+        component.setPurl("pkg:npm/%40angular/cli@17.1.1");
+        analyzer.setRepositoryBaseUrl(String.format("http://localhost:%d", wireMockServer.port()));
+        assertThat(analyzer.isApplicable(component)).isTrue();
+        final MetaModel metaModel = analyzer.analyze(component);
+        assertThat(metaModel).isNotNull();
+        assertThat(metaModel.getLatestVersion()).isEqualTo("17.1.2");
+    }
+
+    @Test
+    public void testWithSpecialCharactersInPackageName() {
+        wireMockServer.stubFor(get(urlPathEqualTo("/-/package/jquery%20joyride%20plugin%20/dist-tags"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withBody("""
+                                "Not Found"
+                                """)));
+        final var component = new Component();
+        component.setPurl("pkg:npm/jquery%20joyride%20plugin%20@2.1");
+        analyzer.setRepositoryBaseUrl(String.format("http://localhost:%d", wireMockServer.port()));
+        assertThat(analyzer.isApplicable(component)).isTrue();
+        final MetaModel metaModel = analyzer.analyze(component);
+        assertThat(metaModel).isNotNull();
+        assertThat(metaModel.getLatestVersion()).isNull();
+    }
 }


### PR DESCRIPTION
### Description

Fixes URISyntaxExceptions during repository metadata analysis, when NPM PURLs contain special characters.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1190 

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly