### PR TITLE
Support idle connection eviction of database config source

### DIFF
--- a/quarkus-extensions/config-dependencytrack/runtime/src/main/java/org/dependencytrack/config/DatabaseConfigSourceConfig.java
+++ b/quarkus-extensions/config-dependencytrack/runtime/src/main/java/org/dependencytrack/config/DatabaseConfigSourceConfig.java
@@ -59,9 +59,16 @@ interface DatabaseConfigSourceConfig {
     /**
      * The timeout for acquiring new database connections.
      */
-    @WithDefault("${quarkus.datasource.jdbc.acquisition-timeout}")
+    @WithDefault("${quarkus.datasource.jdbc.acquisition-timeout:PT5S}")
     @WithConverter(DurationConverter.class)
     Optional<Duration> acquisitionTimeout();
+
+    /**
+     * The interval at which we try to remove idle connections.
+     */
+    @WithDefault("${quarkus.datasource.jdbc.idle-removal-interval:PT5M}")
+    @WithConverter(DurationConverter.class)
+    Optional<Duration> idleRemovalInterval();
 
     /**
      * Connection pooling configuration.

--- a/quarkus-extensions/config-dependencytrack/runtime/src/main/java/org/dependencytrack/config/DatabaseConfigSourceFactory.java
+++ b/quarkus-extensions/config-dependencytrack/runtime/src/main/java/org/dependencytrack/config/DatabaseConfigSourceFactory.java
@@ -82,6 +82,8 @@ class DatabaseConfigSourceFactory implements ConfigSourceFactory {
                 .maxSize(config.pool().maxSize());
         config.acquisitionTimeout()
                 .ifPresent(connectionPoolConfig::acquisitionTimeout);
+        config.idleRemovalInterval()
+                .ifPresent(connectionPoolConfig::reapTimeout);
 
         final AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfig =
                 connectionPoolConfig.connectionFactoryConfiguration();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Supports idle connection eviction of database config source.

Currently, the connection pool used by the `config-dependencytrack` extension does not close database connections, even if they're unused for prolonged periods of time.

This change adopt's Quarkus' `quarkus.datasource.jdbc.idle-removal-interval` property for the pool, which will attempt to evict idle connections every 5min per default.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
