### PR TITLE
Fix e2e tests failing to get API keys

### DIFF
--- a/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.dependencytrack.apiserver.model.Analysis;
+import org.dependencytrack.apiserver.model.ApiKey;
 import org.dependencytrack.apiserver.model.BomProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
 import org.dependencytrack.apiserver.model.ConfigProperty;
@@ -73,6 +74,12 @@ public interface ApiServerClient {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     Team createTeam(final CreateTeamRequest request);
+
+    @PUT
+    @Path("/team/{uuid}/key")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
+    ApiKey createApiKey(@PathParam("uuid") final UUID teamUuid);
 
     @POST
     @Path("/permission/{permission}/team/{uuid}")

--- a/e2e/src/test/java/org/dependencytrack/e2e/AbstractE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/AbstractE2ET.java
@@ -24,6 +24,7 @@ import org.dependencytrack.apiserver.ApiServerAuthInterceptor;
 import org.dependencytrack.apiserver.ApiServerClient;
 import org.dependencytrack.apiserver.CompositeDecoder;
 import org.dependencytrack.apiserver.CompositeEncoder;
+import org.dependencytrack.apiserver.model.ApiKey;
 import org.dependencytrack.apiserver.model.CreateTeamRequest;
 import org.dependencytrack.apiserver.model.Team;
 import org.junit.jupiter.api.AfterEach;
@@ -286,6 +287,9 @@ public class AbstractE2ET {
         logger.info("Creating e2e team");
         final Team team = client.createTeam(new CreateTeamRequest("e2e"));
 
+        logger.info("Creating API key for e2e team");
+        final ApiKey apiKey = client.createApiKey(team.uuid());
+
         // TODO: Should assigned permissions be configurable per test case?
         logger.info("Assigning permissions to e2e team");
         for (final String permission : Set.of(
@@ -302,7 +306,7 @@ public class AbstractE2ET {
         }
 
         logger.info("Authenticating as e2e team");
-        ApiServerAuthInterceptor.setApiKey(team.apiKeys().getFirst().key());
+        ApiServerAuthInterceptor.setApiKey(apiKey.key());
 
         return client;
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes e2e tests failing to get API keys.

As of https://github.com/DependencyTrack/hyades-apiserver/pull/725, API keys are no longer created automatically when creating teams.

Adds a request to explicitly create a key.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~