### PR TITLE
Add `is_active` field to Project message

### DIFF
--- a/proto/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/proto/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -159,6 +159,7 @@ message Project {
   optional string description = 4;
   optional string purl = 5;
   repeated string tags = 6;
+  optional bool is_active = 7;
 }
 
 message PolicyViolation {


### PR DESCRIPTION
### Description

Introduces an optional boolean 'is_active' field to the Project message in the notification.proto

### Addressed Issue

Relates to https://github.com/DependencyTrack/hyades-apiserver/pull/1386
https://github.com/DependencyTrack/hyades/issues/1837

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
