### PR TITLE
Fix max.compaction.lag.ms to make it compatible with Apache Kafka

### DIFF
--- a/commons-kstreams/src/main/java/org/dependencytrack/kstreams/statestore/StateStoreUtil.java
+++ b/commons-kstreams/src/main/java/org/dependencytrack/kstreams/statestore/StateStoreUtil.java
@@ -60,7 +60,7 @@ public final class StateStoreUtil {
         return Map.of(
                 TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
                 TopicConfig.SEGMENT_BYTES_CONFIG, String.valueOf(64 * 1024 * 1024), // 64 MiB
-                TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, "0" // Perform compaction ASAP
+                TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, "1" // Perform compaction ASAP
         );
     }
 

--- a/commons-kstreams/src/test/java/org/dependencytrack/kstreams/statestore/StateStoreUtilTest.java
+++ b/commons-kstreams/src/test/java/org/dependencytrack/kstreams/statestore/StateStoreUtilTest.java
@@ -84,7 +84,7 @@ class StateStoreUtilTest {
                     .containsExactlyInAnyOrderEntriesOf(Map.of(
                             "cleanup.policy", "compact",
                             "segment.bytes", "67108864",
-                            "max.compaction.lag.ms", "0"
+                            "max.compaction.lag.ms", "1"
                     ));
         }
 

--- a/docs/reference/topics.md
+++ b/docs/reference/topics.md
@@ -16,7 +16,7 @@
 | `dtrack.notification.repository`                                                                  | 3          |                                                                                     |
 | `dtrack.notification.vex`                                                                         | 3          |                                                                                     |
 | `dtrack.notification.user`                                                                        | 3          |                                                                                     |
-| `dtrack.notification.project-vuln-analysis-complete` <sup>3</sup>                                 | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `dtrack.notification.project-vuln-analysis-complete` <sup>3</sup>                                 | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
 | `dtrack.repo-meta-analysis.component`<sup>1A</sup>                                                | 3          |                                                                                     |
 | `dtrack.repo-meta-analysis.result`                                                                | 3          |                                                                                     |
 | `dtrack.vuln-analysis.component`<sup>1B</sup>                                                     | 3          |                                                                                     |
@@ -29,16 +29,16 @@
 | `dtrack.vulnerability.mirror.command`<sup>2</sup>                                                 | 1          |                                                                                     |
 | `dtrack.vulnerability.mirror.state`<sup>2</sup>                                                   | 1          | `cleanup.policy=compact`                                                            |
 | `hyades-repository-meta-analyzer-command-by-purl-coordinates-repartition`<sup>1A</sup>            | 3          |                                                                                     |
-| `hyades-vulnerability-analyzer-completed-scans-table-changelog`<sup>1B</sup>                      | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
-| `hyades-vulnerability-analyzer-expected-scanner-results-last-update-store-changelog`<sup>1B</sup> | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
-| `hyades-vulnerability-analyzer-expected-scanner-results-table-changelog`<sup>1B</sup>             | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
-| `hyades-vulnerability-analyzer-ossindex-batch-store-changelog`<sup>1C</sup>                       | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
-| `hyades-vulnerability-analyzer-ossindex-retry-store-changelog`<sup>1C</sup>                       | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-completed-scans-table-changelog`<sup>1B</sup>                      | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
+| `hyades-vulnerability-analyzer-expected-scanner-results-last-update-store-changelog`<sup>1B</sup> | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
+| `hyades-vulnerability-analyzer-expected-scanner-results-table-changelog`<sup>1B</sup>             | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
+| `hyades-vulnerability-analyzer-ossindex-batch-store-changelog`<sup>1C</sup>                       | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
+| `hyades-vulnerability-analyzer-ossindex-retry-store-changelog`<sup>1C</sup>                       | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
 | `hyades-vulnerability-analyzer-scan-task-internal-repartition`                                    | 3          |                                                                                     |
 | `hyades-vulnerability-analyzer-scan-task-ossindex-repartition`<sup>1C</sup>                       | 3          |                                                                                     |
 | `hyades-vulnerability-analyzer-scan-task-snyk-repartition`<sup>1D</sup>                           | 3          |                                                                                     |
-| `hyades-vulnerability-analyzer-snyk-batch-store-changelog`<sup>1D</sup>                           | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
-| `hyades-vulnerability-analyzer-snyk-retry-store-changelog`<sup>1D</sup>                           | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=0` |
+| `hyades-vulnerability-analyzer-snyk-batch-store-changelog`<sup>1D</sup>                           | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
+| `hyades-vulnerability-analyzer-snyk-retry-store-changelog`<sup>1D</sup>                           | 3          | `cleanup.policy=compact`<br/>`segment.bytes=67108864`<br/>`max.compaction.lag.ms=1` |
 
 *<sup>1X</sup> The topic is subject to [co-partitioning requirements](#co-partitioning-requirements)*  
 *<sup>2</sup> The partition number of this topic should not be changed*

--- a/scripts/create-topics.sh
+++ b/scripts/create-topics.sh
@@ -78,7 +78,7 @@ for topic_name in "${vuln_analysis_topics[@]}"; do
 done
 
 create_topic "${KAFKA_TOPIC_PREFIX:-}dtrack.vulnerability.mirror.command" "1" "retention.ms=${VULN_MIRROR_TOPICS_RETENTION_MS:-43200000}"
-create_topic "${KAFKA_TOPIC_PREFIX:-}dtrack.vulnerability.mirror.state" "1" "cleanup.policy=compact segment.bytes=67108864 max.compaction.lag.ms=0"
+create_topic "${KAFKA_TOPIC_PREFIX:-}dtrack.vulnerability.mirror.state" "1" "cleanup.policy=compact segment.bytes=67108864 max.compaction.lag.ms=1"
 create_topic "${KAFKA_TOPIC_PREFIX:-}dtrack.vulnerability.digest" "1" "cleanup.policy=compact segment.bytes=134217728"
 create_topic "${KAFKA_TOPIC_PREFIX:-}dtrack.vulnerability" "${VULN_MIRROR_TOPICS_PARTITIONS:-3}" "cleanup.policy=compact"
 create_topic "${KAFKA_TOPIC_PREFIX:-}dtrack.epss" "${VULN_MIRROR_TOPICS_PARTITIONS:-3}" "cleanup.policy=compact"


### PR DESCRIPTION
### Description

We currently set [max.compaction.lag.ms](https://kafka.apache.org/37/generated/topic_config.html#topicconfigs_max.compaction.lag.ms) to 0 for compacted topics. This works for Redpanda, but fails for Apache Kafka.

The allowed range for max.compaction.lag.ms is [1,...], with the default value being 9223372036854775807.

Fix the same.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1391

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
