### PR TITLE
Set vulnerability as rejected for empty snyk records to suppress it in apiserver

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessor.java
@@ -18,12 +18,14 @@
  */
 package org.dependencytrack.vulnanalyzer.processor.scanner.snyk;
 
+import com.google.protobuf.Timestamp;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.core.IntervalFunction;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.cache.Cache;
 import jakarta.ws.rs.core.MultivaluedMap;
 import org.cyclonedx.proto.v1_6.Bom;
+import org.cyclonedx.proto.v1_6.Vulnerability;
 import org.dependencytrack.common.cwe.CweResolver;
 import org.dependencytrack.proto.vulnanalysis.internal.v1beta1.ScanTask;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
@@ -49,6 +51,7 @@ import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -163,9 +166,7 @@ public class SnykProcessor extends RetryingBatchProcessor<String, ScanTask, Scan
             }
             return;
         }
-        if (page == null) {
-            return;
-        }
+
         for (final PageData<Issue> pageData : page.data()) {
             if (!isPageDataValid(pageData)) {
                 continue;
@@ -217,13 +218,18 @@ public class SnykProcessor extends RetryingBatchProcessor<String, ScanTask, Scan
             LOGGER.debug("No results were returned for coordinates {} (affecting {}/{} records in this batch)",
                     unmatchedRecords.getKey(), unmatchedRecords.getValue().size(), batch.size());
             for (final RetryableRecord<String, ScanTask> record : unmatchedRecords.getValue()) {
+                // Setting vulnerability rejected timestamp for records with empty data, to suppress them in apiserver.
+                var bomToBeSuppressed = Bom.newBuilder()
+                        .addVulnerabilities(Vulnerability.newBuilder()
+                                .setRejected(Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build()).build());
                 final ScannerResult result = ScannerResult.newBuilder()
                         .setScanner(Scanner.SCANNER_SNYK)
                         .setStatus(ScanStatus.SCAN_STATUS_SUCCESSFUL)
+                        .setBom(bomToBeSuppressed)
                         .build();
                 context().forward(record.withKey(record.value().getKey()).withValue(result).withTimestamp(context().currentSystemTimeMs()));
                 reportScanResult(NOT_VULNERABLE);
-                cacheReport(new Report(unmatchedRecords.getKey(), Bom.newBuilder().build()));
+                cacheReport(new Report(unmatchedRecords.getKey(), bomToBeSuppressed.build()));
             }
         }
     }

--- a/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessorTest.java
+++ b/vulnerability-analyzer/src/test/java/org/dependencytrack/vulnanalyzer/processor/scanner/snyk/SnykProcessorTest.java
@@ -151,7 +151,9 @@ class SnykProcessorTest {
         assertThat(outputRecord.getValue().getStatus()).isEqualTo(ScanStatus.SCAN_STATUS_SUCCESSFUL);
         assertThat(outputRecord.getValue().hasFailureReason()).isFalse();
         assertThat(outputRecord.getValue().getScanner()).isEqualTo(Scanner.SCANNER_SNYK);
-        assertThat(outputRecord.getValue().getBom().getVulnerabilitiesCount()).isZero();
+        assertThat(outputRecord.getValue().getBom().getVulnerabilitiesList()).satisfiesExactlyInAnyOrder(
+                vulnerability -> assertThat(vulnerability.getRejected()).isNotNull()
+        );
     }
 
     @Test
@@ -211,7 +213,9 @@ class SnykProcessorTest {
                     assertThat(record.getValue().getStatus()).isEqualTo(ScanStatus.SCAN_STATUS_SUCCESSFUL);
                     //assertThat(record.getValue().getFailureReason()).contains("Purl pkg:deb/debian/curl@7.50.3 failed with status 400 due to Snyk error code SNYK-OSSI-2044 : Expected distro to be present");
                     assertThat(record.getValue().getScanner()).isEqualTo(Scanner.SCANNER_SNYK);
-                    assertThat(record.getValue().getBom().getVulnerabilitiesCount()).isZero();
+                    assertThat(record.getValue().getBom().getVulnerabilitiesList()).satisfiesExactlyInAnyOrder(
+                            vulnerability -> assertThat(vulnerability.getRejected()).isNotNull()
+                    );
         });
         verify(snykClientMock, Mockito.times(1)).getIssues(anyString(), anyString(), any(ReportRequest.class));
     }
@@ -255,7 +259,9 @@ class SnykProcessorTest {
 
         assertThat(outputTopic.getQueueSize()).isEqualTo(3);
         assertThat(outputTopic.readRecordsToList()).allSatisfy(record ->
-                assertThat(record.getValue().getBom().getVulnerabilitiesCount()).isZero());
+                assertThat(record.getValue().getBom().getVulnerabilitiesList()).satisfiesExactlyInAnyOrder(
+                        vulnerability -> assertThat(vulnerability.getRejected()).isNotNull()
+                ));
 
         // Verify that the client was invoked just once, despite three results being returned.
         verify(snykClientMock, Mockito.times(1)).getIssues(anyString(), anyString(), any(ReportRequest.class));
@@ -318,7 +324,9 @@ class SnykProcessorTest {
             assertThat(record.getValue().getStatus()).isEqualTo(ScanStatus.SCAN_STATUS_SUCCESSFUL);
             assertThat(record.getValue().hasFailureReason()).isFalse();
             assertThat(record.getValue().getScanner()).isEqualTo(Scanner.SCANNER_SNYK);
-            assertThat(record.getValue().getBom().getVulnerabilitiesCount()).isZero();
+            assertThat(record.getValue().getBom().getVulnerabilitiesList()).satisfiesExactlyInAnyOrder(
+                    vulnerability -> assertThat(vulnerability.getRejected()).isNotNull()
+            );
         });
     }
 


### PR DESCRIPTION
### Description

When SNYK sends records with empty data, they need to be reported to apiserver so that such component vulnerabilities can be suppressed. 

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1620

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
