### PR TITLE
Port : Exclude pre-releases from NuGet latest version check

### DIFF
--- a/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzerTest.java
+++ b/repository-meta-analyzer/src/test/java/org/dependencytrack/repometaanalyzer/repositories/NugetMetaAnalyzerTest.java
@@ -187,4 +187,40 @@ class NugetMetaAnalyzerTest {
     private String readResourceFileToString(String fileName) throws Exception {
         return Files.readString(Paths.get(getClass().getResource(fileName).toURI()));
     }
+
+    // This test is to check if the analyzer is excluding pre-release versions
+    // The test is transitent depending on the current version of the package
+    // retrieved from the repository at the time of running.
+    // When it was created, the latest release version was 9.0.0-preview.1.24080.9
+    @Test
+    public void testAnalyzerExcludingPreRelease() throws Exception {
+        Component component = new Component();
+        component.setPurl(new PackageURL("pkg:nuget/Microsoft.Extensions.DependencyInjection@8.0.0"));
+
+        analyzer.setRepositoryBaseUrl("https://api.nuget.org");
+        MetaModel metaModel = analyzer.analyze(component);
+
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertFalse(metaModel.getLatestVersion().contains("-"));
+    }
+
+    // This test is to check if the analyzer is including pre-release versions
+    // The test is transitent depending on the current version of the package
+    // retrieved from the repository at the time of running.
+    // When it was created, the latest release version was 9.0.0-preview.1.24080.9
+    @Test
+    public void testAnalyzerIncludingPreRelease() throws Exception {
+        Component component = new Component();
+        component.setPurl(new PackageURL("pkg:nuget/Microsoft.Extensions.DependencyInjection@8.0.0-beta.21301.5"));
+
+        analyzer.setRepositoryBaseUrl("https://api.nuget.org");
+        MetaModel metaModel = analyzer.analyze(component);
+
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertFalse(metaModel.getLatestVersion().contains("-"));
+    }
 }


### PR DESCRIPTION
### Description

This PR addressed the issue of pre-release nuget packages being returned as the latest version.

The [Nuget Documentation](https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions) identifies packages with a "-" in their version string as a pre-release package.

The change is to filter the list of Nuget Packages that contain an "-" when determining the latestVersion. If the component being inspected is a pre-release itself, then pre-release versions are not filtered.

### Addressed Issue

Port change : https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
