### PR TITLE
Enable `reWriteBatchedInserts` Postgres JDBC driver option in e2e tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
       # which can cause problems on some workstations.
       # For production deployments, the default should be used.
       EXTRA_JAVA_OPTIONS: "-Xmx2g"
-      ALPINE_DATABASE_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
+      ALPINE_DATABASE_URL: "jdbc:postgresql://dt-postgres:5432/dtrack?reWriteBatchedInserts=true"
       ALPINE_DATABASE_USERNAME: "dtrack"
       ALPINE_DATABASE_PASSWORD: "dtrack"
       ALPINE_METRICS_ENABLED: "true"

--- a/e2e/src/test/java/org/dependencytrack/e2e/AbstractE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/AbstractE2ET.java
@@ -111,6 +111,7 @@ public class AbstractE2ET {
                 .withDatabaseName("dtrack")
                 .withUsername("dtrack")
                 .withPassword("dtrack")
+                .withUrlParam("reWriteBatchedInserts", "true")
                 .withNetworkAliases("postgres")
                 .withNetwork(internalNetwork);
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

As per JDBC driver documentation (https://jdbc.postgresql.org/documentation/use/):

This will change batch inserts from insert into foo (col1, col2, col3) values (1, 2, 3) into insert into foo (col1, col2, col3) values (1, 2, 3), (4, 5, 6) this provides 2-3x performance improvement

Indeed, per default even batched JDBC statements are executed one-by-one, somewhat defeating the purpose of batching in the first place. This option allows us to get the true benefit out of performing batch operations.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
