### PR TITLE
Increase timeout of expected scanner results KTable

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/VulnerabilityAnalyzerTopology.java
+++ b/vulnerability-analyzer/src/main/java/org/dependencytrack/vulnanalyzer/VulnerabilityAnalyzerTopology.java
@@ -193,7 +193,7 @@ public class VulnerabilityAnalyzerTopology {
                 // This keeps the KTable from growing indefinitely.
                 .processValues(new TombstoneEmittingProcessorSupplier<>(
                         "expected-scanner-results-last-update-store",
-                        scanKeySerde, Duration.ofMinutes(5), Duration.ofHours(1),
+                        scanKeySerde, Duration.ofMinutes(5), Duration.ofHours(3),
                         scanKey -> ScanTask.newBuilder()
                                 .setKey(scanKey)
                                 .setScanner(SCANNER_NONE)
@@ -215,6 +215,10 @@ public class VulnerabilityAnalyzerTopology {
 
         // Join the results we receive from scanners with the table of expected scanner results.
         final KStream<ScanKey, ScannerResultAggregate> completedScansStream = scannerResultStream
+                // This join will not yield any result if no corresponding expectedScannerResultsTable record
+                // exists. This can happen in scenarios where the system is under high load, or scanners are
+                // experiencing lots of retryable errors, and table records have been removed by the tombstone
+                // emitting processor.
                 .join(expectedScannerResultsTable, (scannerResult, expected) -> {
                     final var results = new HashMap<String, ScannerResult>();
                     // Pre-populate results with PENDING statuses for all expected scanners.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Increases timeout of expected scanner results KTable.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

See code comment for details.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
