### PR TITLE
Consider `TimeoutException` to be retryable

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/util/ProcessorUtils.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/util/ProcessorUtils.java
@@ -19,13 +19,14 @@
 package org.dependencytrack.vulnanalyzer.util;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
-import jakarta.ws.rs.WebApplicationException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.conn.ConnectTimeoutException;
 
+import jakarta.ws.rs.WebApplicationException;
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 public class ProcessorUtils {
 
@@ -43,8 +44,9 @@ public class ProcessorUtils {
         }
 
         return rootCause instanceof CallNotPermittedException
-                || rootCause instanceof ConnectTimeoutException
-                || rootCause instanceof SocketTimeoutException;
+               || rootCause instanceof ConnectTimeoutException
+               || rootCause instanceof TimeoutException
+               || rootCause instanceof SocketTimeoutException;
     }
 
     private ProcessorUtils() {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Consider `TimeoutException` to be retryable.

When the Quarkus HTTP client fails due to a timeout, it doesn't throw a `ConnectTimeoutException` or `SocketTimeoutException`, but a vert.x exception that inherits from `TimeoutException`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
