### PR TITLE
Add SELinux :Z suffix to docker-compose volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
       # VULN_ANALYSIS_TOPICS_RETENTION_MS: "43200000" # 12h
       # VULN_MIRROR_TOPICS_RETENTION_MS: "43200000" # 12h
     volumes:
-      - "./scripts/create-topics.sh:/tmp/create-topics.sh:ro"
+      - "./scripts/create-topics.sh:/tmp/create-topics.sh:ro,Z"
     restart: on-failure
 
   redpanda-console:
@@ -255,7 +255,7 @@ services:
     ports:
       - "127.0.0.1:28080:8080"
     volumes:
-      - "./proto/src/main/proto:/etc/protos:ro"
+      - "./proto/src/main/proto:/etc/protos:ro,Z"
     restart: unless-stopped
 
   secret-init:
@@ -273,7 +273,7 @@ services:
     ports:
       - "127.0.0.1:9090:9090"
     volumes:
-      - "./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro"
+      - "./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro,Z"
       - "prometheus-data:/prometheus"
     profiles:
       - monitoring
@@ -291,8 +291,8 @@ services:
       - "127.0.0.1:3000:3000"
     volumes:
       - "grafana-data:/var/lib/grafana"
-      - "./monitoring/grafana/dashboards:/etc/dashboards:ro"
-      - "./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro"
+      - "./monitoring/grafana/dashboards:/etc/dashboards:ro,Z"
+      - "./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro,Z"
     profiles:
       - monitoring
     restart: unless-stopped


### PR DESCRIPTION
### Description

Adds the `:Z` suffix to volume mounts in `docker-compose.yml`. This change instructs the container runtime (Docker or Podman) to relabel the bind-mounted files with the correct SELinux context (`container_file_t`). This ensures the stack starts successfully on distributions with SELinux in Enforcing mode (e.g., Fedora, RHEL, CentOS) without triggering "Permission denied" errors.

### Addressed Issue

Fixes #2021

### Additional Details

* **Problem:** Without the `:Z` suffix, containers on SELinux-enabled hosts cannot read/write to bind-mounted volumes, causing services to fail startup or log errors.
* **Solution:** The `:Z` suffix is the standard way to handle SELinux contexts for bind mounts in Docker/Podman.
* **Compatibility:** This change is backward compatible. On systems without SELinux (Ubuntu, Debian, macOS, Windows), the `:Z` suffix is ignored and causes no side effects.
* **Verification:** Verified locally on Fedora 43 (SELinux Enforcing) with Podman v5.x.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [~This PR implements an enhancement, and I have provided tests to verify that it works as intended~]
- [~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~]
- [~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~]

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/