### PR TITLE
Add null checks to `NvdToCyclonedxParser`

### DIFF
--- a/mirror-service/src/main/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
+++ b/mirror-service/src/main/java/org/dependencytrack/vulnmirror/datasource/nvd/NvdToCyclonedxParser.java
@@ -131,12 +131,14 @@ public final class NvdToCyclonedxParser {
                 // We can't compute negation.
                 .filter(config -> config.getNegate() == null || !config.getNegate())
                 .map(Config::getNodes)
+                .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 // We can't compute negation.
                 .filter(node -> node.getNegate() == null || !node.getNegate())
                 .filter(node -> node.getCpeMatch() != null)
-                .map(node -> extractCpeMatchesFromNode(cveId, node))
+                .map(node -> Optional.ofNullable(extractCpeMatchesFromNode(cveId, node)).orElse(List.of()))
                 .flatMap(Collection::stream)
+                .filter(Objects::nonNull)
                 // We currently have no interest in non-vulnerable versions.
                 .filter(cpeMatch -> cpeMatch.getVulnerable() == null || cpeMatch.getVulnerable())
                 .toList();
@@ -370,9 +372,11 @@ public final class NvdToCyclonedxParser {
 
     private static List<ExternalReference> parseReferences(List<Reference> references) {
         List<ExternalReference> externalReferences = new ArrayList<>();
-        references.forEach(reference -> externalReferences.add(ExternalReference.newBuilder()
-                .setUrl(reference.getUrl())
-                .build()));
+        if (references != null) {
+            references.forEach(reference -> externalReferences.add(ExternalReference.newBuilder()
+                    .setUrl(reference.getUrl())
+                    .build()));
+        }
         return externalReferences;
     }
 


### PR DESCRIPTION
### Description

Added null checks for nodes and references in `NvdToCyclonedxParser` to prevent potential NullPointerExceptions during parsing.

### Addressed Issue

NA

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
