### PR TITLE
Bump open-vulnerability-clients version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <lib.org-json.version>20250107</lib.org-json.version>
     <lib.pebble.version>3.2.2</lib.pebble.version>
     <lib.resilience4j.version>2.3.0</lib.resilience4j.version>
-    <lib.open.vulnerability.clients.version>7.2.0</lib.open.vulnerability.clients.version>
+    <lib.open.vulnerability.clients.version>7.2.2</lib.open.vulnerability.clients.version>
     <lib.packageurl-java.version>1.5.0</lib.packageurl-java.version>
     <lib.protobuf-java.version>4.29.3</lib.protobuf-java.version>
     <lib.quarkus-github-api.version>1.322.0</lib.quarkus-github-api.version>


### PR DESCRIPTION
### Description

Types for `modifiedSubAvailabilityImpact`, `modifiedSubIntegrityImpact`, and `modifiedSubConfidentialityImpact` have been changed in the new version. 
Upgrade the version to avoid `NvdApiException`.

https://github.com/jeremylong/open-vulnerability-clients/releases/tag/v7.2.2

### Addressed Issue

N/A

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
