### PR TITLE
fix: Add Correct Path for Role Documenation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ nav:
   - Database: operations/database.md
 - Development:
   - Roles:
-    - Overview: usage/auth-and-roles/overview.md
+    - Overview: development/Roles/overview.md
   - Overview: development/overview.md
   - Building: development/building.md
   - Testing: development/testing.md


### PR DESCRIPTION
### Description

Adding the correct path to Role Documentation to mkdocs.yml. 



<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~ngly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
