### PR TITLE
Enforce punctuation latency ceiling for scanner result aggregator

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/misc/ScannerResultAggregator.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/processor/misc/ScannerResultAggregator.java
@@ -40,6 +40,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.dependencytrack.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_PENDING;
@@ -62,6 +63,8 @@ import static org.dependencytrack.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_P
 public class ScannerResultAggregator extends ContextualFixedKeyProcessor<ScanKey, ScannerResultAggregate, ScannerResultAggregate> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScannerResultAggregator.class);
+    private static final int PUNCTUATE_LATENCY_MEASUREMENT_RECORD_THRESHOLD = 1000;
+    private static final long MAX_PUNCTUATE_LATENCY_MS = TimeUnit.SECONDS.toMillis(5);
 
     private final String storeName;
     private final Duration checkInterval;
@@ -105,8 +108,35 @@ public class ScannerResultAggregator extends ContextualFixedKeyProcessor<ScanKey
     private void punctuate(final long timestamp) {
         final Instant cutoffTimestamp = Instant.ofEpochMilli(timestamp).minus(maxLifetime);
 
+        long recordsProcessed = 0;
+        final long punctuateStartTimeMillis = System.currentTimeMillis();
+        long punctuateLatencyMillis;
+
         try (final KeyValueIterator<ScanKey, ScannerResultAggregate> all = store.all()) {
             while (all.hasNext()) {
+                // Only measure punctuation latency every N records to reduce the
+                // CPU overhead of time comparisons.
+                recordsProcessed++;
+                if (recordsProcessed % PUNCTUATE_LATENCY_MEASUREMENT_RECORD_THRESHOLD == 0) {
+                    // For large state stores, it could happen that iterating over, and deserializing,
+                    // all entries takes too long. Punctuation blocks record processing and thus also
+                    // consumer polling. Enforce a ceiling as to how long punctuation can reasonably
+                    // take to prevent the consumer from being considered dead by the broker.
+                    //
+                    // Punctuation may be invoked for every single record so eventually the
+                    // work will get done, although spread over a longer time frame.
+                    punctuateLatencyMillis = System.currentTimeMillis() - punctuateStartTimeMillis;
+                    if (punctuateLatencyMillis >= MAX_PUNCTUATE_LATENCY_MS) {
+                        LOGGER.warn("""
+                                        Punctuator took {}ms to iterate over state store records. \
+                                        The maximum punctuation latency is {}ms. Aborting iteration \
+                                        to not block stream task thread for too long.""",
+                                punctuateLatencyMillis,
+                                MAX_PUNCTUATE_LATENCY_MS);
+                        break;
+                    }
+                }
+
                 final KeyValue<ScanKey, ScannerResultAggregate> record = all.next();
                 final Instant lastUpdated = Instant.ofEpochSecond(record.value.getLastUpdated().getSeconds());
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enforces punctuation latency ceiling for scanner result aggregator.

Continuation of https://github.com/DependencyTrack/hyades/pull/1841, which addressed the `TombstoneEmittingProcessor`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
