### PR TITLE
Add initializer container to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
         condition: service_healthy
       redpanda:
         condition: service_healthy
+      initializer:
+        condition: service_completed_successfully
       secret-init:
         condition: service_completed_successfully
     environment:
@@ -47,6 +49,8 @@ services:
         condition: service_healthy
       redpanda:
         condition: service_healthy
+      initializer:
+        condition: service_completed_successfully
       secret-init:
         condition: service_completed_successfully
     environment:
@@ -73,6 +77,8 @@ services:
         condition: service_healthy
       redpanda:
         condition: service_healthy
+      initializer:
+        condition: service_completed_successfully
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
       KAFKA_STREAMS_NUM_STREAM_THREADS: "12" # Default number of input partitions is 12
@@ -104,6 +110,10 @@ services:
         condition: service_healthy
       redpanda:
         condition: service_healthy
+      initializer:
+        condition: service_completed_successfully
+      secret-init:
+        condition: service_completed_successfully
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
       KAFKA_STREAMS_NUM_STREAM_THREADS: "3"
@@ -121,6 +131,23 @@ services:
       - "secret-data:/var/run/secrets:ro"
     restart: unless-stopped
 
+  initializer:
+    image: ghcr.io/dependencytrack/hyades-apiserver:snapshot
+    container_name: dt-initializer
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      EXTRA_JAVA_OPTIONS: "-Xmx256m"
+      ALPINE_DATABASE_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
+      ALPINE_DATABASE_USERNAME: "dtrack"
+      ALPINE_DATABASE_PASSWORD: "dtrack"
+      INIT_TASKS_ENABLED: "true"
+      INIT_AND_EXIT: "true"
+    profiles:
+    - demo
+    restart: on-failure
+
   apiserver:
     image: ghcr.io/dependencytrack/hyades-apiserver:snapshot
     container_name: dt-apiserver
@@ -129,6 +156,8 @@ services:
         condition: service_healthy
       redpanda:
         condition: service_healthy
+      initializer:
+        condition: service_completed_successfully
       secret-init:
         condition: service_completed_successfully
     environment:
@@ -144,6 +173,7 @@ services:
       ALPINE_SECRET_KEY_PATH: "/var/run/secrets/secret.key"
       KAFKA_BOOTSTRAP_SERVERS: "dt-redpanda:29092"
       INTEGRITY_CHECK_ENABLED: "true"
+      INIT_TASKS_ENABLED: "false"
     ports:
       - "127.0.0.1:8080:8080"
     volumes:


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds initializer container to Docker Compose.

The initializer executes schema migrations and populates the database with default objects. We added it to the Helm chart already (see https://github.com/DependencyTrack/helm-charts/issues/136), but it was still missing from `docker-compose.yml`.

The benefit of this addition is that we avoid any schema-related errors in hyades services, and the API server executing migrations and default object population on every startup.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
