### PR TITLE
Port: Disable `include` tag for Pebble templates

### DIFF
--- a/notification-publisher/src/main/java/org/dependencytrack/notification/config/PebbleConfiguration.java
+++ b/notification-publisher/src/main/java/org/dependencytrack/notification/config/PebbleConfiguration.java
@@ -22,7 +22,11 @@ import io.pebbletemplates.pebble.PebbleEngine;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
 import jakarta.ws.rs.Produces;
+
+import io.pebbletemplates.pebble.extension.core.DisallowExtensionCustomizerBuilder;
 import org.dependencytrack.notification.template.extension.CustomExtension;
+
+import java.util.List;
 
 class PebbleConfiguration {
 
@@ -31,6 +35,9 @@ class PebbleConfiguration {
     @Named("pebbleEngineJson")
     PebbleEngine pebbleEngineJson(final CustomExtension customExtension) {
         return new PebbleEngine.Builder()
+                .registerExtensionCustomizer(new DisallowExtensionCustomizerBuilder()
+                        .disallowedTokenParserTags(List.of("include"))
+                        .build())
                 .extension(customExtension)
                 .defaultEscapingStrategy("json")
                 .build();
@@ -41,6 +48,9 @@ class PebbleConfiguration {
     @Named("pebbleEnginePlainText")
     PebbleEngine pebbleEnginePlainText(final CustomExtension customExtension) {
         return new PebbleEngine.Builder()
+                .registerExtensionCustomizer(new DisallowExtensionCustomizerBuilder()
+                        .disallowedTokenParserTags(List.of("include"))
+                        .build())
                 .extension(customExtension)
                 .newLineTrimming(false)
                 .build();

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
@@ -157,4 +157,11 @@ public class CsWebexPublisherTest extends AbstractWebhookPublisherTest<CsWebexPu
                         """)));
     }
 
+    @Test
+    @Override
+    @TestTransaction
+    void testInformWithTemplateInclude() throws Exception {
+        super.testInformWithTemplateInclude();
+    }
+
 }

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
@@ -256,4 +256,12 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         }
                         """)));
     }
+
+    @Test
+    @Override
+    @TestTransaction
+    void testInformWithTemplateInclude() throws Exception {
+        super.testInformWithTemplateInclude();
+    }
+
 }

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/MattermostPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/MattermostPublisherTest.java
@@ -188,4 +188,12 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         }
                         """)));
     }
+
+    @Test
+    @Override
+    @TestTransaction
+    void testInformWithTemplateInclude() throws Exception {
+        super.testInformWithTemplateInclude();
+    }
+
 }

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
@@ -419,4 +419,12 @@ class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPublisher
                         }
                         """)));
     }
+
+    @Test
+    @Override
+    @TestTransaction
+    void testInformWithTemplateInclude() throws Exception {
+        super.testInformWithTemplateInclude();
+    }
+
 }

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
@@ -617,4 +617,11 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
+    @Test
+    @Override
+    @TestTransaction
+    void testInformWithTemplateInclude() throws Exception {
+        super.testInformWithTemplateInclude();
+    }
+
 }

--- a/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
+++ b/notification-publisher/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
@@ -498,4 +498,12 @@ class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPublisher
                         }
                         """)));
     }
+
+    @Test
+    @Override
+    @TestTransaction
+    void testInformWithTemplateInclude() throws Exception {
+        super.testInformWithTemplateInclude();
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <lib.minio.version>8.5.17</lib.minio.version>
     <lib.open-feign.version>13.5</lib.open-feign.version>
     <lib.org-json.version>20250107</lib.org-json.version>
-    <lib.pebble.version>3.2.2</lib.pebble.version>
+    <lib.pebble.version>3.2.3</lib.pebble.version>
     <lib.resilience4j.version>2.3.0</lib.resilience4j.version>
     <lib.open.vulnerability.clients.version>7.2.2</lib.open.vulnerability.clients.version>
     <lib.packageurl-java.version>1.5.0</lib.packageurl-java.version>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Disables `include` tag for Pebble templates.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/dependency-track/security/advisories/GHSA-9582-88hr-54w3
Ports https://github.com/DependencyTrack/dependency-track/pull/4684

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
