### PR TITLE
Port : Fix CPE matching for NVD mirroring via REST API

### DIFF
--- a/mirror-service/src/main/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
+++ b/mirror-service/src/main/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
@@ -167,7 +167,7 @@ public final class NvdToCyclonedxParser {
         //
         // Original logic ported from vanilla Dependency-Track:
         // https://github.com/DependencyTrack/dependency-track/blob/58a83978f714d5940ef7f35cc386b255cbd510f7/src/main/java/org/dependencytrack/parser/nvd/NvdParser.java#L238-L269
-        if (node.getOperator() != Node.Operator.AND) {
+        if (node.getOperator() == Node.Operator.AND) {
             // Re-group `CpeMatch`es by CPE part to determine which are against applications,
             // and which against operating systems. When matches are present for both of them,
             // only use the ones for applications.

--- a/mirror-service/src/test/resources/datasource/nvd/cve-2024-23113.json
+++ b/mirror-service/src/test/resources/datasource/nvd/cve-2024-23113.json
@@ -1,0 +1,176 @@
+{
+  "cve": {
+    "id": "CVE-2024-23113",
+    "sourceIdentifier": "psirt@fortinet.com",
+    "published": "2024-02-15T14:15:46.503",
+    "lastModified": "2024-10-10T01:00:01.433",
+    "vulnStatus": "Analyzed",
+    "cveTags": [],
+    "cisaExploitAdd": "2024-10-09",
+    "cisaActionDue": "2024-10-30",
+    "cisaRequiredAction": "Apply mitigations per vendor instructions or discontinue use of the product if mitigations are unavailable.",
+    "cisaVulnerabilityName": "Fortinet Multiple Products Format String Vulnerability",
+    "descriptions": [
+      {
+        "lang": "en",
+        "value": "A use of externally-controlled format string in Fortinet FortiOS versions 7.4.0 through 7.4.2, 7.2.0 through 7.2.6, 7.0.0 through 7.0.13, FortiProxy versions 7.4.0 through 7.4.2, 7.2.0 through 7.2.8, 7.0.0 through 7.0.14, FortiPAM versions 1.2.0, 1.1.0 through 1.1.2, 1.0.0 through 1.0.3, FortiSwitchManager versions 7.2.0 through 7.2.3, 7.0.0 through 7.0.3 allows attacker to execute unauthorized code or commands via specially crafted packets."
+      },
+      {
+        "lang": "es",
+        "value": "Un uso de cadena de formato controlada externamente en Fortinet FortiOS versiones 7.4.0 a 7.4.2, 7.2.0 a 7.2.6, 7.0.0 a 7.0.13, FortiProxy versiones 7.4.0 a 7.4.2, 7.2.0 a 7.2.8, 7.0.0 a 7.0.14, versiones de FortiPAM 1.2.0, 1.1.0 a 1.1.2, 1.0.0 a 1.0.3, versiones de FortiSwitchManager 7.2.0 a 7.2.3, 7.0.0 a 7.0. 3 permite al atacante ejecutar código o comandos no autorizados a través de paquetes especialmente manipulados."
+      }
+    ],
+    "metrics": {
+      "cvssMetricV31": [
+        {
+          "source": "nvd@nist.gov",
+          "type": "Primary",
+          "cvssData": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL"
+          },
+          "exploitabilityScore": 3.9,
+          "impactScore": 5.9
+        },
+        {
+          "source": "psirt@fortinet.com",
+          "type": "Secondary",
+          "cvssData": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL"
+          },
+          "exploitabilityScore": 3.9,
+          "impactScore": 5.9
+        }
+      ]
+    },
+    "weaknesses": [
+      {
+        "source": "psirt@fortinet.com",
+        "type": "Primary",
+        "description": [
+          {
+            "lang": "en",
+            "value": "CWE-134"
+          }
+        ]
+      }
+    ],
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.0.0",
+                "versionEndIncluding": "7.0.14",
+                "matchCriteriaId": "94C6FBEA-B8B8-4A92-9CAF-F4A125577C3C"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.2.0",
+                "versionEndIncluding": "7.2.8",
+                "matchCriteriaId": "406F8C48-85CE-46AF-BE5C-0ED9E3E16A39"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.4.0",
+                "versionEndIncluding": "7.4.2",
+                "matchCriteriaId": "A8DD8789-6485-49E6-92D3-74004D9B6E9B"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:fortinet:fortiswitchmanager:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.0.0",
+                "versionEndIncluding": "7.0.3",
+                "matchCriteriaId": "CF2B9FD3-9581-465E-A5E1-A1BCEFB0DFA3"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:fortinet:fortiswitchmanager:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.2.0",
+                "versionEndIncluding": "7.2.3",
+                "matchCriteriaId": "094185B2-8DC1-46C2-B160-31BEEFDB2CC7"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.0.0",
+                "versionEndIncluding": "7.0.13",
+                "matchCriteriaId": "DF27CA2F-3F4C-4CCB-B832-0E792673C429"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.2.0",
+                "versionEndIncluding": "7.2.6",
+                "matchCriteriaId": "24D09A92-81EC-4003-B017-C67FC739EEBF"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "7.4.0",
+                "versionEndIncluding": "7.4.2",
+                "matchCriteriaId": "49C323D0-5B01-4DB2-AB98-7113D8E607B6"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:fortinet:fortipam:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "1.0.0",
+                "versionEndIncluding": "1.0.3",
+                "matchCriteriaId": "3BA2C6ED-2765-4B56-9B37-10C50BD32C75"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:fortinet:fortipam:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "1.1.0",
+                "versionEndIncluding": "1.1.2",
+                "matchCriteriaId": "D0060F1F-527F-4E91-A59F-F3141977CB7A"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:fortinet:fortipam:1.2.0:*:*:*:*:*:*:*",
+                "matchCriteriaId": "6D0927D1-F469-4344-B4C9-3190645F5899"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "references": [
+      {
+        "url": "https://fortiguard.com/psirt/FG-IR-24-029",
+        "source": "psirt@fortinet.com",
+        "tags": [
+          "Vendor Advisory"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description

Fixes CPE matching for NVD mirroring.

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
