### PR TITLE
Document pagination support for `findings` REST endpoint

### DIFF
--- a/docs/getting-started/changes-over-v4.md
+++ b/docs/getting-started/changes-over-v4.md
@@ -82,3 +82,6 @@ and vulnerability analysis is performed by services separately from the API serv
     * `cweId`
     * `cweName`
 * In the SARIF file (schema defined in [sarif.peb]), `cweId` will be replaced by list of cwe ids in `cwes`. And name of the SARIF rule will be vulnerability's `vulnId` instead of `cweName`.
+* The `/api/v1/finding/project/{uuid}` REST API endpoint now supports pagination
+  [apiserver/#1111](https://github.com/DependencyTrack/hyades-apiserver/pull/1111). The page size defaults to `100`.
+    Clients currently expecting *all* items to be returned at once must be updated to deal with pagination.


### PR DESCRIPTION
### Description

Pagination was already supported by `findings` REST endpoints `/api/v1/finding` and /api/v1/finding/grouped.
Now, it has been added to endpoint `/api/v1/finding/project/{uuid}` as well.

Document the same.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/1708
Backend : https://github.com/DependencyTrack/hyades-apiserver/pull/1111

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
