### PR TITLE
Use `/api/v1/event/token/{uuid}` instead of /api/v1/bom/token/{uui} in e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hyades
 
 [![Build Status](https://github.com/DependencyTrack/hyades/actions/workflows/ci.yml/badge.svg)](https://github.com/DependencyTrack/hyades/actions/workflows/ci.yml)
+[![End-to-End Test](https://github.com/DependencyTrack/hyades/actions/workflows/e2e-test.yml/badge.svg)](https://github.com/DependencyTrack/hyades/actions/workflows/e2e-test.yml)
 [![Codacy Code Quality Badge](https://app.codacy.com/project/badge/Grade/64c349c2b92340ffb83f7dba1d6b03e5)](https://app.codacy.com/gh/DependencyTrack/hyades/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Codacy Coverage Badge](https://app.codacy.com/project/badge/Coverage/64c349c2b92340ffb83f7dba1d6b03e5)](https://app.codacy.com/gh/DependencyTrack/hyades/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -23,15 +23,19 @@ Refer to the [kafka configuration reference] for details. Example of name change
     |:-----------------------------------------------------------|:----------------------------------------------------|
     | `alpine.kafka.processor.vuln.scan.result.processing.order` | `kafka.processor.vuln.scan.result.processing.order` |
 
-* All deprecated endpoints mentioned below were removed:
-    * POST `/api/v1/policy/{policyUuid}/tag/{tagName}`
-    * DELETE `/api/v1/policy/{policyUuid}/tag/{tagName}`
-    * GET `/api/v1/tag/{policyUuid}`
-    * GET `/api/v1/bom/token/{uuid}`
+* The endpoints deprecated in v4.x mentioned below were removed ([apiserver/#910]):
+
+    | Removed endpoint                                   | Replacement                        |
+    |:---------------------------------------------------|:-----------------------------------|
+    | `POST /api/v1/policy/{policyUuid}/tag/{tagName}`   | `POST /api/v1/tag/{name}/policy`   |
+    | `DELETE /api/v1/policy/{policyUuid}/tag/{tagName}` | `DELETE /api/v1/tag/{name}/policy` |
+    | `GET /api/v1/tag/{policyUuid}`                     | `GET /api/v1/tag/policy/{uuid}`    |
+    | `GET /api/v1/bom/token/{uuid}`                     | `GET /api/v1/event/token/{uuid}`   |
 
 [apiserver/#840]: https://github.com/DependencyTrack/hyades-apiserver/pull/840
 [apiserver/#888]: https://github.com/DependencyTrack/hyades-apiserver/pull/888
 [apiserver/#904]: https://github.com/DependencyTrack/hyades-apiserver/pull/904
+[apiserver/#910]: https://github.com/DependencyTrack/hyades-apiserver/pull/910
 [hyades/#1392]: https://github.com/DependencyTrack/hyades/issues/1392
 
 [kafka configuration reference]: ../reference/configuration/api-server.md#kafka

--- a/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/ApiServerClient.java
@@ -30,7 +30,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.dependencytrack.apiserver.model.Analysis;
 import org.dependencytrack.apiserver.model.ApiKey;
-import org.dependencytrack.apiserver.model.BomProcessingResponse;
+import org.dependencytrack.apiserver.model.EventProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
 import org.dependencytrack.apiserver.model.ConfigProperty;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
@@ -95,10 +95,10 @@ public interface ApiServerClient {
     WorkflowTokenResponse uploadBom(final BomUploadRequest request);
 
     @GET
-    @Path("/bom/token/{token}")
+    @Path("/event/token/{token}")
     @Produces(MediaType.WILDCARD)
     @Consumes(MediaType.WILDCARD)
-    BomProcessingResponse isBomBeingProcessed(@PathParam("token") final String token);
+    EventProcessingResponse isEventBeingProcessed(@PathParam("token") final String token);
 
     @PUT
     @Path("/vulnerability")

--- a/e2e/src/main/java/org/dependencytrack/apiserver/model/EventProcessingResponse.java
+++ b/e2e/src/main/java/org/dependencytrack/apiserver/model/EventProcessingResponse.java
@@ -21,5 +21,5 @@ package org.dependencytrack.apiserver.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record BomProcessingResponse(Boolean processing) {
+public record EventProcessingResponse(Boolean processing) {
 }

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadOssIndexAnalysisE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadOssIndexAnalysisE2ET.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.e2e;
 
-import org.dependencytrack.apiserver.model.BomProcessingResponse;
+import org.dependencytrack.apiserver.model.EventProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
 import org.dependencytrack.apiserver.model.Finding;
 import org.dependencytrack.apiserver.model.Project;
@@ -68,7 +68,7 @@ class BomUploadOssIndexAnalysisE2ET extends AbstractE2ET {
                 .atMost(Duration.ofSeconds(30))
                 .pollDelay(Duration.ofMillis(250))
                 .untilAsserted(() -> {
-                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    final EventProcessingResponse processingResponse = apiServerClient.isEventBeingProcessed(response.token());
                     assertThat(processingResponse.processing()).isFalse();
                 });
 

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
@@ -21,7 +21,7 @@ package org.dependencytrack.e2e;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.ServerSetup;
-import org.dependencytrack.apiserver.model.BomProcessingResponse;
+import org.dependencytrack.apiserver.model.EventProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
 import org.dependencytrack.apiserver.model.ConfigProperty;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
@@ -166,7 +166,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                 .atMost(Duration.ofSeconds(15))
                 .pollDelay(Duration.ofMillis(250))
                 .untilAsserted(() -> {
-                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    final EventProcessingResponse processingResponse = apiServerClient.isEventBeingProcessed(response.token());
                     assertThat(processingResponse.processing()).isFalse();
                 });
 

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadSnykAnalysisE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadSnykAnalysisE2ET.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.e2e;
 
-import org.dependencytrack.apiserver.model.BomProcessingResponse;
+import org.dependencytrack.apiserver.model.EventProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
 import org.dependencytrack.apiserver.model.Finding;
 import org.dependencytrack.apiserver.model.Project;
@@ -81,7 +81,7 @@ class BomUploadSnykAnalysisE2ET extends AbstractE2ET {
                 .atMost(Duration.ofSeconds(30))
                 .pollDelay(Duration.ofMillis(250))
                 .untilAsserted(() -> {
-                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    final EventProcessingResponse processingResponse = apiServerClient.isEventBeingProcessed(response.token());
                     assertThat(processingResponse.processing()).isFalse();
                 });
 

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -27,7 +27,7 @@ import io.minio.UploadObjectArgs;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.dependencytrack.apiserver.model.Analysis;
-import org.dependencytrack.apiserver.model.BomProcessingResponse;
+import org.dependencytrack.apiserver.model.EventProcessingResponse;
 import org.dependencytrack.apiserver.model.BomUploadRequest;
 import org.dependencytrack.apiserver.model.CreateNotificationRuleRequest;
 import org.dependencytrack.apiserver.model.CreateVulnerabilityRequest;
@@ -219,7 +219,7 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                 .atMost(Duration.ofSeconds(15))
                 .pollDelay(Duration.ofMillis(250))
                 .untilAsserted(() -> {
-                    final BomProcessingResponse processingResponse = apiServerClient.isBomBeingProcessed(response.token());
+                    final EventProcessingResponse processingResponse = apiServerClient.isEventBeingProcessed(response.token());
                     assertThat(processingResponse.processing()).isFalse();
                 });
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Uses `/api/v1/event/token/{uuid}` instead of /api/v1/bom/token/{uui} in e2e tests.

Updates upgrade notes to include replacements for removed endpoints.

Adds e2e test status badge to `README.md`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades-apiserver/pull/910

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
